### PR TITLE
Issues/58 data story folder recon

### DIFF
--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -1,87 +1,94 @@
 import UIKit
+import CoreData
 import WordPressFlux
 
 class FoldersViewController: UITableViewController {
 
-    var folders = [URL]()
-    var receipt: Any?
+    var dataSource: FolderDataSource!
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        folders = StoreContainer.shared.folderStore.listStoryFolders()
-
-        receipt = StoreContainer.shared.folderStore.onChange { [weak self] in
-            self?.folders = StoreContainer.shared.folderStore.listStoryFolders()
-            self?.tableView.reloadData()
-        }
+        configureDataSource()
     }
+}
 
-    // MARK: - Actions and Handlers
+// MARK: - Actions and Handlers
+extension FoldersViewController {
 
     @IBAction func handleAddTapped(sender: Any) {
-        let action = FolderAction.createStoryFolder(path: "New Folder", addSuffix: true)
+        let action = FolderAction.createStoryFolder
         SessionManager.shared.sessionDispatcher.dispatch(action)
     }
 
     func handleFolderNameChanged(indexPath: IndexPath, newName: String?) {
-        guard let name = newName else {
+        guard let name = newName, let storyFolder = dataSource.resultsController.fetchedObjects?[indexPath.row] else {
             tableView.reloadRows(at: [indexPath], with: .automatic)
             return
         }
-        let folder = folders[indexPath.row]
-        let action = FolderAction.renameStoryFolder(folder: folder, name: name)
+
+        let action = FolderAction.renameStoryFolder(folderID: storyFolder.uuid, name: name)
         SessionManager.shared.sessionDispatcher.dispatch(action)
     }
 
-    // MARK: - Table view data source
+}
 
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return folders.count
-    }
-
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: FolderCell.reuseIdentifier, for: indexPath) as! FolderCell
-
-        let url = folders[indexPath.row]
-        cell.textField.text = url.lastPathComponent
-        cell.textChangedHandler = { text in
-            self.handleFolderNameChanged(indexPath: indexPath, newName: text)
-        }
-        cell.accessoryType = url == StoreContainer.shared.folderStore.currentStoryFolder ? .detailDisclosureButton : .disclosureIndicator
-
-        return cell
-    }
-
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == .delete {
-            let folder = folders[indexPath.row]
-            let action = FolderAction.deleteStoryFolder(folder: folder)
-            SessionManager.shared.sessionDispatcher.dispatch(action)
-        }
-    }
+// MARK: - TableViewDelegate methods
+extension FoldersViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let folder = folders[indexPath.row]
-        let action = FolderAction.selectStoryFolder(folder: folder)
+        guard let storyFolder = dataSource.resultsController.fetchedObjects?[indexPath.row] else {
+            return
+        }
+
+        let action = FolderAction.selectStoryFolder(folderID: storyFolder.uuid)
         SessionManager.shared.sessionDispatcher.dispatch(action)
 
         let controller = MainStoryboard.instantiateViewController(withIdentifier: .assetsList)
         navigationController?.pushViewController(controller, animated: true)
     }
+}
+
+// MARK: - DataSource related methods
+extension FoldersViewController {
+
+    func cellFor(tableView: UITableView, indexPath: IndexPath, storyFolder: StoryFolder) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: FolderCell.reuseIdentifier, for: indexPath) as? FolderCell else {
+            fatalError("Cannot create new cell")
+        }
+
+        cell.textField.text = storyFolder.name
+        cell.textChangedHandler = { text in
+            self.handleFolderNameChanged(indexPath: indexPath, newName: text)
+        }
+        cell.accessoryType = storyFolder.uuid == StoreContainer.shared.folderStore.currentStoryFolderID ? .detailDisclosureButton : .disclosureIndicator
+
+        return cell
+    }
+
+    func configureDataSource() {
+        dataSource = FolderDataSource(tableView: tableView, cellProvider: { [weak self] (tableView, indexPath, storyFolder) -> UITableViewCell? in
+            return self?.cellFor(tableView: tableView, indexPath: indexPath, storyFolder: storyFolder)
+        })
+        dataSource.update()
+    }
 
 }
 
+// MARK: - Folder Cell
 class FolderCell: UITableViewCell {
+
     @IBOutlet var textField: UITextField!
     var textChangedHandler: ((String?) -> Void)?
+
 }
 
 extension FolderCell: UITextFieldDelegate {
+
     func textFieldDidEndEditing(_ textField: UITextField) {
         textChangedHandler?(textField.text)
     }
@@ -90,4 +97,81 @@ extension FolderCell: UITextFieldDelegate {
         textField.resignFirstResponder()
         return false
     }
+
 }
+
+// MARK: - FolderDataSource
+class FolderDataSource: UITableViewDiffableDataSource<FolderDataSource.Section, StoryFolder> {
+
+    enum Section: CaseIterable {
+        case main
+    }
+
+    // Receipt so we can respond to any emitted changes in the FolderStore.
+    var receipt: Any?
+
+    // A results controller instance used to fetch StoryFolders.
+    // The StoryFolderDataSource is its delegate so it can call update whenever
+    // the results controller's content is changed.
+    lazy var resultsController: NSFetchedResultsController<StoryFolder> = {
+        return StoreContainer.shared.folderStore.getResultsController()
+    }()
+
+    // Hang on to a reference to the tableView. We'll use it to know when to
+    // animate changes.
+    weak var tableView: UITableView?
+
+    override init(tableView: UITableView, cellProvider: @escaping UITableViewDiffableDataSource<FolderDataSource.Section, StoryFolder>.CellProvider) {
+        self.tableView = tableView
+        super.init(tableView: tableView, cellProvider: cellProvider)
+
+        resultsController.delegate = self
+
+        receipt = StoreContainer.shared.folderStore.onChange { [weak self] in
+            self?.tableView?.reloadData()
+        }
+
+        try? resultsController.performFetch()
+    }
+
+    /// Updates the current datasource snapshot. Changes are animated only if
+    /// the tableView has a window (and is presumed visible).
+    ///
+    func update() {
+        guard let items = resultsController.fetchedObjects else {
+            return
+        }
+        var snapshot = NSDiffableDataSourceSnapshot<FolderDataSource.Section, StoryFolder>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(items)
+
+        let shouldAnimate = tableView?.window != nil
+        apply(snapshot, animatingDifferences: shouldAnimate, completion: nil)
+    }
+
+    // MARK: - Overrides for cell deletion behaviors
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        guard let storyFolder = resultsController.fetchedObjects?[indexPath.row] else {
+            return
+        }
+        if editingStyle == .delete {
+            let action = FolderAction.deleteStoryFolder(folderID: storyFolder.uuid)
+            SessionManager.shared.sessionDispatcher.dispatch(action)
+        }
+    }
+
+}
+
+// MARK: - Fetched Results Controller Delegate methods
+extension FolderDataSource: NSFetchedResultsControllerDelegate {
+
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        update()
+   }
+
+}
+

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -174,4 +174,3 @@ extension FolderDataSource: NSFetchedResultsControllerDelegate {
    }
 
 }
-

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -349,6 +349,17 @@ class FolderManager {
         return nil
     }
 
+    /// A convenience wrapper around urlFromBookMark(bookmark:bookmarkIsStale:)
+    /// Only call this when confident the value of bookmarkIsStale: is not relevant.
+    ///
+    /// - Parameter bookmark: The bookmark data.
+    /// - Returns: A URL or nil if there was an error.
+    ///
+    func urlFromBookmark(bookmark: Data) -> URL? {
+        var isStale = false
+        return urlFromBookmark(bookmark: bookmark, bookmarkIsStale: &isStale)
+    }
+
     /// Check if a file resource has been trashed.
     ///
     /// - Parameter url: A file URL.

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -196,6 +196,7 @@ class FolderManager {
     /// - Parameter source: A file URL.
     /// - Returns: true if the folder was deleted, otherwise false
     ///
+    @discardableResult
     func deleteFolder(at source: URL) -> Bool {
         guard folderExists(url: source) else {
             return false

--- a/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
+++ b/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
@@ -260,6 +260,9 @@
     </entity>
     <entity name="StoryFolder" representedClassName="StoryFolder" syncable="YES">
         <attribute name="bookmark" attributeType="Binary"/>
+        <attribute name="date" attributeType="Date" defaultDateTimeInterval="599554800" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="postID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="removed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <relationship name="assets" toMany="YES" deletionRule="Cascade" destinationEntity="StoryAsset" inverseName="folder" inverseEntity="StoryAsset"/>
         <relationship name="site" maxCount="1" deletionRule="Nullify" destinationEntity="Site" inverseName="storyFolders" inverseEntity="Site"/>
@@ -292,7 +295,7 @@
         <element name="StagedMedia" positionX="-1359" positionY="-234" width="128" height="208"/>
         <element name="Status" positionX="-1359" positionY="-234" width="128" height="165"/>
         <element name="StoryAsset" positionX="-1350" positionY="-225" width="128" height="103"/>
-        <element name="StoryFolder" positionX="-1359" positionY="-234" width="128" height="103"/>
+        <element name="StoryFolder" positionX="-1359" positionY="-234" width="128" height="148"/>
         <element name="User" positionX="-1305" positionY="-180" width="128" height="163"/>
     </elements>
 </model>

--- a/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
+++ b/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
@@ -264,6 +264,7 @@
         <attribute name="name" attributeType="String"/>
         <attribute name="postID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="removed" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="uuid" attributeType="UUID" usesScalarValueType="NO"/>
         <relationship name="assets" toMany="YES" deletionRule="Cascade" destinationEntity="StoryAsset" inverseName="folder" inverseEntity="StoryAsset"/>
         <relationship name="site" maxCount="1" deletionRule="Nullify" destinationEntity="Site" inverseName="storyFolders" inverseEntity="Site"/>
     </entity>
@@ -295,7 +296,7 @@
         <element name="StagedMedia" positionX="-1359" positionY="-234" width="128" height="208"/>
         <element name="Status" positionX="-1359" positionY="-234" width="128" height="165"/>
         <element name="StoryAsset" positionX="-1350" positionY="-225" width="128" height="103"/>
-        <element name="StoryFolder" positionX="-1359" positionY="-234" width="128" height="148"/>
+        <element name="StoryFolder" positionX="-1359" positionY="-234" width="128" height="163"/>
         <element name="User" positionX="-1305" positionY="-180" width="128" height="163"/>
     </elements>
 </model>

--- a/Newspack/Newspack/Models/StoryFolder+CoreDataProperties.swift
+++ b/Newspack/Newspack/Models/StoryFolder+CoreDataProperties.swift
@@ -19,6 +19,7 @@ extension StoryFolder {
     @NSManaged public var name: String!
     @NSManaged public var assets: Set<StoryAsset>!
     @NSManaged public var site: Site!
+    @NSManaged public var uuid: UUID!
 
 }
 

--- a/Newspack/Newspack/Models/StoryFolder+CoreDataProperties.swift
+++ b/Newspack/Newspack/Models/StoryFolder+CoreDataProperties.swift
@@ -10,8 +10,15 @@ extension StoryFolder {
 
     @NSManaged public var bookmark: Data!
     @NSManaged public var removed: Bool
-    @NSManaged public var site: Site!
+    // postID is non-optional due to ObjC so we'll let its default be 0.
+    // If postID is > 0 then there is a valid draft associated with the story.
+    @NSManaged public var postID: Int64
+    // Folder creation date, not the post draft date.
+    @NSManaged public var date: Date!
+    // The name of the folder cached for convenience. Used for the draft post title.
+    @NSManaged public var name: String!
     @NSManaged public var assets: Set<StoryAsset>!
+    @NSManaged public var site: Site!
 
 }
 

--- a/Newspack/Newspack/Stores/Actions/FolderAction.swift
+++ b/Newspack/Newspack/Stores/Actions/FolderAction.swift
@@ -4,8 +4,9 @@ import WordPressFlux
 /// Supported Actions for changes to the FolderStore
 ///
 enum FolderAction: Action {
-    case createStoryFolder(path: String, addSuffix: Bool)
-    case renameStoryFolder(folder: URL, name: String)
-    case deleteStoryFolder(folder: URL)
-    case selectStoryFolder(folder: URL)
+    case createStoryFolder
+    case createStoryFolderNamed(path: String, addSuffix: Bool)
+    case renameStoryFolder(folderID: UUID, name: String)
+    case deleteStoryFolder(folderID: UUID)
+    case selectStoryFolder(folderID: UUID)
 }

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -225,9 +225,9 @@ extension FolderStore {
         var newIndex = index - 1
         // However, if that would be a negative index, we want to select the
         // following item.
-        newIndex = (newIndex < 0) ? 1 : newIndex
+        newIndex = max(newIndex, 0)
 
-        currentStoryFolderID = results[newIndex]["uuid"]!
+        selectStoryFolder(uuid: results[newIndex]["uuid"]!)
     }
 
     /// Delete the specified StoryFolder. This removes the entity from core data

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -96,7 +96,7 @@ extension FolderStore {
     private func selectDefaultStoryFolderIfNeeded() {
         guard
             let _ = currentSiteID,
-            !folderManager.currentFolderContains(currentStoryFolder),
+            getStoryFolderByID(uuid: currentStoryFolderID) == nil,
             let storyFolder = getStoryFolders().first
         else {
             return
@@ -143,9 +143,7 @@ extension FolderStore {
             CoreDataManager.shared.saveContext(context: context)
 
             DispatchQueue.main.async {
-                if let folders = self?.getStoryFolders(), folders.count == 1 {
-                    self?.selectStoryFolder(folder: folders.first!)
-                }
+                self?.selectDefaultStoryFolderIfNeeded()
             }
         }
     }

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreData
 import WordPressFlux
 
 /// Responsible for managing folder related things.
@@ -16,6 +17,11 @@ class FolderStore: Store {
     ///
     private(set) var currentStoryFolder = FileManager.default.temporaryDirectory
 
+    /// Warning: We initialize with a random UUID due to the way sessions work.
+    /// Durning normal opperation this is updated to an actual StoryFolder's uuid
+    /// before it is used.
+    private(set) var currentStoryFolderID = UUID()
+
     init(dispatcher: ActionDispatcher = .global, siteID: UUID? = nil) {
         currentSiteID = siteID
 
@@ -32,16 +38,44 @@ class FolderStore: Store {
     override func onDispatch(_ action: Action) {
         if let action = action as? FolderAction {
             switch action {
-            case .createStoryFolder(let path, let addSuffix) :
+            case .createStoryFolder:
+                // Create a story folder with the default name, appending a suffix if needed.
+                createStoryFolder(path: Constants.defaultStoryFolderName, addSuffix: true)
+            case .createStoryFolderNamed(let path, let addSuffix):
                 createStoryFolder(path: path, addSuffix: addSuffix)
-            case .renameStoryFolder(let folder, let name) :
-                renameStoryFolder(at: folder, to: name)
-            case .deleteStoryFolder(let folder) :
-                deleteStoryFolder(at: folder)
-            case .selectStoryFolder(let folder) :
-                selectStoryFolder(folder: folder)
+            case .renameStoryFolder(let uuid, let name):
+                renameStoryFolder(uuid: uuid, to: name)
+            case .deleteStoryFolder(let uuid):
+                deleteStoryFolder(uuid: uuid)
+            case .selectStoryFolder(let uuid):
+                selectStoryFolder(uuid: uuid)
             }
         }
+    }
+}
+
+extension FolderStore {
+
+    /// Convenience method for getting an NSFetchedResultsController configured
+    /// to fetch StoryFolders for the current site. It is expected that this method
+    /// is only called during a logged in session. If called from a logged out
+    /// Session an fatal error is raised.
+    ///
+    /// - Returns: An NSFetchedResultsController instance
+    ///
+    func getResultsController() -> NSFetchedResultsController<StoryFolder> {
+        guard let siteID = currentSiteID else {
+            fatalError()
+        }
+
+        let fetchRequest = StoryFolder.defaultFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "site.uuid = %@", siteID as CVarArg)
+        fetchRequest.sortDescriptors = currentSortDescriptors()
+        return NSFetchedResultsController(fetchRequest: fetchRequest,
+                                          managedObjectContext: CoreDataManager.shared.mainContext,
+                                          sectionNameKeyPath: nil,
+                                          cacheName: nil)
+
     }
 }
 
@@ -51,7 +85,7 @@ extension FolderStore {
     /// site, and there are currently no folders.
     ///
     private func createDefaultStoryFolderIfNeeded() {
-        guard let _ = currentSiteID, listStoryFolders().count == 0 else {
+        guard let _ = currentSiteID, getStoryFolderCount() == 0 else {
             return
         }
         createStoryFolder()
@@ -63,16 +97,19 @@ extension FolderStore {
         guard
             let _ = currentSiteID,
             !folderManager.currentFolderContains(currentStoryFolder),
-            let folder = listStoryFolders().first else {
+            let storyFolder = getStoryFolders().first
+        else {
             return
         }
-        selectStoryFolder(folder: folder)
+        selectStoryFolder(uuid: storyFolder.uuid)
     }
 
     /// Create a new story folder using the supplied string as its path.
     ///
     /// - Parameters:
     ///   - path: The folder name and (optionally) a path to the story folder.
+    ///   If a path, only the last path component will be used for the StoryFolder
+    ///   name in core data.
     ///   - addSuffix: Whether to add a numeric suffix to the folder name if there
     /// is already a folder with that name.
     ///
@@ -92,62 +129,227 @@ extension FolderStore {
         LogDebug(message: "Success: \(url.path)")
 
         // Create the core data proxy for the story folder.
-        CoreDataManager.shared.performBackgroundTask { context in
+        CoreDataManager.shared.performBackgroundTask { [weak self] context in
             let site = context.object(with: siteObjID) as! Site
             let folderManager = SessionManager.shared.folderManager
 
             let storyFolder = StoryFolder(context: context)
+            storyFolder.uuid = UUID()
+            storyFolder.date = Date()
+            storyFolder.name = url.pathComponents.last
             storyFolder.site = site
             storyFolder.bookmark = folderManager.bookmarkForURL(url: url)
 
             CoreDataManager.shared.saveContext(context: context)
-        }
 
-        // Update the currentStoryFolder if needed.
-        if listStoryFolders().count == 1, let folder = listStoryFolders().first {
-            currentStoryFolder = folder
+            DispatchQueue.main.async {
+                if let folders = self?.getStoryFolders(), folders.count == 1 {
+                    self?.selectStoryFolder(folder: folders.first!)
+                }
+            }
         }
-
-        emitChange()
     }
 
-    func renameStoryFolder(at url: URL, to name: String) {
-        if let url = folderManager.renameFolder(at: url, to: name) {
-            LogDebug(message: "Success: \(url)")
+
+    /// Rename a story folder. This updates the name of the story folder's underlying
+    /// directory as well as the name field in core data.
+    ///
+    /// - Parameters:
+    ///   - uuid: The uuid of the StoryFolder to update.
+    ///   - name: The new name.
+    ///
+    func renameStoryFolder(uuid: UUID, to name: String) {
+        // Get the folder.
+        guard let storyFolder = getStoryFolderByID(uuid: uuid) else {
+            LogError(message: "Unable to rename story folder")
+            return
         }
-        // TODO: For now, emit change even if not successful. We'll wire up proper
-        // error handling later when we figure out what that looks like.
-        emitChange()
+
+        // Update the name of its folder. We will assume it is not stale.
+        guard
+            let url = folderManager.urlFromBookmark(bookmark: storyFolder.bookmark),
+            let newUrl = folderManager.renameFolder(at: url, to: name)
+        else {
+            LogError(message: "Unable to rename story folder")
+            return
+        }
+
+        LogDebug(message: "Success: \(newUrl)")
+
+        // Save the name in core data.
+        let objID = storyFolder.objectID
+        CoreDataManager.shared.performOnWriteContext { context in
+            let folder = context.object(with: objID) as! StoryFolder
+            folder.name = name
+
+            CoreDataManager.shared.saveContext(context: context)
+        }
     }
 
-    func deleteStoryFolder(at url: URL) {
+    /// Ensure the selected story folder is any folder other than the one listed.
+    ///
+    /// - Parameter uuid: The uuid of the story folder we do not want selected.
+    ///
+    func selectStoryOtherThan(uuid: UUID) {
+        // If this isn't the currently selected folder then there is nothing to do.
+        guard
+            currentStoryFolderID == uuid,
+            let siteID = currentSiteID
+        else {
+            return
+        }
+
+        let context = CoreDataManager.shared.mainContext
+        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = StoryFolder.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "site.uuid = %@", siteID as CVarArg)
+        fetchRequest.sortDescriptors = currentSortDescriptors()
+        fetchRequest.propertiesToFetch = ["uuid"]
+        fetchRequest.resultType = .dictionaryResultType
+
+        guard let results = try? context.fetch(fetchRequest) as? [[String: UUID]] else {
+            LogError(message: "Error fetching StoryFolders.")
+            return
+        }
+
+        guard results.count > 0 else {
+            // Nothing to select.
+            return
+        }
+
+        // Get the index of the storyfolder that's selected.
+        guard let index = (results.firstIndex { item -> Bool in
+            item["uuid"] == uuid
+        }) else { return }
+
+        // Normally we want to select the preceding item.
+        var newIndex = index - 1
+        // However, if that would be a negative index, we want to select the
+        // following item.
+        newIndex = (newIndex < 0) ? 1 : newIndex
+
+        currentStoryFolderID = results[newIndex]["uuid"]!
+    }
+
+    /// Delete the specified StoryFolder. This removes the entity from core data
+    /// as well as the underlying directory.
+    ///
+    /// - Parameter uuid: The UUID of the folder.
+    ///
+    func deleteStoryFolder(uuid: UUID) {
+        guard let storyFolder = getStoryFolderByID(uuid: uuid) else {
+            LogError(message: "Unable to delete story folder.")
+            return
+        }
+
+        guard let url = folderManager.urlFromBookmark(bookmark: storyFolder.bookmark) else {
+            return
+        }
+
+        // If the story folder is the current folder, choose a different folder and select it.
+        selectStoryOtherThan(uuid: storyFolder.uuid)
+
+        // Remove the underlying directory
         if !folderManager.deleteFolder(at: url) {
             // TODO: For now emit change even if not successful. We'll wire up
             // proper error handling later.
             LogError(message: "Unable to delete the folder at \(url)")
         }
 
-        // There should always be at least one folder.
-        createDefaultStoryFolderIfNeeded()
+        // Clean up core data.
+        let objID = storyFolder.objectID
+        CoreDataManager.shared.performOnWriteContext { [weak self] context in
+            let folder = context.object(with: objID) as! StoryFolder
+            context.delete(folder)
 
-        // Update the current story folder if it was the one deleted.
-        if url == currentStoryFolder, let folder = listStoryFolders().first {
-            currentStoryFolder = folder
+            CoreDataManager.shared.saveContext(context: context)
+
+            DispatchQueue.main.async {
+                self?.createDefaultStoryFolderIfNeeded()
+            }
+        }
+    }
+
+    /// Returns an array of StoryFolder instances for the current site.
+    /// - Returns: An array of StoryFolder instances.
+    ///
+    func getStoryFolders() -> [StoryFolder] {
+        guard let siteID = currentSiteID else {
+            LogError(message: "Attempted to fetch story folders without a current site.")
+            return [StoryFolder]()
         }
 
-        emitChange()
+        let context = CoreDataManager.shared.mainContext
+        let fetchRequest = StoryFolder.defaultFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "site.uuid = %@", siteID as CVarArg)
+        fetchRequest.sortDescriptors = currentSortDescriptors()
+
+        if let results = try? context.fetch(fetchRequest) {
+            return results
+        }
+
+        return [StoryFolder]()
+    }
+
+    func currentSortDescriptors() -> [NSSortDescriptor] {
+        return [NSSortDescriptor(key: "date", ascending: false)]
+    }
+
+    /// Get the number of story folders for the current site.
+    ///
+    /// - Returns: The number of folders.
+    ///
+    func getStoryFolderCount() -> Int {
+        guard let siteID = currentSiteID else {
+            return 0
+        }
+
+        let context = CoreDataManager.shared.mainContext
+        let fetchRequest = StoryFolder.defaultFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "site.uuid = %@", siteID as CVarArg)
+
+        if let count = try? context.count(for: fetchRequest) {
+            return count
+        }
+
+        return 0
     }
 
     func listStoryFolders() -> [URL] {
         return folderManager.enumerateFolders(url: folderManager.currentFolder)
     }
 
-    func selectStoryFolder(folder: URL) {
-        guard folderManager.currentFolderContains(folder) else {
+    func getStoryFolderByID(uuid: UUID) -> StoryFolder? {
+        let fetchRequest = StoryFolder.defaultFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "uuid == %@", uuid as CVarArg)
+        let context = CoreDataManager.shared.mainContext
+        do {
+            let results = try context.fetch(fetchRequest)
+            return results.first
+        } catch {
+            let error = error as NSError
+            LogError(message: error.localizedDescription)
+        }
+        return nil
+    }
+
+    /// Set the specified story folder as the selected folder.
+    ///
+    /// - Parameter uuid: The uuid of the story folder.
+    ///
+    func selectStoryFolder(uuid: UUID) {
+        guard let storyFolder = getStoryFolderByID(uuid: uuid) else {
+            LogError(message: "Unable to select story folder.")
             return
         }
+        selectStoryFolder(folder: storyFolder)
+    }
 
-        currentStoryFolder = folder
+    /// Set the specified story folder as the selected folder.
+    ///
+    /// - Parameter uuid: The story folder.
+    ///
+    func selectStoryFolder(folder: StoryFolder) {
+        currentStoryFolderID = folder.uuid
         emitChange()
     }
 

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hEm-rr-Shu">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -71,7 +71,6 @@
                             </tableViewCell>
                         </prototypes>
                         <connections>
-                            <outlet property="dataSource" destination="o5i-8K-DIP" id="oaT-da-M5T"/>
                             <outlet property="delegate" destination="o5i-8K-DIP" id="arm-xD-IwK"/>
                         </connections>
                     </tableView>

--- a/Newspack/Newspack/System/SessionManager.swift
+++ b/Newspack/Newspack/System/SessionManager.swift
@@ -134,6 +134,7 @@ class SessionManager: StatefulStore<SessionState> {
 
     func handleAccountRemoved() {
         if currentSite?.isDeleted == true || currentSite?.account == nil {
+            folderManager.resetCurrentFolder()
             state = .pending
             let store = AccountStore()
             initialize(site: store.getAccounts().first?.sites.first)


### PR DESCRIPTION
Refs #58 
The changes here are getting rather large so I'm breaking this PR into two parts.  This part will focus on the changes to add a core data layer to the Story Folders list.  The next part will focus on reconciling file system changes with what's in core data.

In this PR we're:
- Cleaning up the site folder when a user logs out.
- Refactoring the FolderStore and the FolderViewController to do its work via core data rather than dealing with file URLs directly. This effectively adds a core data layer to wrap file operations. 
- Implements an NSFetchedResultsController and a UITableViewDiffableDataSource for managing the list of folders.

Test these changes with a clean install. 

To test:
- Run unit tests, ensure everything passes. 

Scenario 1:
- Log in.  
- Check the files app to confirm you have a folder for your site.  
- Log out. 
- Check the files app and confirm that the folder was removed.

Scenario 2:
- Log in.
- View the list of story folders.
- Confirm you can create new folders.
- Confirm you can rename folders.
- Confirm you can delete folders. 
- Confirm that changes are animated.
- Tap the disclosure icon to view a detail (ignore what's in the detail view for now).
- Tap back and confirm that the site is marked as selected.
- Tap back to the menu and back to the folder list. 
- Confirm the site is still selected.

@jleandroperez game to review some fun new API in this PR? 