### PR TITLE
Folders: Adds ability to delete a folder.

### DIFF
--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -17,8 +17,20 @@ class FoldersViewController: UITableViewController {
         }
     }
 
+    // MARK: - Actions and Handlers
+
     @IBAction func handleAddTapped(sender: Any) {
         let action = FolderAction.createFolder(path: "New Folder", addSuffix: true)
+        SessionManager.shared.sessionDispatcher.dispatch(action)
+    }
+
+    func handleFolderNameChanged(indexPath: IndexPath, newName: String?) {
+        guard let name = newName else {
+            tableView.reloadRows(at: [indexPath], with: .automatic)
+            return
+        }
+        let folder = folders[indexPath.row]
+        let action = FolderAction.renameFolder(folder: folder, name: name)
         SessionManager.shared.sessionDispatcher.dispatch(action)
     }
 
@@ -44,14 +56,12 @@ class FoldersViewController: UITableViewController {
         return cell
     }
 
-    func handleFolderNameChanged(indexPath: IndexPath, newName: String?) {
-        guard let name = newName else {
-            tableView.reloadRows(at: [indexPath], with: .automatic)
-            return
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            let folder = folders[indexPath.row]
+            let action = FolderAction.deleteFolder(folder: folder)
+            SessionManager.shared.sessionDispatcher.dispatch(action)
         }
-        let folder = folders[indexPath.row]
-        let action = FolderAction.renameFolder(folder: folder, name: name)
-        SessionManager.shared.sessionDispatcher.dispatch(action)
     }
 
 }

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -165,6 +165,36 @@ class FolderManager {
         return folders
     }
 
+    /// Delete the folder at the specified file URL
+    /// - Parameter source: A file URL.
+    /// - Returns: true if the folder was deleted, otherwise false
+    ///
+    func deleteFolder(at source: URL) -> Bool {
+        guard folderExists(url: source) else {
+            return false
+        }
+
+        // Do not perform a delete operation on anything outside of our root folder.
+        let relation = UnsafeMutablePointer<FileManager.URLRelationship>.allocate(capacity: 1)
+        do {
+            try fileManager.getRelationship(relation, ofDirectoryAt: rootFolder, toItemAt: source)
+        } catch {
+            LogError(message: "Error checking folder relationships. \(error)")
+        }
+        if relation.pointee != .contains {
+            return false
+        }
+
+        do {
+            try fileManager.removeItem(at: source)
+            return true
+        } catch {
+            LogError(message: "Error checking folder relationships. \(error)")
+        }
+
+        return false
+    }
+
     /// Move the folder at the specified URL to a new location.
     ///
     /// - Parameters:

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -189,7 +189,7 @@ class FolderManager {
             try fileManager.removeItem(at: source)
             return true
         } catch {
-            LogError(message: "Error checking folder relationships. \(error)")
+            LogError(message: "Error removing folder. \(error)")
         }
 
         return false

--- a/Newspack/Newspack/Stores/Actions/FolderAction.swift
+++ b/Newspack/Newspack/Stores/Actions/FolderAction.swift
@@ -6,4 +6,5 @@ import WordPressFlux
 enum FolderAction: Action {
     case createFolder(path: String, addSuffix: Bool)
     case renameFolder(folder: URL, name: String)
+    case deleteFolder(folder: URL)
 }

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -41,6 +41,8 @@ class FolderStore: Store {
                 createFolder(path: path, addSuffix: addSuffix)
             case .renameFolder(let folder, let name) :
                 renameFolder(at: folder, to: name)
+            case .deleteFolder(let folder) :
+                deleteFolder(at: folder)
             }
         }
     }
@@ -61,6 +63,14 @@ extension FolderStore {
         }
         // TODO: For now, emit change even if not successful. We'll wire up proper
         // error handling later when we figure out what that looks like.
+        emitChange()
+    }
+
+    func deleteFolder(at url: URL) {
+        if !folderManager.deleteFolder(at: url) {
+            // TODO: For now emit change even if not successful. We'll wire up
+            // proper error handling later.
+        }
         emitChange()
     }
 

--- a/Newspack/NewspackTests/Folders/FolderManagerTests.swift
+++ b/Newspack/NewspackTests/Folders/FolderManagerTests.swift
@@ -128,4 +128,21 @@ class FolderManagerTests: XCTestCase {
         XCTAssertFalse(folderManager.folderExists(url: folder))
         XCTAssertTrue(folderManager.folderExists(url: renamedFolder))
     }
+
+    func testDeleteFolder() {
+        let path = "TestFolder"
+        let folder = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)!
+
+        // We should not delete folders not contained by our root folder.
+        var result = folderManager.deleteFolder(at: FolderManager.createTemporaryDirectory()!)
+        XCTAssertFalse(result)
+
+        // We should delete a cihld of the root folder.
+        result = folderManager.deleteFolder(at: folder)
+        XCTAssertTrue(result)
+
+        // We should not delete a non-existant folder.
+        result = folderManager.deleteFolder(at: folder)
+        XCTAssertFalse(result)
+    }
 }


### PR DESCRIPTION
Closes #46 

This PR adds the ability to swipe to delete a folder from the list of folders. The UI behavior is simplistic for now. In a future enhancement we'll add a nice animation to remove the deleted cell.

To test: 
- Run unit tests.  Confirm they all pass. 

Scenario 1
- Launch the app and view the folder list.
- Create some folders if you do not currently have any.
- Switch to the Files app.
- Choose Browse > On my Phone > Newspack > [Your Test Site]
- Observe the files match what is shown in the Newspack app.
- Switch back to Newspack
- Swipe on one of the rows in the folder list. 
- Tap the Delete option. 
- Confirm that the row is removed from the UI. 
- Switch to the Files app.
- Confirm the deleted folder no longer appears in the Files app.

@jleandroperez game for another? Not a whole lot to this one. :)