### PR TITLE
Issues/45 rename folders

### DIFF
--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -33,12 +33,41 @@ class FoldersViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "FolderCell", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: "FolderCell", for: indexPath) as! FolderCell
 
         let url = folders[indexPath.row]
-        cell.textLabel?.text = url.lastPathComponent
+        cell.textField.text = url.lastPathComponent
+        cell.textChangedHandler = { text in
+            self.handleFolderNameChanged(indexPath: indexPath, newName: text)
+        }
 
         return cell
     }
 
+    func handleFolderNameChanged(indexPath: IndexPath, newName: String?) {
+        guard let name = newName else {
+            tableView.reloadRows(at: [indexPath], with: .automatic)
+            return
+        }
+        let folder = folders[indexPath.row]
+        let action = FolderAction.renameFolder(folder: folder, name: name)
+        SessionManager.shared.sessionDispatcher.dispatch(action)
+    }
+
+}
+
+class FolderCell: UITableViewCell {
+    @IBOutlet var textField: UITextField!
+    var textChangedHandler: ((String?) -> Void)?
+}
+
+extension FolderCell: UITextFieldDelegate {
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        textChangedHandler?(textField.text)
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return false
+    }
 }

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -173,6 +173,12 @@ class FolderManager {
     /// - Returns: true if successful, false otherwise
     ///
     func moveFolder(at source: URL, to destination: URL) -> Bool {
+        let name = sanitizeFolderName(name: destination.lastPathComponent)
+        guard isValidFolderName(name: name) else {
+            return false
+        }
+
+        let destination = destination.deletingLastPathComponent().appendingPathComponent(name, isDirectory: true)
         guard folderExists(url: source) && !folderExists(url: destination) else {
             return false
         }
@@ -192,10 +198,35 @@ class FolderManager {
     /// - Parameters:
     ///   - source: The url of the folder to rename.
     ///   - name: The new name.
-    /// - Returns: true if successful, false otherwise
+    /// - Returns: The new URL of the folder, or nil if the folder could not be
+    /// renamed.
     ///
-    func renameFolder(at source: URL, to name: String) -> Bool {
+    func renameFolder(at source: URL, to name: String) -> URL? {
         let newURL = source.deletingLastPathComponent().appendingPathComponent(name, isDirectory: true)
-        return moveFolder(at: source, to: newURL)
+        if moveFolder(at: source, to: newURL) {
+            return newURL
+        }
+        return nil
+    }
+
+    /// Returns a sanitized version of the specified string.
+    ///
+    /// - Parameter name: A prospective folder name.
+    /// - Returns: The sanitized version of the name.
+    ///
+    func sanitizeFolderName(name: String) -> String {
+        return name.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "/", with: "-")
+    }
+
+    /// Checks if a string is a valid folder name.
+    ///
+    /// - Parameter name: The prospective folder name
+    /// - Returns: true if valid, otherwise false.
+    ///
+    func isValidFolderName(name: String) -> Bool {
+        guard name.characterCount > 0 else {
+            return false
+        }
+        return true
     }
 }

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -145,7 +145,6 @@ class FolderManager {
         return didSetCurrentFolder
     }
 
-
     /// Get a list of the folders at the specified URL. Only folders are returned
     /// other file system items are ignored.
     ///
@@ -164,5 +163,39 @@ class FolderManager {
         }
 
         return folders
+    }
+
+    /// Move the folder at the specified URL to a new location.
+    ///
+    /// - Parameters:
+    ///   - source: The location of the folder to move.
+    ///   - destination: The new location for the folder.
+    /// - Returns: true if successful, false otherwise
+    ///
+    func moveFolder(at source: URL, to destination: URL) -> Bool {
+        guard folderExists(url: source) && !folderExists(url: destination) else {
+            return false
+        }
+
+        do {
+            try fileManager.moveItem(at: source, to: destination)
+            return true
+        } catch {
+            LogError(message: "Error moving folder \(source) to \(destination)")
+        }
+
+        return false
+    }
+
+    /// Rename the folder at the specified url to the specified name.
+    ///
+    /// - Parameters:
+    ///   - source: The url of the folder to rename.
+    ///   - name: The new name.
+    /// - Returns: true if successful, false otherwise
+    ///
+    func renameFolder(at source: URL, to name: String) -> Bool {
+        let newURL = source.deletingLastPathComponent().appendingPathComponent(name, isDirectory: true)
+        return moveFolder(at: source, to: newURL)
     }
 }

--- a/Newspack/Newspack/Stores/Actions/FolderAction.swift
+++ b/Newspack/Newspack/Stores/Actions/FolderAction.swift
@@ -5,4 +5,5 @@ import WordPressFlux
 ///
 enum FolderAction: Action {
     case createFolder(path: String, addSuffix: Bool)
+    case renameFolder(folder: URL, name: String)
 }

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -39,6 +39,8 @@ class FolderStore: Store {
             switch action {
             case .createFolder(let path, let addSuffix) :
                 createFolder(path: path, addSuffix: addSuffix)
+            case .renameFolder(let folder, let name) :
+                renameFolder(at: folder, to: name)
             }
         }
     }
@@ -49,6 +51,12 @@ extension FolderStore {
     func createFolder(path: String, addSuffix: Bool) {
         if let url = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: addSuffix) {
             LogDebug(message: "Success: \(url.path)")
+            emitChange()
+        }
+    }
+
+    func renameFolder(at url: URL, to name: String) {
+        if folderManager.renameFolder(at: url, to: name) {
             emitChange()
         }
     }

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -56,9 +56,12 @@ extension FolderStore {
     }
 
     func renameFolder(at url: URL, to name: String) {
-        if folderManager.renameFolder(at: url, to: name) {
-            emitChange()
+        if let url = folderManager.renameFolder(at: url, to: name) {
+            LogDebug(message: "Success: \(url)")
         }
+        // TODO: For now, emit change even if not successful. We'll wire up proper
+        // error handling later when we figure out what that looks like.
+        emitChange()
     }
 
     func listFolders() -> [URL] {

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -31,18 +31,43 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="T7a-7n-C8K">
-                            <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                            <rect key="frame" x="0.0" y="98.5" width="375" height="44"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         </view>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FolderCell" id="O2R-uA-A0M">
-                                <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="FolderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FolderCell" id="O2R-uA-A0M" customClass="FolderCell" customModule="Newspack" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="28" width="375" height="42.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="O2R-uA-A0M" id="W0e-Zt-FK0">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="42.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="KCq-fL-Dbc">
+                                            <rect key="frame" x="16" y="10" width="351" height="22.5"/>
+                                            <subviews>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Placeholder" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Ga5-YF-VJ1">
+                                                    <rect key="frame" x="0.0" y="0.0" width="351" height="22.5"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <textInputTraits key="textInputTraits" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
+                                                    <connections>
+                                                        <outlet property="delegate" destination="O2R-uA-A0M" id="N7w-xy-EBg"/>
+                                                    </connections>
+                                                </textField>
+                                            </subviews>
+                                        </stackView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="KCq-fL-Dbc" firstAttribute="leading" secondItem="Ec6-1T-jHG" secondAttribute="leading" constant="16" id="Tro-Fm-MIL"/>
+                                        <constraint firstItem="Ec6-1T-jHG" firstAttribute="bottom" secondItem="KCq-fL-Dbc" secondAttribute="bottom" constant="10" id="d4m-mh-1Xi"/>
+                                        <constraint firstItem="KCq-fL-Dbc" firstAttribute="top" secondItem="Ec6-1T-jHG" secondAttribute="top" constant="10" id="d5f-3M-nz7"/>
+                                        <constraint firstItem="Ec6-1T-jHG" firstAttribute="trailing" secondItem="KCq-fL-Dbc" secondAttribute="trailing" constant="8" id="k4x-LJ-wmS"/>
+                                    </constraints>
+                                    <viewLayoutGuide key="safeArea" id="Ec6-1T-jHG"/>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="textField" destination="Ga5-YF-VJ1" id="yfq-1p-9Di"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>
@@ -61,7 +86,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DK2-Ey-tPA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="292" y="-504"/>
+            <point key="canvasLocation" x="292" y="-504.19790104947532"/>
         </scene>
         <!--Initial View Controller-->
         <scene sceneID="tne-QT-ifu">

--- a/Newspack/NewspackTests/Folders/FolderManagerTests.swift
+++ b/Newspack/NewspackTests/Folders/FolderManagerTests.swift
@@ -85,9 +85,14 @@ class FolderManagerTests: XCTestCase {
     func testMoveFolder() {
         let path = "TestFolder"
         let newPath = "MovedFolder"
+        let invalidPath = " "
         let url = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)!
         let childURL = url.appendingPathComponent(newPath, isDirectory: true)
         let newURL = url.deletingLastPathComponent().appendingPathComponent(newPath, isDirectory: true)
+        let invalidURL = url.deletingLastPathComponent().appendingPathComponent(invalidPath, isDirectory: true)
+
+        // Should return false if the folder name is invalid
+        XCTAssertFalse(folderManager.moveFolder(at: url, to: invalidURL))
 
         // Should return false if the urls are the same
         XCTAssertFalse(folderManager.moveFolder(at: url, to: url))
@@ -115,12 +120,12 @@ class FolderManagerTests: XCTestCase {
         let newName = "RenamedFolder"
 
         let folder = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)!
-        let success = folderManager.renameFolder(at: folder, to: newName)
-        XCTAssertTrue(success)
+        guard let renamedFolder = folderManager.renameFolder(at: folder, to: newName) else {
+            XCTFail("The renamed folder's URL should not be nil.")
+            return
+        }
 
         XCTAssertFalse(folderManager.folderExists(url: folder))
-
-        let url = folderManager.urlForFolderAtPath(path: newName)
-        XCTAssertTrue(folderManager.folderExists(url: url))
+        XCTAssertTrue(folderManager.folderExists(url: renamedFolder))
     }
 }

--- a/Newspack/NewspackTests/Folders/FolderManagerTests.swift
+++ b/Newspack/NewspackTests/Folders/FolderManagerTests.swift
@@ -81,4 +81,46 @@ class FolderManagerTests: XCTestCase {
         folders = folderManager.enumerateFolders(url: folderManager.currentFolder)
         XCTAssertEqual(folders.count, 4)
     }
+
+    func testMoveFolder() {
+        let path = "TestFolder"
+        let newPath = "MovedFolder"
+        let url = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)!
+        let childURL = url.appendingPathComponent(newPath, isDirectory: true)
+        let newURL = url.deletingLastPathComponent().appendingPathComponent(newPath, isDirectory: true)
+
+        // Should return false if the urls are the same
+        XCTAssertFalse(folderManager.moveFolder(at: url, to: url))
+
+        // Should return false if trying to make the folder a child of itself.
+        XCTAssertFalse((folderManager.moveFolder(at: url, to: childURL)))
+
+        // Should succeed moving folder to a sibling location.
+        XCTAssertTrue(folderManager.moveFolder(at: url, to: newURL))
+
+        // Original folder should no longer exist
+        XCTAssertFalse(folderManager.folderExists(url: url))
+
+        // New folder should exist
+        XCTAssertTrue(folderManager.folderExists(url: newURL))
+
+        _ = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)!
+
+        // Should return false if there is already a folder.
+        XCTAssertFalse(folderManager.moveFolder(at: newURL, to: url))
+    }
+
+    func testRenameFolder() {
+        let path = "TestFolder"
+        let newName = "RenamedFolder"
+
+        let folder = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)!
+        let success = folderManager.renameFolder(at: folder, to: newName)
+        XCTAssertTrue(success)
+
+        XCTAssertFalse(folderManager.folderExists(url: folder))
+
+        let url = folderManager.urlForFolderAtPath(path: newName)
+        XCTAssertTrue(folderManager.folderExists(url: url))
+    }
 }


### PR DESCRIPTION
Closes #45 

This PR adds basic functionality to rename (move) a folder and a simple UI to see it in action in the app.

To test: 
- Run unit tests.  Ensure everything passes.

Scenario 1:
- Launch the app and view the folder list.
- Create some folders if you do not currently have any.
- Switch to the Files app.  
- Choose Browse > On my Phone > Newspack > [Your Test Site]
- Observe the files match what is shown in the Newspack app.
- Switch back to Newspack
- Tap onto one of the folders that you've created. You should see a cursor and (maybe the soft keyboard)
- Type a new name for the folder and press enter / done. 
- Confirm that the folder has been renamed. 
- Switch to the Files app.  
- Confirm that the folder shows its new name here as well.

Scenario 2:
- When renaming a folder, backspace to completely remove the name, then tap on a different row.
- Confirm the original title is restored. 

Scenario 3
- When renaming a folder, try entering just a bunch of spaces, then press enter / done.
- Confirm the original title is restored. 

@jleandroperez Can I trouble you yet again sir? 