### PR TITLE
Issues/44 list folders

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		E67B9D60236775FC00860A6C /* MediaCache+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67B9D5E236775FB00860A6C /* MediaCache+CoreDataClass.swift */; };
 		E67B9D61236775FC00860A6C /* MediaCache+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67B9D5F236775FC00860A6C /* MediaCache+CoreDataProperties.swift */; };
 		E67F56D52230914800BFD38B /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67F56D42230914800BFD38B /* CoreDataManager.swift */; };
+		E68689C0243C080400B7E363 /* FoldersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68689BF243C080400B7E363 /* FoldersViewController.swift */; };
 		E6871F1922C3FD8A008D3D46 /* SiteMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6871F1822C3FD8A008D3D46 /* SiteMenuViewController.swift */; };
 		E6871F1B22C3FDE7008D3D46 /* PostListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6871F1A22C3FDE7008D3D46 /* PostListViewController.swift */; };
 		E68B29FF23048C6C0021283C /* EditCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68B29FE23048C6C0021283C /* EditCoordinator.swift */; };
@@ -363,6 +364,7 @@
 		E67B9D5E236775FB00860A6C /* MediaCache+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MediaCache+CoreDataClass.swift"; sourceTree = "<group>"; };
 		E67B9D5F236775FC00860A6C /* MediaCache+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MediaCache+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		E67F56D42230914800BFD38B /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CoreDataManager.swift; path = Newspack/System/CoreDataManager.swift; sourceTree = SOURCE_ROOT; };
+		E68689BF243C080400B7E363 /* FoldersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldersViewController.swift; sourceTree = "<group>"; };
 		E6871F1822C3FD8A008D3D46 /* SiteMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMenuViewController.swift; sourceTree = "<group>"; };
 		E6871F1A22C3FDE7008D3D46 /* PostListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListViewController.swift; sourceTree = "<group>"; };
 		E68B29FE23048C6C0021283C /* EditCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCoordinator.swift; sourceTree = "<group>"; };
@@ -716,6 +718,7 @@
 				E6500F9C2368F36500CB8C6C /* MediaDetailViewController.swift */,
 				E632F9A023515116003737BF /* SiteMediaDataSource.swift */,
 				E690D57123722BB700676B1D /* PhotoLibraryViewController.swift */,
+				E68689BF243C080400B7E363 /* FoldersViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -1318,6 +1321,7 @@
 				E68B2A0123048E050021283C /* EditorAttachmentImageProvider.swift in Sources */,
 				E6500F9A2368B63800CB8C6C /* ImageStore.swift in Sources */,
 				E6241B96224EC8CD00B578F5 /* SessionManager.swift in Sources */,
+				E68689C0243C080400B7E363 /* FoldersViewController.swift in Sources */,
 				E641A66122A71A83008BBD85 /* SiteStore.swift in Sources */,
 				E6A10C6323579CE300435670 /* MediaAction.swift in Sources */,
 				E66CCA092303527C00F1CA59 /* PostQuery+CoreDataClass.swift in Sources */,

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -3,9 +3,10 @@ import WordPressFlux
 
 class FoldersViewController: UITableViewController {
 
-    
+
 
     @IBAction func handleAddTapped(sender: Any) {
-
+        let action = FolderAction.createFolder(path: "New Folder", addSuffix: true)
+        SessionManager.shared.sessionDispatcher.dispatch(action)
     }
 }

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -1,0 +1,11 @@
+import UIKit
+import WordPressFlux
+
+class FoldersViewController: UITableViewController {
+
+    
+
+    @IBAction func handleAddTapped(sender: Any) {
+
+    }
+}

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -3,10 +3,42 @@ import WordPressFlux
 
 class FoldersViewController: UITableViewController {
 
+    var folders = [URL]()
+    var receipt: Any?
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        folders = StoreContainer.shared.folderStore.listFolders()
+
+        receipt = StoreContainer.shared.folderStore.onChange { [weak self] in
+            self?.folders = StoreContainer.shared.folderStore.listFolders()
+            self?.tableView.reloadData()
+        }
+    }
 
     @IBAction func handleAddTapped(sender: Any) {
         let action = FolderAction.createFolder(path: "New Folder", addSuffix: true)
         SessionManager.shared.sessionDispatcher.dispatch(action)
     }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return folders.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "FolderCell", for: indexPath)
+
+        let url = folders[indexPath.row]
+        cell.textLabel?.text = url.lastPathComponent
+
+        return cell
+    }
+
 }

--- a/Newspack/Newspack/Controllers/SiteMenuViewController.swift
+++ b/Newspack/Newspack/Controllers/SiteMenuViewController.swift
@@ -35,8 +35,8 @@ struct SiteMenuViewModel {
         }
 
         let folderRow = SiteMenuRow(title: "New Story Folder") {
-            let action = FolderAction.createFolder(path: "New Folder", addSuffix: true)
-            SessionManager.shared.sessionDispatcher.dispatch(action)
+            let controller = MainStoryboard.instantiateViewController(withIdentifier: .folderList)
+            presenter.navigationController?.pushViewController(controller, animated: true)
         }
 
         let rows = [

--- a/Newspack/Newspack/Controllers/SiteMenuViewController.swift
+++ b/Newspack/Newspack/Controllers/SiteMenuViewController.swift
@@ -34,7 +34,7 @@ struct SiteMenuViewModel {
             SessionManager.shared.sessionDispatcher.dispatch(action)
         }
 
-        let folderRow = SiteMenuRow(title: "New Story Folder") {
+        let folderRow = SiteMenuRow(title: "Folders List") {
             let controller = MainStoryboard.instantiateViewController(withIdentifier: .folderList)
             presenter.navigationController?.pushViewController(controller, animated: true)
         }

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -144,4 +144,25 @@ class FolderManager {
 
         return didSetCurrentFolder
     }
+
+
+    /// Get a list of the folders at the specified URL. Only folders are returned
+    /// other file system items are ignored.
+    ///
+    /// - Parameter url: A file URL to the parent folder.
+    /// - Returns: An array of file URLs
+    ///
+    func enumerateFolders(url: URL) -> [URL] {
+        var folders = [URL]()
+        let keys: [URLResourceKey] = [.isDirectoryKey]
+        do {
+            folders = try fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: .skipsHiddenFiles).filter {
+                return try $0.resourceValues(forKeys: Set(keys)).isDirectory!
+            }
+        } catch {
+            LogError(message: "Error getting contents of \(url): \(error)")
+        }
+
+        return folders
+    }
 }

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -28,7 +28,7 @@ class FolderStore: Store {
                 fatalError("Unable to set the current working folder to \(url.path)")
             }
         }
-        
+
         super.init(dispatcher: dispatcher)
     }
 
@@ -49,7 +49,12 @@ extension FolderStore {
     func createFolder(path: String, addSuffix: Bool) {
         if let url = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: addSuffix) {
             LogDebug(message: "Success: \(url.path)")
+            emitChange()
         }
+    }
+
+    func listFolders() -> [URL] {
+        return folderManager.enumerateFolders(url: folderManager.currentFolder)
     }
 
 }

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -30,6 +30,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <view key="tableFooterView" contentMode="scaleToFill" id="T7a-7n-C8K">
+                            <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        </view>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FolderCell" id="O2R-uA-A0M">
                                 <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -31,7 +31,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="O2R-uA-A0M">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FolderCell" id="O2R-uA-A0M">
                                 <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="O2R-uA-A0M" id="W0e-Zt-FK0">

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hEm-rr-Shu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hEm-rr-Shu">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,6 +21,42 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="g3f-be-Ywh" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1138" y="149"/>
+        </scene>
+        <!--Folders-->
+        <scene sceneID="8gr-DY-Qxl">
+            <objects>
+                <tableViewController storyboardIdentifier="FoldersViewController" title="Folders" useStoryboardIdentifierAsRestorationIdentifier="YES" id="o5i-8K-DIP" customClass="FoldersViewController" customModule="Newspack" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="w0w-el-gTo">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="O2R-uA-A0M">
+                                <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="O2R-uA-A0M" id="W0e-Zt-FK0">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="o5i-8K-DIP" id="oaT-da-M5T"/>
+                            <outlet property="delegate" destination="o5i-8K-DIP" id="arm-xD-IwK"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Folders" id="uV3-oP-jOr">
+                        <barButtonItem key="rightBarButtonItem" style="plain" systemItem="add" id="H42-WT-r23">
+                            <connections>
+                                <action selector="handleAddTappedWithSender:" destination="o5i-8K-DIP" id="SsC-s9-7NN"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="DK2-Ey-tPA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="292" y="-504"/>
         </scene>
         <!--Initial View Controller-->
         <scene sceneID="tne-QT-ifu">

--- a/Newspack/Newspack/Storyboards/MainStoryboard.swift
+++ b/Newspack/Newspack/Storyboards/MainStoryboard.swift
@@ -10,6 +10,7 @@ class MainStoryboard {
         case postList = "PostListViewController"
         case editor = "EditorViewController"
         case mediaDetail = "MediaDetailViewController"
+        case folders = "FoldersViewController"
     }
 
     static func instantiateViewController(withIdentifier identifier: Identifier) -> UIViewController {

--- a/Newspack/Newspack/Storyboards/MainStoryboard.swift
+++ b/Newspack/Newspack/Storyboards/MainStoryboard.swift
@@ -10,7 +10,7 @@ class MainStoryboard {
         case postList = "PostListViewController"
         case editor = "EditorViewController"
         case mediaDetail = "MediaDetailViewController"
-        case folders = "FoldersViewController"
+        case folderList = "FoldersViewController"
     }
 
     static func instantiateViewController(withIdentifier identifier: Identifier) -> UIViewController {

--- a/Newspack/NewspackTests/Folders/FolderManagerTests.swift
+++ b/Newspack/NewspackTests/Folders/FolderManagerTests.swift
@@ -66,4 +66,19 @@ class FolderManagerTests: XCTestCase {
         success = folderManager.setCurrentFolder(url: FileManager.default.temporaryDirectory)
         XCTAssertFalse(success)
     }
+
+    func testListFolders() {
+        let path = "TestFolder"
+
+        var folders = folderManager.enumerateFolders(url: folderManager.currentFolder)
+        XCTAssertEqual(folders.count, 0)
+
+        _ = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)
+        _ = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)
+        _ = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)
+        _ = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)
+
+        folders = folderManager.enumerateFolders(url: folderManager.currentFolder)
+        XCTAssertEqual(folders.count, 4)
+    }
 }


### PR DESCRIPTION
Closes #44 

In this PR we're adding a simple UI to display a site's story folders in a list. A few notes about the code:
- The UI is intentionally simplistic
- The order of story folders in the list is currently undefined. Sorting will be added later.
- The ability to create a new story is moved to the + icon in the story list screen.

To test: 
- Run unit tests and confirm they all pass. 
- Launch the app and log in if needed.
- On the main screen, tap the option to view the Folders List
- In the FoldersViewController confirm you see any folders you've already created. 
- Tap the + button a few times.  Confirm that new folders appear after tapping the button. 

@jleandroperez game for one more? 