### PR TITLE
CI: Updates Xcode version used by CI tools.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   Build Tests:
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "11.4"
     steps:
       - git/shallow-checkout
       - ios/install-dependencies:
@@ -25,10 +25,10 @@ jobs:
   Unit Tests:
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "11.4"
     steps:
       - ios/boot-simulator:
-          xcode-version: "11.2.1"
+          xcode-version: "11.4"
           device: iPhone 11
       - attach_workspace:
           at: ./
@@ -40,7 +40,7 @@ jobs:
   Installable Build:
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "11.4"
     steps:
       - git/shallow-checkout
       - ios/install-dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   Build Tests:
     executor:
       name: ios/default
-      xcode-version: "11.4"
+      xcode-version: "11.4.0"
     steps:
       - git/shallow-checkout
       - ios/install-dependencies:
@@ -25,10 +25,10 @@ jobs:
   Unit Tests:
     executor:
       name: ios/default
-      xcode-version: "11.4"
+      xcode-version: "11.4.0"
     steps:
       - ios/boot-simulator:
-          xcode-version: "11.4"
+          xcode-version: "11.4.0"
           device: iPhone 11
       - attach_workspace:
           at: ./
@@ -40,7 +40,7 @@ jobs:
   Installable Build:
     executor:
       name: ios/default
-      xcode-version: "11.4"
+      xcode-version: "11.4.0"
     steps:
       - git/shallow-checkout
       - ios/install-dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - ios/wait-for-simulator
       - ios/xcodebuild:
           command: test-without-building
-          arguments: -xctestrun DerivedData/Build/Products/Newspack_iphonesimulator13.2-x86_64.xctestrun -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" -resultBundlePath test-without-building.xcresult
+          arguments: -xctestrun DerivedData/Build/Products/Newspack_iphonesimulator13.4-x86_64.xctestrun -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" -resultBundlePath test-without-building.xcresult
       - ios/save-xcodebuild-artifacts
   Installable Build:
     executor:


### PR DESCRIPTION
Updates the version of Xcode used by CircleCI to 11.4. 
Xcode 11.4 introduced new API for unit tests.  We need to update CI so tests written with the new API will build and run.  h/t @jleandroperez :) 

@loremattei Would you mind taking a peek since this deals with tooling? CI looks happy with the changes but I want to be sure there isn't something subtle I've overlooked. 