### PR TITLE
Issues/43 create folder

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -170,6 +170,8 @@
 		E6D44DEF234BDB8400B51438 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEE234BDB8400B51438 /* MediaStore.swift */; };
 		E6D44DF1234BDBA000B51438 /* MediaApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DF0234BDBA000B51438 /* MediaApiService.swift */; };
 		E6D44DF3234BDBB500B51438 /* MediaServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DF2234BDBB500B51438 /* MediaServiceRemote.swift */; };
+		E6DF5575242E7139007DDC47 /* FolderManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DF5574242E7139007DDC47 /* FolderManager.swift */; };
+		E6DF5578242E7242007DDC47 /* FolderManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DF5577242E7242007DDC47 /* FolderManagerTests.swift */; };
 		E6E1834D22D6D44D009C2D0A /* remote-post-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6E1834B22D6D44C009C2D0A /* remote-post-edit.json */; };
 		E6E1834E22D6D44D009C2D0A /* remote-post-id-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6E1834C22D6D44D009C2D0A /* remote-post-id-edit.json */; };
 		E6E1835022D79473009C2D0A /* RemoteTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E1834F22D79473009C2D0A /* RemoteTestCase.swift */; };
@@ -386,6 +388,8 @@
 		E6D44DEE234BDB8400B51438 /* MediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStore.swift; sourceTree = "<group>"; };
 		E6D44DF0234BDBA000B51438 /* MediaApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaApiService.swift; sourceTree = "<group>"; };
 		E6D44DF2234BDBB500B51438 /* MediaServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaServiceRemote.swift; sourceTree = "<group>"; };
+		E6DF5574242E7139007DDC47 /* FolderManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderManager.swift; sourceTree = "<group>"; };
+		E6DF5577242E7242007DDC47 /* FolderManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderManagerTests.swift; sourceTree = "<group>"; };
 		E6E1834B22D6D44C009C2D0A /* remote-post-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-post-edit.json"; sourceTree = "<group>"; };
 		E6E1834C22D6D44D009C2D0A /* remote-post-id-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-post-id-edit.json"; sourceTree = "<group>"; };
 		E6E1834F22D79473009C2D0A /* RemoteTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTestCase.swift; sourceTree = "<group>"; };
@@ -549,6 +553,7 @@
 		E6138FD02211FE86004E5B91 /* Newspack */ = {
 			isa = PBXGroup;
 			children = (
+				E6DF5573242E7115007DDC47 /* Folders */,
 				E6FB51FE22B9677A0010FDF8 /* Extensions */,
 				E62C7C632235E0EC000FEB33 /* Stores */,
 				E6138FFE22120467004E5B91 /* Controllers */,
@@ -567,6 +572,7 @@
 		E6138FE82211FE88004E5B91 /* NewspackTests */ = {
 			isa = PBXGroup;
 			children = (
+				E6DF5576242E722B007DDC47 /* Folders */,
 				E61FC60A229F330A009E1748 /* TestData */,
 				E61FC607229F3280009E1748 /* TestTools */,
 				E66E8A122235ABB300E8DD88 /* Base */,
@@ -864,6 +870,22 @@
 				E6710A1622CE9F040036156E /* FadeTransitionController.swift */,
 			);
 			path = Transitions;
+			sourceTree = "<group>";
+		};
+		E6DF5573242E7115007DDC47 /* Folders */ = {
+			isa = PBXGroup;
+			children = (
+				E6DF5574242E7139007DDC47 /* FolderManager.swift */,
+			);
+			path = Folders;
+			sourceTree = "<group>";
+		};
+		E6DF5576242E722B007DDC47 /* Folders */ = {
+			isa = PBXGroup;
+			children = (
+				E6DF5577242E7242007DDC47 /* FolderManagerTests.swift */,
+			);
+			path = Folders;
 			sourceTree = "<group>";
 		};
 		E6FB51FE22B9677A0010FDF8 /* Extensions */ = {
@@ -1277,6 +1299,7 @@
 				E602E68F22C1637800795CBA /* PostApiActions.swift in Sources */,
 				E641A66322A7584A008BBD85 /* AccountDetailsStore.swift in Sources */,
 				E636C262234FBE6800564B63 /* RemoteMedia.swift in Sources */,
+				E6DF5575242E7139007DDC47 /* FolderManager.swift in Sources */,
 				E6D44DF1234BDBA000B51438 /* MediaApiService.swift in Sources */,
 				E66CCA0C2303527C00F1CA59 /* Media+CoreDataClass.swift in Sources */,
 				E6FB520622B973A60010FDF8 /* PostStore.swift in Sources */,
@@ -1310,6 +1333,7 @@
 				E637A6E422F0EE1500229C1D /* RequestQueueTests.swift in Sources */,
 				E65875AA23A8139500185C75 /* StagedMediaImporterTests.swift in Sources */,
 				E66E8A072235979500E8DD88 /* BaseTest.swift in Sources */,
+				E6DF5578242E7242007DDC47 /* FolderManagerTests.swift in Sources */,
 				E64D9FBD23D667D80075A60E /* PostItemStoreTests.swift in Sources */,
 				E607385F22A9A5DB00504EA4 /* AccountCapabilitiesStoreTests.swift in Sources */,
 				E61A28CF22D53EFD003E214F /* PostServiceRemoteTests.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -162,6 +162,8 @@
 		E6A4D742230A08A700929376 /* StagedEdits+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A4D740230A08A600929376 /* StagedEdits+CoreDataProperties.swift */; };
 		E6A4D743230A08A700929376 /* StagedEdits+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A4D741230A08A700929376 /* StagedEdits+CoreDataClass.swift */; };
 		E6A7C06D2257A42400CC2191 /* UserServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A7C06C2257A42400CC2191 /* UserServiceRemote.swift */; };
+		E6A800F324380A5300A14E6C /* FolderStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A800F224380A5300A14E6C /* FolderStore.swift */; };
+		E6A800F524380A6600A14E6C /* FolderAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A800F424380A6600A14E6C /* FolderAction.swift */; };
 		E6AC98B823CCD5DE00E95381 /* MainNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AC98B723CCD5DE00E95381 /* MainNavController.swift */; };
 		E6B4034D22D8E12500A0DDCA /* remote-posts-ids-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */; };
 		E6B4034E22D8E12500A0DDCA /* remote-posts-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */; };
@@ -380,6 +382,8 @@
 		E6A4D740230A08A600929376 /* StagedEdits+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StagedEdits+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		E6A4D741230A08A700929376 /* StagedEdits+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StagedEdits+CoreDataClass.swift"; sourceTree = "<group>"; };
 		E6A7C06C2257A42400CC2191 /* UserServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserServiceRemote.swift; sourceTree = "<group>"; };
+		E6A800F224380A5300A14E6C /* FolderStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderStore.swift; sourceTree = "<group>"; };
+		E6A800F424380A6600A14E6C /* FolderAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderAction.swift; sourceTree = "<group>"; };
 		E6AC98B723CCD5DE00E95381 /* MainNavController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavController.swift; sourceTree = "<group>"; };
 		E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-ids-edit.json"; sourceTree = "<group>"; };
 		E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-edit.json"; sourceTree = "<group>"; };
@@ -503,6 +507,7 @@
 				E602E69722C1670800795CBA /* PostAction.swift */,
 				E6E43EA3230F1D2B00A1974E /* EditAction.swift */,
 				E6A10C6223579CE300435670 /* MediaAction.swift */,
+				E6A800F424380A6600A14E6C /* FolderAction.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -787,6 +792,7 @@
 				E61D8F6B2375EC3E005FECED /* StagedMediaStore.swift */,
 				E640D27723883ED800887FD9 /* StagedMediaImporter.swift */,
 				E640D27923883EE700887FD9 /* StagedMediaUploader.swift */,
+				E6A800F224380A5300A14E6C /* FolderStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -1273,8 +1279,10 @@
 				E6A7C06D2257A42400CC2191 /* UserServiceRemote.swift in Sources */,
 				E66CCA102303527C00F1CA59 /* User+CoreDataProperties.swift in Sources */,
 				E6E2ACF722E10F3400A8E85D /* MainStoryboard.swift in Sources */,
+				E6A800F524380A6600A14E6C /* FolderAction.swift in Sources */,
 				E67F56D52230914800BFD38B /* CoreDataManager.swift in Sources */,
 				E602E69F22C1747D00795CBA /* Dictionary+Unwrappers.swift in Sources */,
+				E6A800F324380A5300A14E6C /* FolderStore.swift in Sources */,
 				E629822A2303667E00E8CEC7 /* EditorViewController.swift in Sources */,
 				E66CCA1B2303527D00F1CA59 /* User+CoreDataClass.swift in Sources */,
 				E6051DE323071A3A005AAF0B /* RemoteRevision.swift in Sources */,

--- a/Newspack/Newspack/Controllers/SiteMenuViewController.swift
+++ b/Newspack/Newspack/Controllers/SiteMenuViewController.swift
@@ -34,9 +34,15 @@ struct SiteMenuViewModel {
             SessionManager.shared.sessionDispatcher.dispatch(action)
         }
 
+        let folderRow = SiteMenuRow(title: "New Story Folder") {
+            let action = FolderAction.createFolder(path: "New Folder", addSuffix: true)
+            SessionManager.shared.sessionDispatcher.dispatch(action)
+        }
+
         let rows = [
             postRow,
             mediaRow,
+            folderRow,
             logoutRow
         ]
 

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -35,7 +35,7 @@ class FolderManager {
     init(rootFolder: URL? = nil) {
         fileManager = FileManager()
 
-        guard let documentDirectory  = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+        guard let documentDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
             fatalError()
         }
 
@@ -129,11 +129,15 @@ class FolderManager {
 
         let relation = UnsafeMutablePointer<FileManager.URLRelationship>.allocate(capacity: 1)
 
-        try? fileManager.getRelationship(relation, ofDirectoryAt: rootFolder, toItemAt: url)
+        do {
+            try fileManager.getRelationship(relation, ofDirectoryAt: rootFolder, toItemAt: url)
 
-        if relation.pointee != .other {
-            currentFolder = url
-            didSetCurrentFolder = true
+            if relation.pointee != .other {
+                currentFolder = url
+                didSetCurrentFolder = true
+            }
+        } catch {
+            LogError(message: "Error checking folder relationships. \(error)")
         }
 
         relation.deallocate()

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -13,7 +13,7 @@ class FolderManager {
 
     // The current working folder. This will be either the rootFolder or
     // one of its children.
-    private var currentFolder: URL
+    private(set) var currentFolder: URL
 
     /// A convenience method to create a new temporary directory and returns its URL.
     ///

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -57,11 +57,16 @@ class FolderManager {
 
     /// Creates a new folder with the specified name underneath the currentFolder.
     ///
-    /// - Parameter folderName: The name of the folder to create.
-    /// - Returns: The file URL of the folder or nil if the folder could not be created.
+    /// - Parameters:
+    ///   - path: The path, including name, of the folder to create.
+    ///   - ifExistsAppendSuffix: If true, if the specified path already exists
+    ///   a numberic index is appended to the path. Default is false.
+    /// - Returns: The file URL of the folder or nil if the folder could not be
+    /// created.
     ///
-    func createFolderAtPath(path: String) -> URL? {
-        let url = urlForFolderAtPath(path: path)
+    func createFolderAtPath(path: String, ifExistsAppendSuffix: Bool = false) -> URL? {
+        let url = urlForFolderAtPath(path: path, ifExistsAppendSuffix: ifExistsAppendSuffix)
+
         guard !folderExists(url: url) else {
             return url
         }
@@ -79,10 +84,27 @@ class FolderManager {
     /// or relative.  A relative path will be considered relative to the
     /// currentFolder.
     ///
-    /// - Parameter path: A path to a folder.
+    /// - Parameters:
+    ///   - path: The path, including name, of the folder.
+    ///   - ifExistsAppendSuffix: If true, if the specified path already exists
+    ///   a numberic index is appended to the path. Default is false.
     /// - Returns: A URL
     ///
-    func urlForFolderAtPath(path: String) -> URL {
-        return URL(fileURLWithPath: path, isDirectory: true, relativeTo: currentFolder)
+    func urlForFolderAtPath(path: String, ifExistsAppendSuffix: Bool = false) -> URL {
+        var url = URL(fileURLWithPath: path, isDirectory: true, relativeTo: currentFolder)
+
+        if !ifExistsAppendSuffix || !folderExists(url: url) {
+            return url
+        }
+
+        var newPath = path
+        var counter = 1
+        repeat {
+            counter = counter + 1
+            newPath = "\(path) \(counter)"
+            url = URL(fileURLWithPath: newPath, isDirectory: true, relativeTo: currentFolder)
+        } while folderExists(url: url)
+
+        return url
     }
 }

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// FolderManager provides a simplified interface for working with the file system.
+/// Operations are conducted relative to the current working folder.
+///
+class FolderManager {
+
+    // An instance of a FileManager
+    private let fileManager: FileManager
+
+    // All relative paths are mapped beneath thie specified rootFolder.
+    private let rootFolder: URL
+
+    // The current working folder. This will be either the rootFolder or
+    // one of its children.
+    private var currentFolder: URL
+
+    /// Initializes the FolderManager, optionally specifying its default
+    /// rootFolder.
+    ///
+    /// - Parameter rootFolder: Optional. A URL to an existing folder to
+    /// use as the root of any relative paths. The folder must be writable.
+    /// If not specified the default rootFolder is the document directory.
+    ///
+    init(rootFolder: URL? = nil) {
+        fileManager = FileManager()
+
+        guard let documentDirectory  = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            fatalError()
+        }
+
+        var isDirectory: ObjCBool = false
+        if
+            let root = rootFolder,
+            fileManager.fileExists(atPath: root.absoluteString, isDirectory: &isDirectory),
+            isDirectory.boolValue,
+            fileManager.isWritableFile(atPath: root.path)
+        {
+            self.rootFolder = root
+        } else {
+            self.rootFolder = documentDirectory
+        }
+
+        currentFolder = self.rootFolder
+    }
+
+    /// Checks if a folder exists.
+    ///
+    /// - Parameter url: A file url to a folder.
+    /// - Returns: true if the folder exists, otherwise false.
+
+    func folderExists(url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        let exists = fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+        return exists && isDirectory.boolValue
+    }
+
+    /// Creates a new folder with the specified name underneath the currentFolder.
+    ///
+    /// - Parameter folderName: The name of the folder to create.
+    /// - Returns: The file URL of the folder or nil if the folder could not be created.
+    ///
+    func createFolderAtPath(path: String) -> URL? {
+        let url = urlForFolderAtPath(path: path)
+        guard !folderExists(url: url) else {
+            return url
+        }
+
+        do {
+            try fileManager.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+            LogError(message: "Unable to create directory: \(url.path)")
+            return nil
+        }
+        return url
+    }
+
+    /// Get a file URL for a folder at the specified path. Paths may be absolute
+    /// or relative.  A relative path will be considered relative to the
+    /// currentFolder.
+    ///
+    /// - Parameter path: A path to a folder.
+    /// - Returns: A URL
+    ///
+    func urlForFolderAtPath(path: String) -> URL {
+        return URL(fileURLWithPath: path, isDirectory: true, relativeTo: currentFolder)
+    }
+}

--- a/Newspack/Newspack/Stores/Actions/FolderAction.swift
+++ b/Newspack/Newspack/Stores/Actions/FolderAction.swift
@@ -1,0 +1,8 @@
+import Foundation
+import WordPressFlux
+
+/// Supported Actions for changes to the FolderStore
+///
+enum FolderAction: Action {
+    case createFolder(path: String, addSuffix: Bool)
+}

--- a/Newspack/Newspack/Stores/StoreContainer.swift
+++ b/Newspack/Newspack/Stores/StoreContainer.swift
@@ -16,6 +16,7 @@ class StoreContainer {
     private(set) var mediaItemStore = MediaItemStore()
     private(set) var imageStore = ImageStore()
     private(set) var stagedMediaStore = StagedMediaStore()
+    private(set) var folderStore = FolderStore()
 
     private init() {}
 
@@ -35,5 +36,6 @@ class StoreContainer {
         mediaItemStore = MediaItemStore(dispatcher: dispatcher, siteID: site?.uuid)
         imageStore = ImageStore(dispatcher: dispatcher)
         stagedMediaStore = StagedMediaStore(dispatcher: dispatcher, siteID: site?.uuid)
+        folderStore = FolderStore(dispatcher: dispatcher, siteID: site?.uuid)
     }
 }

--- a/Newspack/NewspackTests/Folders/FolderManagerTests.swift
+++ b/Newspack/NewspackTests/Folders/FolderManagerTests.swift
@@ -22,4 +22,32 @@ class FolderManagerTests: XCTestCase {
         XCTAssertTrue(url.lastPathComponent.hasSuffix(path))
         XCTAssertTrue(folderManager.folderExists(url: url))
     }
+
+    func testCreatingExistingFolder() {
+        let path = "TestFolder"
+        let expectedPath2 = "TestFolder 2"
+        let expectedPath3 = "TestFolder 3"
+
+        // Create the starting folder
+        _ = folderManager.createFolderAtPath(path: path)
+
+        guard let url2 = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true) else {
+            XCTFail("URL is expected to not be nil")
+            return
+        }
+
+        XCTAssertNotNil(url2)
+        XCTAssertTrue(url2.lastPathComponent.hasSuffix(expectedPath2))
+        XCTAssertTrue(folderManager.folderExists(url: url2))
+
+
+        guard let url3 = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true) else {
+            XCTFail("URL is expected to not be nil")
+            return
+        }
+
+        XCTAssertNotNil(url3)
+        XCTAssertTrue(url3.lastPathComponent.hasSuffix(expectedPath3))
+        XCTAssertTrue(folderManager.folderExists(url: url3))
+    }
 }

--- a/Newspack/NewspackTests/Folders/FolderManagerTests.swift
+++ b/Newspack/NewspackTests/Folders/FolderManagerTests.swift
@@ -49,4 +49,21 @@ class FolderManagerTests: XCTestCase {
         XCTAssertTrue(url3.lastPathComponent.hasSuffix(expectedPath3))
         XCTAssertTrue(folderManager.folderExists(url: url3))
     }
+
+    func testSetCurrentFolder() {
+        let path = "TestFolder"
+
+        let originalCurrentFolder = folderManager.currentFolder
+
+        // Create the starting folder
+        let url = folderManager.createFolderAtPath(path: path)!
+        var success = folderManager.setCurrentFolder(url: url)
+        XCTAssertTrue(success)
+
+        success = folderManager.setCurrentFolder(url: originalCurrentFolder)
+        XCTAssertTrue(success)
+
+        success = folderManager.setCurrentFolder(url: FileManager.default.temporaryDirectory)
+        XCTAssertFalse(success)
+    }
 }

--- a/Newspack/NewspackTests/Folders/FolderManagerTests.swift
+++ b/Newspack/NewspackTests/Folders/FolderManagerTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Newspack
+
+class FolderManagerTests: XCTestCase {
+
+    var folderManager: FolderManager!
+
+    override func setUpWithError() throws {
+        let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        let tempDirectory = try! FileManager.default.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: documentDirectory, create: true)
+        folderManager = FolderManager(rootFolder: tempDirectory)
+    }
+
+    func testCreateFolder() {
+        let path = "TestFolder"
+        guard let url = folderManager.createFolderAtPath(path: path) else {
+            XCTFail("URL is expected to not be nil")
+            return
+        }
+
+        XCTAssertNotNil(url)
+        XCTAssertTrue(url.lastPathComponent.hasSuffix(path))
+        XCTAssertTrue(folderManager.folderExists(url: url))
+    }
+}

--- a/Newspack/NewspackTests/Folders/FolderManagerTests.swift
+++ b/Newspack/NewspackTests/Folders/FolderManagerTests.swift
@@ -6,8 +6,7 @@ class FolderManagerTests: XCTestCase {
     var folderManager: FolderManager!
 
     override func setUpWithError() throws {
-        let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
-        let tempDirectory = try! FileManager.default.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: documentDirectory, create: true)
+        let tempDirectory = FolderManager.createTemporaryDirectory()
         folderManager = FolderManager(rootFolder: tempDirectory)
     }
 


### PR DESCRIPTION
Closes #43 
This PR adds the ability to create folders under the app's document's folder.  
- A FolderManager encapsulate logic for dealing with the file system. 
- FolderStore and FolderAction implements the flux pattern for dealing with new folder creation. 
- A simple test UI is added to test creating folders. 
- Unit tests are added to check logic. 

To test: 
Scenario 1: Creating the site's folder
- Log in to the app.
- Back ground the app and open the Files app. 
- Browse to files on your Phone. Find the Newspack folder.
- Confirm there is a folder for your site inside the Newspack folder.

Scenario 2: Creating story folders. 
- While logged into the app, tap the Add Story Folder row a few times. 
- Note in the console that a successful folder creation is logged. 
- Switch to the Files app. 
- Inside the Newspack > Site folder you should see a new child folder for every time you tapped the row.
- Confirm the correct number of folders exist.  Confirm duplicates have a numeric suffix beginning with "2". 

Scenario 3: Confirm tests do not pollute the document directory.
- Run the test suite.
- Open the files app. 
- Look inside the Newspack and the Newspack > Sites folder.  Confirm you do not see any unexpected site or story folders.  Note you'll currently expect to see folders for staged media and staged media tests that will be dealt with in a future PR. 

@jleandroperez could I trouble you with this one? 