### PR TITLE
Issues/better url wrangling

### DIFF
--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -52,8 +52,7 @@ class FoldersViewController: UITableViewController {
         cell.textChangedHandler = { text in
             self.handleFolderNameChanged(indexPath: indexPath, newName: text)
         }
-        let isCurrentStory = url.absoluteString == StoreContainer.shared.folderStore.currentStoryFolder.absoluteString
-        cell.accessoryType = isCurrentStory ? .detailDisclosureButton : .disclosureIndicator
+        cell.accessoryType = url == StoreContainer.shared.folderStore.currentStoryFolder ? .detailDisclosureButton : .disclosureIndicator
 
         return cell
     }

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -119,7 +119,7 @@ extension FolderStore {
         createDefaultFolderIfNeeded()
 
         // Update the current story folder if it was the one deleted.
-        if url.absoluteString == currentStoryFolder.absoluteString, let folder = listStoryFolders().first {
+        if url == currentStoryFolder, let folder = listStoryFolders().first {
             currentStoryFolder = folder
         }
 


### PR DESCRIPTION
This PR simplifies some URL handling by resolving symlinks and ensuring created URLs are absolute.  It rolls back some equality checks that are now unnecessary.

To test: 
Go through the process of creating/deleting folders down to the last folder.  Make sure that there is always a selected folder. 

@jleandroperez would you mind a quick peek at this one as you're already familiar with the issues :) 