### PR TITLE
Issues/47 folder detail

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		E6AC98B823CCD5DE00E95381 /* MainNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AC98B723CCD5DE00E95381 /* MainNavController.swift */; };
 		E6B4034D22D8E12500A0DDCA /* remote-posts-ids-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */; };
 		E6B4034E22D8E12500A0DDCA /* remote-posts-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */; };
+		E6BA1322243F9D1E00635A8A /* AssetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */; };
 		E6CE56AF22B19001004895E5 /* ModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CE56AE22B19001004895E5 /* ModelFactory.swift */; };
 		E6D44DEC234BC56C00B51438 /* MediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEB234BC56C00B51438 /* MediaViewController.swift */; };
 		E6D44DEF234BDB8400B51438 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEE234BDB8400B51438 /* MediaStore.swift */; };
@@ -389,6 +390,7 @@
 		E6AC98B723CCD5DE00E95381 /* MainNavController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavController.swift; sourceTree = "<group>"; };
 		E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-ids-edit.json"; sourceTree = "<group>"; };
 		E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-edit.json"; sourceTree = "<group>"; };
+		E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsViewController.swift; sourceTree = "<group>"; };
 		E6CE56AE22B19001004895E5 /* ModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFactory.swift; sourceTree = "<group>"; };
 		E6D44DEB234BC56C00B51438 /* MediaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewController.swift; sourceTree = "<group>"; };
 		E6D44DEE234BDB8400B51438 /* MediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStore.swift; sourceTree = "<group>"; };
@@ -719,6 +721,7 @@
 				E632F9A023515116003737BF /* SiteMediaDataSource.swift */,
 				E690D57123722BB700676B1D /* PhotoLibraryViewController.swift */,
 				E68689BF243C080400B7E363 /* FoldersViewController.swift */,
+				E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -1229,6 +1232,7 @@
 				E6138FD42211FE86004E5B91 /* InitialViewController.swift in Sources */,
 				E66CCA072303527C00F1CA59 /* Account+CoreDataClass.swift in Sources */,
 				E69E59F922540D0900899DE2 /* SiteServiceRemote.swift in Sources */,
+				E6BA1322243F9D1E00635A8A /* AssetsViewController.swift in Sources */,
 				E6A4D742230A08A700929376 /* StagedEdits+CoreDataProperties.swift in Sources */,
 				E636C26B234FEAD800564B63 /* MediaQuery+CoreDataClass.swift in Sources */,
 				E67339A6232EFEA3007C5E45 /* Logging.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		E68B2A0323048E510021283C /* EditorAttachmentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68B2A0223048E510021283C /* EditorAttachmentDelegate.swift */; };
 		E68BA80C2347BAA300AB60F9 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68BA80B2347BAA300AB60F9 /* Environment.swift */; };
 		E690D57223722BB700676B1D /* PhotoLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E690D57123722BB700676B1D /* PhotoLibraryViewController.swift */; };
+		E69634102440C1C400D906E0 /* UITableViewCell+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E696340F2440C1C400D906E0 /* UITableViewCell+Helpers.swift */; };
 		E69DE37423A97F1C00F87157 /* remote-media-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E69DE37323A97F1C00F87157 /* remote-media-edit.json */; };
 		E69DE37623A981D000F87157 /* preview.png in Resources */ = {isa = PBXBuildFile; fileRef = E69DE37523A981D000F87157 /* preview.png */; };
 		E69E59F922540D0900899DE2 /* SiteServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69E59F822540D0900899DE2 /* SiteServiceRemote.swift */; };
@@ -375,6 +376,7 @@
 		E68B2A0223048E510021283C /* EditorAttachmentDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorAttachmentDelegate.swift; sourceTree = "<group>"; };
 		E68BA80B2347BAA300AB60F9 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		E690D57123722BB700676B1D /* PhotoLibraryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibraryViewController.swift; sourceTree = "<group>"; };
+		E696340F2440C1C400D906E0 /* UITableViewCell+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Helpers.swift"; sourceTree = "<group>"; };
 		E69DE37323A97F1C00F87157 /* remote-media-edit.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "remote-media-edit.json"; sourceTree = "<group>"; };
 		E69DE37523A981D000F87157 /* preview.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = preview.png; sourceTree = "<group>"; };
 		E69E59F822540D0900899DE2 /* SiteServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteServiceRemote.swift; sourceTree = "<group>"; };
@@ -913,6 +915,7 @@
 				E602E69E22C1747D00795CBA /* Dictionary+Unwrappers.swift */,
 				E6051DEB23075A3A005AAF0B /* Dictionary+Merge.swift */,
 				E6E2ACF822E2840C00A8E85D /* Date+FormatGMTString.swift */,
+				E696340F2440C1C400D906E0 /* UITableViewCell+Helpers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1257,6 +1260,7 @@
 				E66CCA1E2303527D00F1CA59 /* Status+CoreDataClass.swift in Sources */,
 				E6051DEC23075A3A005AAF0B /* Dictionary+Merge.swift in Sources */,
 				E6343ADF23A077C80033D369 /* MediaSelectViewController.swift in Sources */,
+				E69634102440C1C400D906E0 /* UITableViewCell+Helpers.swift in Sources */,
 				E61BBD6822FA0470008A6D4C /* StartupHelper.swift in Sources */,
 				E636C26C234FEAD800564B63 /* MediaQuery+CoreDataProperties.swift in Sources */,
 				E66CCA112303527C00F1CA59 /* AccountCapabilities+CoreDataClass.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -169,6 +169,8 @@
 		E6B4034D22D8E12500A0DDCA /* remote-posts-ids-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */; };
 		E6B4034E22D8E12500A0DDCA /* remote-posts-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */; };
 		E6BA1322243F9D1E00635A8A /* AssetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */; };
+		E6BA9FC9243FF7ED00A563BC /* AssetStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA9FC8243FF7ED00A563BC /* AssetStore.swift */; };
+		E6BA9FCB243FFA2100A563BC /* AssetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA9FCA243FFA2100A563BC /* AssetAction.swift */; };
 		E6CE56AF22B19001004895E5 /* ModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CE56AE22B19001004895E5 /* ModelFactory.swift */; };
 		E6D44DEC234BC56C00B51438 /* MediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEB234BC56C00B51438 /* MediaViewController.swift */; };
 		E6D44DEF234BDB8400B51438 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEE234BDB8400B51438 /* MediaStore.swift */; };
@@ -391,6 +393,8 @@
 		E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-ids-edit.json"; sourceTree = "<group>"; };
 		E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-edit.json"; sourceTree = "<group>"; };
 		E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsViewController.swift; sourceTree = "<group>"; };
+		E6BA9FC8243FF7ED00A563BC /* AssetStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetStore.swift; sourceTree = "<group>"; };
+		E6BA9FCA243FFA2100A563BC /* AssetAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAction.swift; sourceTree = "<group>"; };
 		E6CE56AE22B19001004895E5 /* ModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFactory.swift; sourceTree = "<group>"; };
 		E6D44DEB234BC56C00B51438 /* MediaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewController.swift; sourceTree = "<group>"; };
 		E6D44DEE234BDB8400B51438 /* MediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStore.swift; sourceTree = "<group>"; };
@@ -512,6 +516,7 @@
 				E6E43EA3230F1D2B00A1974E /* EditAction.swift */,
 				E6A10C6223579CE300435670 /* MediaAction.swift */,
 				E6A800F424380A6600A14E6C /* FolderAction.swift */,
+				E6BA9FCA243FFA2100A563BC /* AssetAction.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -799,6 +804,7 @@
 				E640D27723883ED800887FD9 /* StagedMediaImporter.swift */,
 				E640D27923883EE700887FD9 /* StagedMediaUploader.swift */,
 				E6A800F224380A5300A14E6C /* FolderStore.swift */,
+				E6BA9FC8243FF7ED00A563BC /* AssetStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -1273,6 +1279,7 @@
 				E62C7C662235E16E000FEB33 /* AccountStore.swift in Sources */,
 				E6E43EA4230F1D2B00A1974E /* EditAction.swift in Sources */,
 				E69E59FB22540D5000899DE2 /* ServiceRemoteCoreRest.swift in Sources */,
+				E6BA9FCB243FFA2100A563BC /* AssetAction.swift in Sources */,
 				E602E68022C1588600795CBA /* ApiService.swift in Sources */,
 				E6E2ACF922E2840C00A8E85D /* Date+FormatGMTString.swift in Sources */,
 				E6F1C52522C2A48600334003 /* ApiAction.swift in Sources */,
@@ -1306,6 +1313,7 @@
 				E66CCA132303527C00F1CA59 /* Status+CoreDataProperties.swift in Sources */,
 				E605418F2369E1920078D978 /* Diagnostics.swift in Sources */,
 				E63EECDB23428A0900669FFC /* UserApiService.swift in Sources */,
+				E6BA9FC9243FF7ED00A563BC /* AssetStore.swift in Sources */,
 				E640D27823883ED800887FD9 /* StagedMediaImporter.swift in Sources */,
 				E61D8F6C2375EC3E005FECED /* StagedMediaStore.swift in Sources */,
 				E66CCA0D2303527C00F1CA59 /* Site+CoreDataProperties.swift in Sources */,

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -1,0 +1,40 @@
+import UIKit
+import WordPressFlux
+
+class AssetsViewController: UITableViewController {
+
+    var folder: URL?
+    var items = [URL]()
+    var receipt: Any?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        items = StoreContainer.shared.folderStore.listFolders()
+
+        receipt = StoreContainer.shared.folderStore.onChange { [weak self] in
+            self?.items = StoreContainer.shared.folderStore.listFolders()
+            self?.tableView.reloadData()
+        }
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return items.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "AssetCell", for: indexPath)
+
+        let url = items[indexPath.row]
+        cell.textLabel?.text = url.lastPathComponent
+
+        return cell
+    }
+
+}

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -3,17 +3,16 @@ import WordPressFlux
 
 class AssetsViewController: UITableViewController {
 
-    var folder: URL?
     var items = [URL]()
     var receipt: Any?
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        items = StoreContainer.shared.folderStore.listFolders()
+        items = StoreContainer.shared.assetStore.listAssets()
 
         receipt = StoreContainer.shared.folderStore.onChange { [weak self] in
-            self?.items = StoreContainer.shared.folderStore.listFolders()
+            self?.items = StoreContainer.shared.assetStore.listAssets()
             self?.tableView.reloadData()
         }
     }

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -52,6 +52,7 @@ class FoldersViewController: UITableViewController {
         cell.textChangedHandler = { text in
             self.handleFolderNameChanged(indexPath: indexPath, newName: text)
         }
+        cell.accessoryType = .disclosureIndicator
 
         return cell
     }
@@ -62,6 +63,11 @@ class FoldersViewController: UITableViewController {
             let action = FolderAction.deleteFolder(folder: folder)
             SessionManager.shared.sessionDispatcher.dispatch(action)
         }
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let controller = MainStoryboard.instantiateViewController(withIdentifier: .assetsList)
+        navigationController?.pushViewController(controller, animated: true)
     }
 
 }

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -45,7 +45,7 @@ class FoldersViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "FolderCell", for: indexPath) as! FolderCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: FolderCell.reuseIdentifier, for: indexPath) as! FolderCell
 
         let url = folders[indexPath.row]
         cell.textField.text = url.lastPathComponent

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -66,6 +66,10 @@ class FoldersViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let folder = folders[indexPath.row]
+        let action = AssetAction.selectFolder(folder: folder)
+        SessionManager.shared.sessionDispatcher.dispatch(action)
+
         let controller = MainStoryboard.instantiateViewController(withIdentifier: .assetsList)
         navigationController?.pushViewController(controller, animated: true)
     }

--- a/Newspack/Newspack/Extensions/UITableViewCell+Helpers.swift
+++ b/Newspack/Newspack/Extensions/UITableViewCell+Helpers.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+extension UITableViewCell {
+    class var reuseIdentifier: String {
+        return String(describing: self)
+    }
+}

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -165,6 +165,22 @@ class FolderManager {
         return folders
     }
 
+    /// Get a list of the folder contents at the specified URL.
+    ///
+    /// - Parameter url: A file URL to the parent folder.
+    /// - Returns: An array of file URLs
+    ///
+    func enumerateFolderContents(url: URL) -> [URL] {
+        var contents = [URL]()
+        do {
+            contents = try fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
+        } catch {
+            LogError(message: "Error getting contents of folder at \(url): \(error)")
+        }
+
+        return contents
+    }
+
     /// Delete the folder at the specified file URL
     /// - Parameter source: A file URL.
     /// - Returns: true if the folder was deleted, otherwise false

--- a/Newspack/Newspack/Stores/Actions/AssetAction.swift
+++ b/Newspack/Newspack/Stores/Actions/AssetAction.swift
@@ -1,0 +1,8 @@
+import Foundation
+import WordPressFlux
+
+/// Supported Actions for changes to the FolderStore
+///
+enum AssetAction: Action {
+    case selectFolder(folder: URL)
+}

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -1,0 +1,58 @@
+import Foundation
+import WordPressFlux
+
+/// Responsible for managing folder related things.
+///
+class AssetStore: Store {
+
+    private(set) var currentSiteID: UUID?
+
+    private let folderManager: FolderManager
+
+    private var selectedFolder: URL?
+
+    init(dispatcher: ActionDispatcher = .global, siteID: UUID? = nil) {
+        currentSiteID = siteID
+
+        folderManager = SessionManager.shared.folderManager
+
+        if let _ = siteID, let folder = StoreContainer.shared.folderStore.listFolders().first {
+            selectedFolder = folder
+        }
+
+        super.init(dispatcher: dispatcher)
+    }
+
+    /// Action handler
+    ///
+    override func onDispatch(_ action: Action) {
+        if let action = action as? AssetAction {
+            switch action {
+            case .selectFolder(let folder) :
+                selectFolder(folder: folder)
+            }
+        }
+    }
+}
+
+extension AssetStore {
+
+    func getSelectedFolder() -> URL? {
+        return selectedFolder
+    }
+
+    func selectFolder(folder: URL) {
+        guard folderManager.folderExists(url: folder) else {
+            return
+        }
+        selectedFolder = folder
+        emitChange()
+    }
+
+    func listAssets() -> [URL] {
+        guard let selectedFolder = selectedFolder else {
+            return [URL]()
+        }
+        return folderManager.enumerateFolderContents(url: selectedFolder)
+    }
+}

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -9,7 +9,7 @@ class AssetStore: Store {
 
     private let folderManager: FolderManager
 
-    private var selectedFolder: URL?
+    private(set) var selectedFolder: URL?
 
     init(dispatcher: ActionDispatcher = .global, siteID: UUID? = nil) {
         currentSiteID = siteID
@@ -36,10 +36,6 @@ class AssetStore: Store {
 }
 
 extension AssetStore {
-
-    func getSelectedFolder() -> URL? {
-        return selectedFolder
-    }
 
     func selectFolder(folder: URL) {
         guard folderManager.folderExists(url: folder) else {

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -12,8 +12,7 @@ class FolderStore: Store {
     init(dispatcher: ActionDispatcher = .global, siteID: UUID? = nil) {
         currentSiteID = siteID
 
-        let rootFolder = Environment.isTesting() ? FolderManager.createTemporaryDirectory() : nil
-        folderManager = FolderManager(rootFolder: rootFolder)
+        folderManager = SessionManager.shared.folderManager
 
         if
             let siteID = siteID,

--- a/Newspack/Newspack/Stores/StoreContainer.swift
+++ b/Newspack/Newspack/Stores/StoreContainer.swift
@@ -17,6 +17,7 @@ class StoreContainer {
     private(set) var imageStore = ImageStore()
     private(set) var stagedMediaStore = StagedMediaStore()
     private(set) var folderStore = FolderStore()
+    private(set) var assetStore = AssetStore()
 
     private init() {}
 
@@ -37,5 +38,6 @@ class StoreContainer {
         imageStore = ImageStore(dispatcher: dispatcher)
         stagedMediaStore = StagedMediaStore(dispatcher: dispatcher, siteID: site?.uuid)
         folderStore = FolderStore(dispatcher: dispatcher, siteID: site?.uuid)
+        assetStore = AssetStore(dispatcher: dispatcher, siteID: site?.uuid)
     }
 }

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -88,6 +88,40 @@
             </objects>
             <point key="canvasLocation" x="292" y="-504.19790104947532"/>
         </scene>
+        <!--Assets-->
+        <scene sceneID="crf-0X-lV6">
+            <objects>
+                <tableViewController storyboardIdentifier="AssetsViewController" title="Assets" useStoryboardIdentifierAsRestorationIdentifier="YES" id="EtD-KI-a1B" customClass="AssetsViewController" customModule="Newspack" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Gj8-TX-CtG">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <view key="tableFooterView" contentMode="scaleToFill" id="GFd-8g-uaH">
+                            <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        </view>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AssetCell" id="a0I-9b-USj">
+                                <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="a0I-9b-USj" id="G1c-S4-kfV">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="EtD-KI-a1B" id="1Yf-zF-eCU"/>
+                            <outlet property="delegate" destination="EtD-KI-a1B" id="vcw-dE-pg9"/>
+                        </connections>
+                    </tableView>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="V9p-Z4-7n1" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="964" y="-504"/>
+        </scene>
         <!--Initial View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>

--- a/Newspack/Newspack/Storyboards/MainStoryboard.swift
+++ b/Newspack/Newspack/Storyboards/MainStoryboard.swift
@@ -11,6 +11,7 @@ class MainStoryboard {
         case editor = "EditorViewController"
         case mediaDetail = "MediaDetailViewController"
         case folderList = "FoldersViewController"
+        case assetsList = "AssetsViewController"
     }
 
     static func instantiateViewController(withIdentifier identifier: Identifier) -> UIViewController {

--- a/Newspack/Newspack/System/SessionManager.swift
+++ b/Newspack/Newspack/System/SessionManager.swift
@@ -17,6 +17,8 @@ class SessionManager: StatefulStore<SessionState> {
     ///
     static let shared = SessionManager()
 
+    var folderManager: FolderManager
+
     /// Used with UserDefaults to store the current site's uuid for later recovery.
     ///
     private var currentSiteIDKey: String {
@@ -50,6 +52,9 @@ class SessionManager: StatefulStore<SessionState> {
     private(set) var api = WordPressCoreRestApi(oAuthToken: nil, userAgent: UserAgent.defaultUserAgent)
 
     private init() {
+        let rootFolder = Environment.isTesting() ? FolderManager.createTemporaryDirectory() : nil
+        folderManager = FolderManager(rootFolder: rootFolder)
+
         super.init(initialState: .pending)
     }
 

--- a/Newspack/NewspackTests/Folders/FolderManagerTests.swift
+++ b/Newspack/NewspackTests/Folders/FolderManagerTests.swift
@@ -145,4 +145,22 @@ class FolderManagerTests: XCTestCase {
         result = folderManager.deleteFolder(at: folder)
         XCTAssertFalse(result)
     }
+
+    func testListFolderContents() {
+        let parent = "ParentFolder"
+        let url = folderManager.createFolderAtPath(path: parent, ifExistsAppendSuffix: true)!
+
+        let path = "ParentFolder/TestFolder"
+        var items = folderManager.enumerateFolderContents(url: url)
+        XCTAssertEqual(items.count, 0)
+
+        _ = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)
+        _ = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)
+        _ = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)
+        _ = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)
+
+        items = folderManager.enumerateFolderContents(url: url)
+        XCTAssertEqual(items.count, 4)
+
+    }
 }


### PR DESCRIPTION
Closes #47

This PR adds a simple detail view for a story folder.  The detail view will display the contents of the story folder in a simple list. 

The PR performs a minor refactor of how the FolderManager is instantiated. Rather than belonging to the FolderStore, its created by the SessionManager so it may be shared between FolderStore and AssetStore. 

There is a flaw in the current implementation -- the scenario where no story folders exist is not well handled. This will be improved in a future PR.

Prep:
- Launch the app and view the folder list.
- Create some folders if you do not currently have any.
- Switch to the Files app.
- Choose Browse > On my Phone > Newspack > [Your Test Site]
- Observe the files match what is shown in the Newspack app.
- Press and hold to copy one of the folders.
- Double click to enter a different folder. 
- Paste the copied folder inside.
This will allow you to see that there is some content inside a selected story folder.

To test: 
- Run unit tests.  Confirm all tests pass. 
- Launch the app and view the folder list.
- Tap the disclosure icon on one of the folders to view its detail. 
- If this is the folder you pasted content inside, confirm you see the pasted content. 

@jleandroperez One more, sir? 

