### PR TITLE
Config: Let other apps view and edit our documents.

### DIFF
--- a/Newspack/Newspack/Resources/Info.plist
+++ b/Newspack/Newspack/Resources/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>NSAppleMusicUsageDescription</key>
 	<string></string>
 	<key>NSCameraUsageDescription</key>
@@ -28,6 +30,8 @@
 	<string></string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string></string>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -49,5 +53,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UISupportsDocumentBrowser</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Closes #36 
In this PR we're setting the keys and values in the Info.plist to allow other apps to view and edit the contents of our documents directory.

To test: 
- Switch to this branch, build and run. 
- Open the Files app. 
- Select the Browse tab.
- If necessary, tap back to the tab's root vc. 
- Tap On My Phone. 
- Confirm you see a Newspack folder as an option.  Currently it should contain 1 item -- a Staged Media folder.

Game for a quick reivew @jleandroperez? 

![Simulator Screen Shot - iPhone 8 - 2020-03-20 at 12 51 12](https://user-images.githubusercontent.com/1435271/77191880-a34d7080-6aa9-11ea-8841-fdad062e985c.png)
