### PR TITLE
Issues/data fixes and new datasource

### DIFF
--- a/Newspack/Newspack/Controllers/PostListViewController.swift
+++ b/Newspack/Newspack/Controllers/PostListViewController.swift
@@ -12,24 +12,14 @@ import WordPressUI
 class PostListViewController: UITableViewController {
 
     let cellIdentifier = "PostCellIdentifier"
-    let sortField = "postID"
+    var dataSource: PostListDataSource!
 
     // PostItemStore receipt.
     var postItemReceipt: Receipt?
 
-    lazy var resultsController: NSFetchedResultsController<PostItem> = {
-        let fetchRequest = PostItem.defaultFetchRequest()
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: sortField, ascending: false)]
-        return NSFetchedResultsController(fetchRequest: fetchRequest,
-                                          managedObjectContext: CoreDataManager.shared.mainContext,
-                                          sectionNameKeyPath: nil,
-                                          cacheName: nil)
-    }()
-
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 
-        resultsController.delegate = self
         postItemReceipt = StoreContainer.shared.postItemStore.onStateChange({ [weak self] state in
             self?.handlePostItemStoreStateChanged(oldState: state.0, newState: state.1)
         })
@@ -40,29 +30,21 @@ class PostListViewController: UITableViewController {
 
         refreshControl = UIRefreshControl()
         refreshControl?.addTarget(self, action: #selector(handleRefreshControl), for: .valueChanged)
+
+        configureDataSource()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        configureResultsController()
         syncIfNeeded()
     }
 
-    func configureResultsController() {
-        if let postQuery = StoreContainer.shared.postItemStore.currentQuery {
-            resultsController.fetchRequest.predicate = NSPredicate(format: "%@ in postQueries", postQuery)
-        }
-        try? resultsController.performFetch()
-
-        tableView.reloadData()
-    }
-
     @IBAction func handleCreatePostButtonTapped() {
-        guard let site = StoreContainer.shared.postItemStore.currentQuery?.site else {
+        guard let uuid = StoreContainer.shared.postItemStore.currentSiteID else {
             return
         }
-        let coordinator = EditCoordinator(postItem: nil, dispatcher: SessionManager.shared.sessionDispatcher, siteID: site.uuid)
+        let coordinator = EditCoordinator(postItem: nil, dispatcher: SessionManager.shared.sessionDispatcher, siteID: uuid)
         let controller = MainStoryboard.instantiateViewController(withIdentifier: .editor) as! EditorViewController
         controller.coordinator = coordinator
         navigationController?.pushViewController(controller, animated: true)
@@ -91,46 +73,39 @@ extension PostListViewController {
             refreshControl?.endRefreshing()
 
         } else if oldState == .changingCurrentQuery {
-            configureResultsController()
+            dataSource.configureResultsController()
         }
     }
 }
 
-// MARK: - Table view data source
+// MARK: - Table view delegate methods
 extension PostListViewController {
 
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        // #warning Incomplete implementation, return the number of sections
-        return 1
-    }
-
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of rows
-        return resultsController.fetchedObjects?.count ?? 0
-    }
-
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        let listItem = resultsController.object(at: indexPath)
+        let listItem = dataSource.object(at: indexPath)
         let dispatcher = SessionManager.shared.sessionDispatcher
         dispatcher.dispatch(PostAction.syncPost(postID: listItem.postID))
 
-        let count = resultsController.fetchedObjects?.count ?? 0
+        let count = dataSource.count()
         if count > 0 && indexPath.row > (count - 5)  {
             dispatcher.dispatch(PostAction.syncNextPage)
         }
     }
 
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
-
-        configureCell(cell, atIndexPath: indexPath)
-
-        return cell
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let listItem = dataSource.object(at: indexPath)
+        let coordinator = EditCoordinator.init(postItem: listItem, dispatcher: SessionManager.shared.sessionDispatcher, siteID: listItem.siteUUID)
+        let controller = MainStoryboard.instantiateViewController(withIdentifier: .editor) as! EditorViewController
+        controller.coordinator = coordinator
+        navigationController?.pushViewController(controller, animated: true)
     }
+}
 
-    func configureCell(_ cell: UITableViewCell, atIndexPath indexPath: IndexPath) {
-        let listItem = resultsController.object(at: indexPath)
+// MARK: - Datasource related
+extension PostListViewController {
 
+    func cellFor(tableView: UITableView, indexPath: IndexPath, listItem: PostItem) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
         cell.accessoryView = nil
         cell.accessoryType = .disclosureIndicator
 
@@ -142,64 +117,105 @@ extension PostListViewController {
         } else {
             cell.textLabel?.text = ""
         }
+
+        return cell
     }
 
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let listItem = resultsController.object(at: indexPath)
-        let coordinator = EditCoordinator.init(postItem: listItem, dispatcher: SessionManager.shared.sessionDispatcher, siteID: listItem.site.uuid)
-        let controller = MainStoryboard.instantiateViewController(withIdentifier: .editor) as! EditorViewController
-        controller.coordinator = coordinator
-        navigationController?.pushViewController(controller, animated: true)
+    func configureDataSource() {
+        dataSource = PostListDataSource(tableView: tableView, cellProvider: { [weak self] (tableView, indexPath, listItem) -> UITableViewCell? in
+            return self?.cellFor(tableView: tableView, indexPath: indexPath, listItem: listItem)
+        })
+        dataSource.update()
     }
+
 }
 
-// MARK: - NSFetchedResultsController Methods
-extension PostListViewController: NSFetchedResultsControllerDelegate {
+// MARK: - PostListDataSource
+class PostListDataSource: UITableViewDiffableDataSource<PostListDataSource.Section, PostItem> {
 
-    func controllerWillChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        tableView.beginUpdates()
+    enum Section: CaseIterable {
+        case main
     }
 
-    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange sectionInfo: NSFetchedResultsSectionInfo, atSectionIndex sectionIndex: Int, for type: NSFetchedResultsChangeType) {
-        switch type {
-        case .insert:
-            tableView.insertSections(IndexSet.init(integer: sectionIndex), with: .automatic)
-        case .delete:
-            tableView.deleteSections(IndexSet.init(integer: sectionIndex), with: .automatic)
-        default:
-            break;
+    var updatedItems = [PostItem]()
+
+    // A results controller instance used to fetch StoryFolders.
+    // The StoryFolderDataSource is its delegate so it can call update whenever
+    // the results controller's content is changed.
+    lazy var resultsController: NSFetchedResultsController<PostItem> = {
+        let sortField = "postID"
+        let fetchRequest = PostItem.defaultFetchRequest()
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: sortField, ascending: false)]
+        return NSFetchedResultsController(fetchRequest: fetchRequest,
+                                          managedObjectContext: CoreDataManager.shared.mainContext,
+                                          sectionNameKeyPath: nil,
+                                          cacheName: nil)
+    }()
+
+    // Hang on to a reference to the tableView. We'll use it to know when to
+    // animate changes.
+    weak var tableView: UITableView?
+
+    override init(tableView: UITableView, cellProvider: @escaping UITableViewDiffableDataSource<PostListDataSource.Section, PostItem>.CellProvider) {
+        self.tableView = tableView
+        super.init(tableView: tableView, cellProvider: cellProvider)
+
+        resultsController.delegate = self
+
+        configureResultsController()
+
+        try? resultsController.performFetch()
+    }
+
+    func configureResultsController() {
+        if let postQuery = StoreContainer.shared.postItemStore.currentQuery {
+            resultsController.fetchRequest.predicate = NSPredicate(format: "%@ in postQueries", postQuery)
         }
     }
 
+    /// Updates the current datasource snapshot. Changes are animated only if
+    /// the tableView has a window (and is presumed visible).
+    ///
+    func update() {
+        guard let items = resultsController.fetchedObjects else {
+            return
+        }
+        var snapshot = NSDiffableDataSourceSnapshot<PostListDataSource.Section, PostItem>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(items)
+
+        if updatedItems.count > 0 {
+            snapshot.reloadItems(updatedItems)
+        }
+        updatedItems.removeAll()
+
+        let shouldAnimate = tableView?.window != nil
+        apply(snapshot, animatingDifferences: shouldAnimate, completion: nil)
+    }
+
+    func count() -> Int {
+        return resultsController.fetchedObjects?.count ?? 0
+    }
+
+    func object(at indexPath: IndexPath) -> PostItem {
+        return resultsController.object(at: indexPath)
+    }
+}
+
+// MARK: - Fetched Results Controller Delegate methods
+extension PostListDataSource: NSFetchedResultsControllerDelegate {
+
     func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
-        // Seriously, Apple?
-        // https://developer.apple.com/library/archive/releasenotes/iPhone/NSFetchedResultsChangeMoveReportedAsNSFetchedResultsChangeUpdate/index.html
-        //
-        let fixedType: NSFetchedResultsChangeType = {
-            guard type == .update && newIndexPath != nil && newIndexPath != indexPath else {
-                return type
+
+        if type == .update {
+            if let item = anObject as? PostItem {
+                updatedItems.append(item)
             }
-            return .move
-        }()
-
-        let animation = UITableView.RowAnimation.none
-
-        switch fixedType {
-        case .insert:
-            tableView.insertRows(at: [newIndexPath!], with: animation)
-        case .delete:
-            tableView.deleteRows(at: [indexPath!], with: animation)
-        case .move:
-            tableView.deleteRows(at: [indexPath!], with: animation)
-            tableView.insertRows(at: [newIndexPath!], with: animation)
-        case .update:
-            tableView.reloadRows(at: [indexPath!], with: animation)
-        @unknown default:
-            LogWarn(message: "Unhandled NSFetchedResultsChangeType")
         }
     }
 
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        tableView.endUpdates()
-    }
+        update()
+   }
+
 }

--- a/Newspack/Newspack/Controllers/PostListViewController.swift
+++ b/Newspack/Newspack/Controllers/PostListViewController.swift
@@ -11,6 +11,7 @@ import WordPressUI
 ///
 class PostListViewController: UITableViewController {
 
+    let syncNextThreshold = 5
     let cellIdentifier = "PostCellIdentifier"
     var dataSource: PostListDataSource!
 
@@ -87,7 +88,7 @@ extension PostListViewController {
         dispatcher.dispatch(PostAction.syncPost(postID: listItem.postID))
 
         let count = dataSource.count()
-        if count > 0 && indexPath.row > (count - 5)  {
+        if count > 0 && indexPath.row > (count - syncNextThreshold)  {
             dispatcher.dispatch(PostAction.syncNextPage)
         }
     }

--- a/Newspack/Newspack/Controllers/PostListViewController.swift
+++ b/Newspack/Newspack/Controllers/PostListViewController.swift
@@ -223,7 +223,7 @@ extension PostListDataSource: NSFetchedResultsControllerDelegate {
     func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
 
         if type == .update {
-            if let item = anObject as? PostItem {
+            if let item = anObject as? PostItem, !updatedItems.contains(item) {
                 updatedItems.append(item)
             }
         }

--- a/Newspack/Newspack/Controllers/PostListViewController.swift
+++ b/Newspack/Newspack/Controllers/PostListViewController.swift
@@ -88,7 +88,7 @@ extension PostListViewController {
         dispatcher.dispatch(PostAction.syncPost(postID: listItem.postID))
 
         let count = dataSource.count()
-        if count > 0 && indexPath.row > (count - syncNextThreshold)  {
+        if count > 0 && indexPath.row > (count - syncNextThreshold) {
             dispatcher.dispatch(PostAction.syncNextPage)
         }
     }

--- a/Newspack/Newspack/Controllers/PostListViewController.swift
+++ b/Newspack/Newspack/Controllers/PostListViewController.swift
@@ -95,7 +95,7 @@ extension PostListViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let listItem = dataSource.object(at: indexPath)
-        let coordinator = EditCoordinator.init(postItem: listItem, dispatcher: SessionManager.shared.sessionDispatcher, siteID: listItem.siteUUID)
+        let coordinator = EditCoordinator(postItem: listItem, dispatcher: SessionManager.shared.sessionDispatcher, siteID: listItem.siteUUID)
         let controller = MainStoryboard.instantiateViewController(withIdentifier: .editor) as! EditorViewController
         controller.coordinator = coordinator
         navigationController?.pushViewController(controller, animated: true)
@@ -138,9 +138,9 @@ class PostListDataSource: UITableViewDiffableDataSource<PostListDataSource.Secti
         case main
     }
 
-    var updating = false
-    var needsUpdate = false
-    var updatedItems = [PostItem]()
+    private var updating = false
+    private var needsUpdate = false
+    private var updatedItems = [PostItem]()
 
     // A results controller instance used to fetch StoryFolders.
     // The StoryFolderDataSource is its delegate so it can call update whenever

--- a/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
+++ b/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
@@ -277,24 +277,24 @@
         <relationship name="site" maxCount="1" deletionRule="Nullify" destinationEntity="Site" inverseName="users" inverseEntity="Site"/>
     </entity>
     <elements>
-        <element name="Account" positionX="-1478.8671875" positionY="-295.10546875" width="128" height="103"/>
-        <element name="AccountCapabilities" positionX="-1215.9921875" positionY="-44.7890625" width="128" height="88"/>
-        <element name="AccountDetails" positionX="-1479.90625" positionY="-91.0390625" width="128" height="268"/>
-        <element name="Media" positionX="-1314" positionY="-189" width="128" height="523"/>
-        <element name="MediaCache" positionX="-1359" positionY="-234" width="128" height="103"/>
-        <element name="MediaItem" positionX="-1359" positionY="-234" width="128" height="193"/>
-        <element name="MediaQuery" positionX="-1350" positionY="-225" width="128" height="148"/>
-        <element name="Page" positionX="-1323" positionY="-198" width="128" height="465"/>
-        <element name="Post" positionX="-1359" positionY="-234" width="128" height="538"/>
-        <element name="PostItem" positionX="-1350" positionY="-234" width="128" height="178"/>
-        <element name="PostQuery" positionX="-1341" positionY="-225" width="128" height="148"/>
-        <element name="Revision" positionX="-1350" positionY="-225" width="128" height="270"/>
-        <element name="Site" positionX="-1215.6171875" positionY="-384.84765625" width="128" height="448"/>
-        <element name="StagedEdits" positionX="-1341" positionY="-234" width="128" height="118"/>
-        <element name="StagedMedia" positionX="-1359" positionY="-234" width="128" height="208"/>
-        <element name="Status" positionX="-1359" positionY="-234" width="128" height="165"/>
-        <element name="StoryAsset" positionX="-1350" positionY="-225" width="128" height="103"/>
-        <element name="StoryFolder" positionX="-1359" positionY="-234" width="128" height="163"/>
-        <element name="User" positionX="-1305" positionY="-180" width="128" height="163"/>
+        <element name="Account" positionX="-1570.83203125" positionY="-505.7578125" width="128" height="103"/>
+        <element name="AccountCapabilities" positionX="-1073.984375" positionY="-661.828125" width="128" height="88"/>
+        <element name="AccountDetails" positionX="-1759.9765625" positionY="-686.81640625" width="128" height="268"/>
+        <element name="Media" positionX="-1954.6953125" positionY="-781.09765625" width="128" height="523"/>
+        <element name="MediaCache" positionX="-1759.8671875" positionY="-391.15625" width="128" height="103"/>
+        <element name="MediaItem" positionX="-2139.03125" positionY="-297.9921875" width="128" height="193"/>
+        <element name="MediaQuery" positionX="-2145.46875" positionY="-40.94140625" width="128" height="148"/>
+        <element name="Page" positionX="-925.3203125" positionY="-977.1171875" width="128" height="465"/>
+        <element name="Post" positionX="-476.9921875" positionY="-838.31640625" width="128" height="538"/>
+        <element name="PostItem" positionX="-651.76171875" positionY="-463.09375" width="128" height="178"/>
+        <element name="PostQuery" positionX="-873.41015625" positionY="-480.81640625" width="128" height="148"/>
+        <element name="Revision" positionX="-478.33203125" positionY="-266.12890625" width="128" height="270"/>
+        <element name="Site" positionX="-1345.60546875" positionY="-448.2890625" width="128" height="448"/>
+        <element name="StagedEdits" positionX="-868.6484375" positionY="-275.66015625" width="128" height="118"/>
+        <element name="StagedMedia" positionX="-2097.73828125" positionY="129.59765625" width="128" height="208"/>
+        <element name="Status" positionX="-1600.76953125" positionY="-2.2265625" width="128" height="165"/>
+        <element name="StoryAsset" positionX="-1702.796875" positionY="382.8671875" width="128" height="103"/>
+        <element name="StoryFolder" positionX="-1515.86328125" positionY="210.171875" width="128" height="163"/>
+        <element name="User" positionX="-976.9921875" positionY="-127.2734375" width="128" height="163"/>
     </elements>
 </model>

--- a/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
+++ b/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
@@ -142,6 +142,7 @@
         <attribute name="pingStatus" attributeType="String"/>
         <attribute name="postID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="revisionCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteUUID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="slug" attributeType="String"/>
         <attribute name="status" attributeType="String"/>
         <attribute name="sticky" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
@@ -152,17 +153,16 @@
         <attribute name="type" attributeType="String"/>
         <relationship name="item" maxCount="1" deletionRule="Nullify" destinationEntity="PostItem" inverseName="post" inverseEntity="PostItem"/>
         <relationship name="revisions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Revision" inverseName="post" inverseEntity="Revision"/>
-        <relationship name="site" maxCount="1" deletionRule="Nullify" destinationEntity="Site" inverseName="posts" inverseEntity="Site"/>
     </entity>
     <entity name="PostItem" representedClassName="PostItem" syncable="YES">
         <attribute name="dateGMT" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="modifiedGMT" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="postID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="revisionCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteUUID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="syncing" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <relationship name="post" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Post" inverseName="item" inverseEntity="Post"/>
         <relationship name="postQueries" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PostQuery" inverseName="items" inverseEntity="PostQuery"/>
-        <relationship name="site" maxCount="1" deletionRule="Nullify" destinationEntity="Site" inverseName="postItems" inverseEntity="Site"/>
         <relationship name="stagedEdits" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="StagedEdits" inverseName="postItem" inverseEntity="StagedEdits"/>
     </entity>
     <entity name="PostQuery" representedClassName="PostQuery" syncable="YES">
@@ -214,9 +214,7 @@
         <relationship name="mediaItems" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MediaItem" inverseName="site" inverseEntity="MediaItem"/>
         <relationship name="mediaQueries" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MediaQuery" inverseName="site" inverseEntity="MediaQuery"/>
         <relationship name="pages" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Page" inverseName="site" inverseEntity="Page"/>
-        <relationship name="postItems" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PostItem" inverseName="site" inverseEntity="PostItem"/>
         <relationship name="postQueries" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PostQuery" inverseName="site" inverseEntity="PostQuery"/>
-        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Post" inverseName="site" inverseEntity="Post"/>
         <relationship name="stagedMedia" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="StagedMedia" inverseName="site" inverseEntity="StagedMedia"/>
         <relationship name="statuses" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Status" inverseName="site" inverseEntity="Status"/>
         <relationship name="storyFolders" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="StoryFolder" inverseName="site" inverseEntity="StoryFolder"/>
@@ -291,7 +289,7 @@
         <element name="PostItem" positionX="-1350" positionY="-234" width="128" height="178"/>
         <element name="PostQuery" positionX="-1341" positionY="-225" width="128" height="148"/>
         <element name="Revision" positionX="-1350" positionY="-225" width="128" height="270"/>
-        <element name="Site" positionX="-1215.6171875" positionY="-384.84765625" width="128" height="478"/>
+        <element name="Site" positionX="-1215.6171875" positionY="-384.84765625" width="128" height="448"/>
         <element name="StagedEdits" positionX="-1341" positionY="-234" width="128" height="118"/>
         <element name="StagedMedia" positionX="-1359" positionY="-234" width="128" height="208"/>
         <element name="Status" positionX="-1359" positionY="-234" width="128" height="165"/>

--- a/Newspack/Newspack/Models/Post+CoreDataProperties.swift
+++ b/Newspack/Newspack/Models/Post+CoreDataProperties.swift
@@ -30,6 +30,7 @@ extension Post {
     @NSManaged public var pingStatus: String!
     @NSManaged public var postID: Int64
     @NSManaged public var revisionCount: Int16
+    @NSManaged public var siteUUID: UUID!
     @NSManaged public var slug: String!
     @NSManaged public var status: String!
     @NSManaged public var sticky: Bool
@@ -40,7 +41,6 @@ extension Post {
     @NSManaged public var type: String!
 
     @NSManaged public var revisions: Set<Revision>?
-    @NSManaged public var site: Site!
     @NSManaged public var item: PostItem!
 
 }

--- a/Newspack/Newspack/Models/PostItem+CoreDataProperties.swift
+++ b/Newspack/Newspack/Models/PostItem+CoreDataProperties.swift
@@ -12,10 +12,10 @@ extension PostItem {
     @NSManaged public var dateGMT: Date!
     @NSManaged public var modifiedGMT: Date!
     @NSManaged public var revisionCount: Int16
+    @NSManaged public var siteUUID: UUID!
     @NSManaged public var syncing: Bool
 
     @NSManaged public var post: Post!
-    @NSManaged public var site: Site!
     @NSManaged public var postQueries: Set<PostQuery>!
     @NSManaged public var stagedEdits: StagedEdits?
 

--- a/Newspack/Newspack/Models/Site+CoreDataProperties.swift
+++ b/Newspack/Newspack/Models/Site+CoreDataProperties.swift
@@ -109,23 +109,6 @@ extension Site {
 
 }
 
-// MARK: Generated accessors for postItems
-extension Site {
-
-    @objc(addPostItemsObject:)
-    @NSManaged public func addToPostItems(_ value: PostItem)
-
-    @objc(removePostItemsObject:)
-    @NSManaged public func removeFromPostItems(_ value: PostItem)
-
-    @objc(addPostItems:)
-    @NSManaged public func addToPostItems(_ values: Set<PostItem>)
-
-    @objc(removePostItems:)
-    @NSManaged public func removeFromPostItems(_ values: Set<PostItem>)
-
-}
-
 // MARK: Generated accessors for postQueries
 extension Site {
 
@@ -140,23 +123,6 @@ extension Site {
 
     @objc(removePostQueries:)
     @NSManaged public func removeFromPostQueries(_ values: Set<PostQuery>)
-
-}
-
-// MARK: Generated accessors for posts
-extension Site {
-
-    @objc(addPostsObject:)
-    @NSManaged public func addToPosts(_ value: Post)
-
-    @objc(removePostsObject:)
-    @NSManaged public func removeFromPosts(_ value: Post)
-
-    @objc(addPosts:)
-    @NSManaged public func addToPosts(_ values: Set<Post>)
-
-    @objc(removePosts:)
-    @NSManaged public func removeFromPosts(_ values: Set<Post>)
 
 }
 

--- a/Newspack/Newspack/Stores/EditCoordinator.swift
+++ b/Newspack/Newspack/Stores/EditCoordinator.swift
@@ -319,7 +319,7 @@ extension EditCoordinator {
             let postStore = StoreContainer.shared.postStore
             let post = Post(context: context)
             postStore.updatePost(post, with: remotePost)
-            post.site = query.site
+            post.siteUUID = self.currentSiteID
 
             let postItem = PostItem(context: context)
             postItem.postID = post.postID
@@ -329,7 +329,7 @@ extension EditCoordinator {
 
             postItem.stagedEdits = stagedEdits
             postItem.post = post
-            postItem.site = query.site
+            postItem.siteUUID = self.currentSiteID
             postItem.addToPostQueries(query)
 
             CoreDataManager.shared.saveContext(context: context)

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -129,7 +129,7 @@ extension FolderStore {
         LogDebug(message: "Success: \(url.path)")
 
         // Create the core data proxy for the story folder.
-        CoreDataManager.shared.performBackgroundTask { [weak self] context in
+        CoreDataManager.shared.performOnWriteContext { [weak self] context in
             let site = context.object(with: siteObjID) as! Site
             let folderManager = SessionManager.shared.folderManager
 

--- a/Newspack/Newspack/Stores/MediaItemStore.swift
+++ b/Newspack/Newspack/Stores/MediaItemStore.swift
@@ -278,12 +278,12 @@ extension MediaItemStore {
 
         let objID = query.objectID
         CoreDataManager.shared.performOnWriteContext { (context) in
-            let query = context.object(with: objID) as! MediaQuery
             defer {
                 DispatchQueue.main.async {
                     self.state = .ready
 
                     if let page = self.queue.popLast() {
+                        let query = context.object(with: objID) as! MediaQuery
                         self.syncItemsForQuery(query: query, page: page)
                     } else {
                         self.cleanupAfterSync()
@@ -291,11 +291,11 @@ extension MediaItemStore {
                 }
             }
 
+            let query = context.object(with: objID) as! MediaQuery
             guard !action.isError() else {
                 // TODO: Inspect and handle error.
                 // For now assume we're out of pages.
 
-                let query = context.object(with: objID) as! MediaQuery
                 query.hasMore = action.hasMore
                 CoreDataManager.shared.saveContext(context: context)
 

--- a/Newspack/Newspack/Stores/PostItemStore.swift
+++ b/Newspack/Newspack/Stores/PostItemStore.swift
@@ -310,7 +310,7 @@ extension PostItemStore {
 
                 let item: PostItem
                 let fetchRequest = PostItem.defaultFetchRequest()
-                fetchRequest.predicate = NSPredicate(format: "%@ IN postQueries AND postID = %ld",query, remotePostID.postID)
+                fetchRequest.predicate = NSPredicate(format: "%@ IN postQueries AND postID = %ld", query, remotePostID.postID)
 
                 do {
                     item = try context.fetch(fetchRequest).first ?? PostItem(context: context)
@@ -321,7 +321,7 @@ extension PostItemStore {
                 }
 
                 self.updatePostItem(item, with: remotePostID)
-                item.site = query.site
+                item.siteUUID = siteID
                 query.addToItems(item)
             }
             CoreDataManager.shared.saveContext(context: context)

--- a/Newspack/Newspack/Stores/PostItemStore.swift
+++ b/Newspack/Newspack/Stores/PostItemStore.swift
@@ -259,19 +259,22 @@ extension PostItemStore {
         guard
             let siteID = currentSiteID,
             let query = postQueryByFilter(filter: action.filter, siteUUID: siteID)
-            else {
-                // TODO: Handle error.
-                LogError(message: "handlePostIDsFetched: A value was unexpectedly nil.")
-                return
+        else {
+            // TODO: Handle error.
+            LogError(message: "handlePostIDsFetched: A value was unexpectedly nil.")
+            return
         }
 
-        defer {
-            state = .ready
+        // Call this as the last thing before returning, or as the last step after
+        // saving changes. Use this instead of a defer statement since the save
+        // will happen async.
+        let completionBlock = {
+            self.state = .ready
 
-            if let page = queue.popLast() {
-                syncItemsForQuery(query: query, page: page)
+            if let page = self.queue.popLast() {
+                self.syncItemsForQuery(query: query, page: page)
             } else {
-                cleanupAfterSync()
+                self.cleanupAfterSync()
             }
         }
 
@@ -285,17 +288,29 @@ extension PostItemStore {
                 CoreDataManager.shared.saveContext(context: context)
             }
             queue.removeAll()
+
+            completionBlock()
             return
         }
 
         guard let remotePostIDs = action.payload else {
             queue.removeAll()
             LogWarn(message: "handlePostIDsFetched: A value was unexpectedly nil.")
+
+            completionBlock()
             return
         }
 
+        // Get a copy so we're not reading or mutating across threads.
+        let itemsForCleanup = itemsToRemoveAfterSync
+
         let queryObjID = query.objectID
         CoreDataManager.shared.performOnWriteContext { (context) in
+            // Use this array to store postIDs that are returned by the endpoint.
+            // When we're done, we'll remove these IDs from itemsToRemoveAfterSync
+            // leaving only the IDs of posts that need cleaning up.
+            var returnedItems = [Int64]()
+
             let query = context.object(with: queryObjID) as! PostQuery
             query.hasMore = remotePostIDs.count == self.pageSize
 
@@ -304,8 +319,11 @@ extension PostItemStore {
             }
 
             for remotePostID in remotePostIDs {
-                if let idx = self.itemsToRemoveAfterSync.firstIndex(of: remotePostID.postID) {
-                    self.itemsToRemoveAfterSync.remove(at: idx)
+                // See if we have a match, if add it to our list of returned items
+                // that need to be removed from the list of items that need to be
+                // cleaned up.
+                if itemsForCleanup.contains(remotePostID.postID) {
+                    returnedItems.append(remotePostID.postID)
                 }
 
                 let item: PostItem
@@ -325,6 +343,12 @@ extension PostItemStore {
                 query.addToItems(item)
             }
             CoreDataManager.shared.saveContext(context: context)
+
+            DispatchQueue.main.async {
+                // Update the itemsToRemoveAfterSync. This should be thrad safe now.
+                self.itemsToRemoveAfterSync = Array(Set(self.itemsToRemoveAfterSync).subtracting(returnedItems))
+                completionBlock()
+            }
         }
 
     }

--- a/Newspack/Newspack/Stores/PostStore.swift
+++ b/Newspack/Newspack/Stores/PostStore.swift
@@ -79,7 +79,7 @@ extension PostStore {
 
         let context = CoreDataManager.shared.mainContext
         let fetchRequest = PostItem.defaultFetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "postID = %ld AND site.uuid = %@", postID, siteID as CVarArg)
+        fetchRequest.predicate = NSPredicate(format: "postID = %ld AND siteUUID = %@", postID, siteID as CVarArg)
         do {
             return try context.fetch(fetchRequest).first
         } catch {
@@ -151,7 +151,7 @@ extension PostStore {
             let listItem = context.object(with: listItemObjID) as! PostItem
 
             let fetchRequest = Post.defaultFetchRequest()
-            fetchRequest.predicate = NSPredicate(format: "site = %@ AND postID = %ld", site, remotePost.postID)
+            fetchRequest.predicate = NSPredicate(format: "siteUUID = %@ AND postID = %ld", site.uuid as CVarArg, remotePost.postID)
 
             let post: Post
             do {
@@ -163,7 +163,7 @@ extension PostStore {
             }
 
             self.updatePost(post, with: remotePost)
-            post.site = site
+            post.siteUUID = site.uuid
             post.item = listItem
 
             CoreDataManager.shared.saveContext(context: context)

--- a/Newspack/Newspack/System/CoreDataManager.swift
+++ b/Newspack/Newspack/System/CoreDataManager.swift
@@ -31,18 +31,6 @@ class CoreDataManager {
         return container.viewContext
     }
 
-    /// A convenience method for performing work in the supplied block on a
-    /// background thread.
-    ///
-    /// Parameters:
-    /// - block: An anonymous block executed on a background thread.
-    ///
-    public func performBackgroundTask(_ block: @escaping (NSManagedObjectContext) -> Void) {
-        container.performBackgroundTask { context in
-            block(context)
-        }
-    }
-
     /// A convenience method for performing work on a persistent write context.  Useful when multiple
     /// units of work need to happen in order on a single background queue.
     ///
@@ -66,13 +54,6 @@ class CoreDataManager {
         writeContext.performAndWait { [unowned writeContext] in
             block(writeContext)
         }
-    }
-
-    /// Returns an NSManagedObjectContext that is a child of the NSPersistentContainer's
-    /// private context--a sibling of the public mainContext.
-    ///
-    public func newPrivateContext() -> NSManagedObjectContext {
-        return container.newBackgroundContext()
     }
 
     /// Saves the passed NSManagedObjectContext if it has changes.

--- a/Newspack/NewspackTests/CoreData/CoreDataManagerTests.swift
+++ b/Newspack/NewspackTests/CoreData/CoreDataManagerTests.swift
@@ -14,28 +14,6 @@ class CoreDataManagerTests: BaseTest {
         XCTAssertTrue(type == NSInMemoryStoreType)
     }
 
-    // Check that the context is a private sibling of the public main context.
-    //
-    func testPrivateContextIsSiblingOfMainContext() {
-        let context = CoreDataManager.shared.newPrivateContext()
-
-        XCTAssertTrue(context.parent == CoreDataManager.shared.mainContext.parent)
-        XCTAssertTrue(context.concurrencyType == .privateQueueConcurrencyType)
-    }
-
-    // Check that blocks are ran on a background thread.
-    //
-    func testPerformBackgroundTaskIsRanInBackground() {
-        let expectation = XCTestExpectation(description: "Check if background thread")
-
-        CoreDataManager.shared.performBackgroundTask { _ in
-            XCTAssertFalse(Thread.isMainThread)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 5.0)
-    }
-
     // Check that blocks are ran on a background thread.
     //
     func testPerformOnWriteContextIsRanInBackground() {

--- a/Newspack/NewspackTests/Stores/PostStoreTests.swift
+++ b/Newspack/NewspackTests/Stores/PostStoreTests.swift
@@ -54,7 +54,7 @@ class PostStoreTests: BaseTest {
 
         let remoteItem = RemotePostID(dict: response)
         let postItem = PostItem(context: context)
-        postItem.site = site!
+        postItem.siteUUID = site?.uuid!
         postItem.addToPostQueries(itemStore!.currentQuery!)
         itemStore!.updatePostItem(postItem, with: remoteItem)
         CoreDataManager.shared.saveContext(context: context)
@@ -76,7 +76,7 @@ class PostStoreTests: BaseTest {
         //
         let remoteItem = RemotePostID(dict: response)
         let postItem = PostItem(context: context)
-        postItem.site = site!
+        postItem.siteUUID = site!.uuid!
         postItem.addToPostQueries(itemStore!.currentQuery!)
         itemStore!.updatePostItem(postItem, with: remoteItem)
         CoreDataManager.shared.saveContext(context: context)


### PR DESCRIPTION
This is a multipurpose PR. It introduces a `UITableViewDiffableDataSource` to back the post list. It also addresses an annoying core data merge error that seems to be related to a complex entity relationship pattern that (according to [the docs](https://developer.apple.com/documentation/coredata/nsmergeconflict)) created a conflict between the persistent store layer, and the external store (database) layer. The issue seems to be present in `develop`, but was exacerbated by the introduction of the `UITableViewDiffableDataSource`. (It would crash 3/5 times). 

You should be able to confirm the merge error by logging out, then logging in and attempting to rapidly scroll the post list so that its loading the next page of post items while still loading individual rows. It might take a number of tries to get it to trigger (I didn't know it was there 😬 but could eventually reproduce it in develop). 

The crash is addressed by removing the site relationship on `PostItem` and `Post` and replacing it with the site's UUID.

To test: 
- Bonus: Confirm the crash in the `develop` branch.
- Switch to this branch.  Confirm tests pass.
- Launch the app and view the post list. 
- Confirm the post list loads as expected. 
- Rapidly scroll the list a lot. 
- Confirm new rows load as expected and there is no crash. 
- Confirm scrolling is reasonably snappy. 
- Repeat the post list test a few times after logging out and back in.  Confirm there is no crash.

@jleandroperez would you mind taking a peek at this one? 
