### PR TITLE
Issues/58 folder data reconciliation final

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		E63EECDB23428A0900669FFC /* UserApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63EECDA23428A0900669FFC /* UserApiService.swift */; };
 		E63F3F3C236350BE00DB760E /* MediaTypeDiscerner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63F3F3B236350BE00DB760E /* MediaTypeDiscerner.swift */; };
 		E63FF0E824AA4ECD0002A32F /* Reconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63FF0E724AA4ECD0002A32F /* Reconciler.swift */; };
+		E63FF0EC24AA864C0002A32F /* URL+FileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63FF0EB24AA864C0002A32F /* URL+FileReference.swift */; };
 		E640D27823883ED800887FD9 /* StagedMediaImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E640D27723883ED800887FD9 /* StagedMediaImporter.swift */; };
 		E640D27A23883EE700887FD9 /* StagedMediaUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E640D27923883EE700887FD9 /* StagedMediaUploader.swift */; };
 		E641A66122A71A83008BBD85 /* SiteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E641A66022A71A83008BBD85 /* SiteStore.swift */; };
@@ -319,6 +320,7 @@
 		E63EECDA23428A0900669FFC /* UserApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserApiService.swift; sourceTree = "<group>"; };
 		E63F3F3B236350BE00DB760E /* MediaTypeDiscerner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeDiscerner.swift; sourceTree = "<group>"; };
 		E63FF0E724AA4ECD0002A32F /* Reconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reconciler.swift; sourceTree = "<group>"; };
+		E63FF0EB24AA864C0002A32F /* URL+FileReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+FileReference.swift"; sourceTree = "<group>"; };
 		E640D27723883ED800887FD9 /* StagedMediaImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedMediaImporter.swift; sourceTree = "<group>"; };
 		E640D27923883EE700887FD9 /* StagedMediaUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedMediaUploader.swift; sourceTree = "<group>"; };
 		E641A66022A71A83008BBD85 /* SiteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStore.swift; sourceTree = "<group>"; };
@@ -931,6 +933,7 @@
 				E68A965F2460990B00BE664B /* NSManagedObject+Helpers.swift */,
 				E68A965D246098C700BE664B /* NSObject+Helpers.swift */,
 				E696340F2440C1C400D906E0 /* UITableViewCell+Helpers.swift */,
+				E63FF0EB24AA864C0002A32F /* URL+FileReference.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1330,6 +1333,7 @@
 				E623C6F62220516600F9865C /* ApiCredentials.swift in Sources */,
 				E66CCA1A2303527D00F1CA59 /* Post+CoreDataClass.swift in Sources */,
 				E61AE63C2237373E00E6A489 /* StoreContainer.swift in Sources */,
+				E63FF0EC24AA864C0002A32F /* URL+FileReference.swift in Sources */,
 				E602E68722C15ED700795CBA /* RemotePost.swift in Sources */,
 				E66CCA082303527C00F1CA59 /* PostItem+CoreDataProperties.swift in Sources */,
 				E602E68B22C1632C00795CBA /* UserApiActions.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		E6B4034D22D8E12500A0DDCA /* remote-posts-ids-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */; };
 		E6B4034E22D8E12500A0DDCA /* remote-posts-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */; };
 		E6B8CFDB24AB91430068C6BE /* URLFileReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDA24AB91430068C6BE /* URLFileReferenceTests.swift */; };
+		E6B8CFDD24ABC48C0068C6BE /* FolderStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDC24ABC48C0068C6BE /* FolderStoreTests.swift */; };
 		E6BA1322243F9D1E00635A8A /* AssetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */; };
 		E6CE56AF22B19001004895E5 /* ModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CE56AE22B19001004895E5 /* ModelFactory.swift */; };
 		E6D44DEC234BC56C00B51438 /* MediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEB234BC56C00B51438 /* MediaViewController.swift */; };
@@ -410,6 +411,7 @@
 		E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-ids-edit.json"; sourceTree = "<group>"; };
 		E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-edit.json"; sourceTree = "<group>"; };
 		E6B8CFDA24AB91430068C6BE /* URLFileReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLFileReferenceTests.swift; sourceTree = "<group>"; };
+		E6B8CFDC24ABC48C0068C6BE /* FolderStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderStoreTests.swift; sourceTree = "<group>"; };
 		E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsViewController.swift; sourceTree = "<group>"; };
 		E6CE56AE22B19001004895E5 /* ModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFactory.swift; sourceTree = "<group>"; };
 		E6D44DEB234BC56C00B51438 /* MediaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewController.swift; sourceTree = "<group>"; };
@@ -835,6 +837,7 @@
 				E62C7C682235E73F000FEB33 /* AccountStoreTests.swift */,
 				E607385E22A9A5DB00504EA4 /* AccountCapabilitiesStoreTests.swift */,
 				E607386022A9A5EF00504EA4 /* AccountDetailsStoreTests.swift */,
+				E6B8CFDC24ABC48C0068C6BE /* FolderStoreTests.swift */,
 				E65875A523A811A400185C75 /* MediaStoreTests.swift */,
 				E65875A723A811F100185C75 /* MediaItemStoreTests.swift */,
 				E64D9FBA23D667760075A60E /* PostStoreTests.swift */,
@@ -1396,6 +1399,7 @@
 				E607385D22A9A5C300504EA4 /* SiteStoreTests.swift in Sources */,
 				E6B8CFDB24AB91430068C6BE /* URLFileReferenceTests.swift in Sources */,
 				E6051DEF23075F8A005AAF0B /* DateTests.swift in Sources */,
+				E6B8CFDD24ABC48C0068C6BE /* FolderStoreTests.swift in Sources */,
 				E65875AC23A813EA00185C75 /* StagedMediaStoreTests.swift in Sources */,
 				E61FC605229F2F10009E1748 /* SiteServiceRemoteTests.swift in Sources */,
 				E65875A623A811A400185C75 /* MediaStoreTests.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		E63EECD9234289F700669FFC /* SiteApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63EECD8234289F700669FFC /* SiteApiService.swift */; };
 		E63EECDB23428A0900669FFC /* UserApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63EECDA23428A0900669FFC /* UserApiService.swift */; };
 		E63F3F3C236350BE00DB760E /* MediaTypeDiscerner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63F3F3B236350BE00DB760E /* MediaTypeDiscerner.swift */; };
+		E63FF0E824AA4ECD0002A32F /* Reconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63FF0E724AA4ECD0002A32F /* Reconciler.swift */; };
 		E640D27823883ED800887FD9 /* StagedMediaImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E640D27723883ED800887FD9 /* StagedMediaImporter.swift */; };
 		E640D27A23883EE700887FD9 /* StagedMediaUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E640D27923883EE700887FD9 /* StagedMediaUploader.swift */; };
 		E641A66122A71A83008BBD85 /* SiteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E641A66022A71A83008BBD85 /* SiteStore.swift */; };
@@ -317,6 +318,7 @@
 		E63EECD8234289F700669FFC /* SiteApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteApiService.swift; sourceTree = "<group>"; };
 		E63EECDA23428A0900669FFC /* UserApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserApiService.swift; sourceTree = "<group>"; };
 		E63F3F3B236350BE00DB760E /* MediaTypeDiscerner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTypeDiscerner.swift; sourceTree = "<group>"; };
+		E63FF0E724AA4ECD0002A32F /* Reconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reconciler.swift; sourceTree = "<group>"; };
 		E640D27723883ED800887FD9 /* StagedMediaImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedMediaImporter.swift; sourceTree = "<group>"; };
 		E640D27923883EE700887FD9 /* StagedMediaUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedMediaUploader.swift; sourceTree = "<group>"; };
 		E641A66022A71A83008BBD85 /* SiteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStore.swift; sourceTree = "<group>"; };
@@ -620,6 +622,7 @@
 				E67339A5232EFEA3007C5E45 /* Logging.swift */,
 				E68BA80B2347BAA300AB60F9 /* Environment.swift */,
 				E605418E2369E1920078D978 /* Diagnostics.swift */,
+				E63FF0E724AA4ECD0002A32F /* Reconciler.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -1290,6 +1293,7 @@
 				E66CCA182303527D00F1CA59 /* Page+CoreDataClass.swift in Sources */,
 				E66CCA142303527D00F1CA59 /* AccountDetails+CoreDataProperties.swift in Sources */,
 				E602E68322C15EC100795CBA /* RemoteUser.swift in Sources */,
+				E63FF0E824AA4ECD0002A32F /* Reconciler.swift in Sources */,
 				E695A7E8244FD686007B29BB /* StoryFolder+CoreDataClass.swift in Sources */,
 				E6871F1B22C3FDE7008D3D46 /* PostListViewController.swift in Sources */,
 				E632F9A123515116003737BF /* SiteMediaDataSource.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		E6B4034E22D8E12500A0DDCA /* remote-posts-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */; };
 		E6B8CFDB24AB91430068C6BE /* URLFileReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDA24AB91430068C6BE /* URLFileReferenceTests.swift */; };
 		E6B8CFDD24ABC48C0068C6BE /* FolderStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDC24ABC48C0068C6BE /* FolderStoreTests.swift */; };
+		E6B8CFE024ABD6EB0068C6BE /* ReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */; };
 		E6BA1322243F9D1E00635A8A /* AssetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */; };
 		E6CE56AF22B19001004895E5 /* ModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CE56AE22B19001004895E5 /* ModelFactory.swift */; };
 		E6D44DEC234BC56C00B51438 /* MediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEB234BC56C00B51438 /* MediaViewController.swift */; };
@@ -412,6 +413,7 @@
 		E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-edit.json"; sourceTree = "<group>"; };
 		E6B8CFDA24AB91430068C6BE /* URLFileReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLFileReferenceTests.swift; sourceTree = "<group>"; };
 		E6B8CFDC24ABC48C0068C6BE /* FolderStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderStoreTests.swift; sourceTree = "<group>"; };
+		E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcilerTests.swift; sourceTree = "<group>"; };
 		E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsViewController.swift; sourceTree = "<group>"; };
 		E6CE56AE22B19001004895E5 /* ModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFactory.swift; sourceTree = "<group>"; };
 		E6D44DEB234BC56C00B51438 /* MediaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewController.swift; sourceTree = "<group>"; };
@@ -604,15 +606,16 @@
 		E6138FE82211FE88004E5B91 /* NewspackTests */ = {
 			isa = PBXGroup;
 			children = (
-				E6DF5576242E722B007DDC47 /* Folders */,
 				E61FC60A229F330A009E1748 /* TestData */,
 				E61FC607229F3280009E1748 /* TestTools */,
 				E66E8A122235ABB300E8DD88 /* Base */,
+				E61FC601229F2E96009E1748 /* Api */,
 				E66E8A03223596B400E8DD88 /* CoreData */,
 				E6051DED23075F60005AAF0B /* Extensions */,
-				E61FC601229F2E96009E1748 /* Api */,
-				E62C7C672235E729000FEB33 /* Stores */,
+				E6DF5576242E722B007DDC47 /* Folders */,
 				E62C7C6A2235F042000FEB33 /* Services */,
+				E62C7C672235E729000FEB33 /* Stores */,
+				E6B8CFDE24ABD6B20068C6BE /* SystemTests */,
 				E6138FEB2211FE88004E5B91 /* Info.plist */,
 			);
 			path = NewspackTests;
@@ -911,6 +914,14 @@
 				E6710A1622CE9F040036156E /* FadeTransitionController.swift */,
 			);
 			path = Transitions;
+			sourceTree = "<group>";
+		};
+		E6B8CFDE24ABD6B20068C6BE /* SystemTests */ = {
+			isa = PBXGroup;
+			children = (
+				E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */,
+			);
+			path = SystemTests;
 			sourceTree = "<group>";
 		};
 		E6DF5573242E7115007DDC47 /* Folders */ = {
@@ -1392,6 +1403,7 @@
 				E65875AA23A8139500185C75 /* StagedMediaImporterTests.swift in Sources */,
 				E66E8A072235979500E8DD88 /* BaseTest.swift in Sources */,
 				E6DF5578242E7242007DDC47 /* FolderManagerTests.swift in Sources */,
+				E6B8CFE024ABD6EB0068C6BE /* ReconcilerTests.swift in Sources */,
 				E64D9FBD23D667D80075A60E /* PostItemStoreTests.swift in Sources */,
 				E607385F22A9A5DB00504EA4 /* AccountCapabilitiesStoreTests.swift in Sources */,
 				E61A28CF22D53EFD003E214F /* PostServiceRemoteTests.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		E6AC98B823CCD5DE00E95381 /* MainNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AC98B723CCD5DE00E95381 /* MainNavController.swift */; };
 		E6B4034D22D8E12500A0DDCA /* remote-posts-ids-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */; };
 		E6B4034E22D8E12500A0DDCA /* remote-posts-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */; };
+		E6B8CFDB24AB91430068C6BE /* URLFileReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDA24AB91430068C6BE /* URLFileReferenceTests.swift */; };
 		E6BA1322243F9D1E00635A8A /* AssetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */; };
 		E6CE56AF22B19001004895E5 /* ModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CE56AE22B19001004895E5 /* ModelFactory.swift */; };
 		E6D44DEC234BC56C00B51438 /* MediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEB234BC56C00B51438 /* MediaViewController.swift */; };
@@ -408,6 +409,7 @@
 		E6AC98B723CCD5DE00E95381 /* MainNavController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavController.swift; sourceTree = "<group>"; };
 		E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-ids-edit.json"; sourceTree = "<group>"; };
 		E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-edit.json"; sourceTree = "<group>"; };
+		E6B8CFDA24AB91430068C6BE /* URLFileReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLFileReferenceTests.swift; sourceTree = "<group>"; };
 		E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsViewController.swift; sourceTree = "<group>"; };
 		E6CE56AE22B19001004895E5 /* ModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFactory.swift; sourceTree = "<group>"; };
 		E6D44DEB234BC56C00B51438 /* MediaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewController.swift; sourceTree = "<group>"; };
@@ -539,6 +541,7 @@
 			children = (
 				E6051DEE23075F8A005AAF0B /* DateTests.swift */,
 				E6051DF023076191005AAF0B /* DictionaryMergeTests.swift */,
+				E6B8CFDA24AB91430068C6BE /* URLFileReferenceTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1391,6 +1394,7 @@
 				E61A28CF22D53EFD003E214F /* PostServiceRemoteTests.swift in Sources */,
 				E61FC603229F2EEE009E1748 /* UserServiceRemoteTests.swift in Sources */,
 				E607385D22A9A5C300504EA4 /* SiteStoreTests.swift in Sources */,
+				E6B8CFDB24AB91430068C6BE /* URLFileReferenceTests.swift in Sources */,
 				E6051DEF23075F8A005AAF0B /* DateTests.swift in Sources */,
 				E65875AC23A813EA00185C75 /* StagedMediaStoreTests.swift in Sources */,
 				E61FC605229F2F10009E1748 /* SiteServiceRemoteTests.swift in Sources */,

--- a/Newspack/Newspack/Extensions/URL+FileReference.swift
+++ b/Newspack/Newspack/Extensions/URL+FileReference.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension URL {
+    /// This is a work around to an issue where Swift URL instances will not
+    /// return a fileReferenceURL. See the thread (and answer) at:
+    /// https://bugs.swift.org/browse/SR-2728?focusedCommentId=22388&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22388
+    ///
+    /// - Returns: An NSURL or nil if self is not a file URL.
+    ///
+    func getFileReferenceURL() -> NSURL? {
+        return (self as NSURL).perform(#selector(NSURL.fileReferenceURL))?.takeUnretainedValue() as? NSURL
+    }
+}

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -287,14 +287,14 @@ class FolderManager {
 
     /// Check if a folder at one url contains the item at anoter url.
     /// - Parameters:
-    ///   - parent: A file URL to the parent folder.
-    ///   - child: A file URL to the child item.
-    /// - Returns: true if the parent folder contains the child, otherwise false.
+    ///   - folder: A file URL to the folder.
+    ///   - descendent: A file URL to the descendent item.
+    /// - Returns: true if the folder contains the descendent, otherwise false.
     ///
-    func folder(_ parent: URL, contains child: URL) -> Bool {
+    func folder(_ folder: URL, contains descendent: URL) -> Bool {
         let relation = UnsafeMutablePointer<FileManager.URLRelationship>.allocate(capacity: 1)
         do {
-            try fileManager.getRelationship(relation, ofDirectoryAt: parent, toItemAt: child)
+            try fileManager.getRelationship(relation, ofDirectoryAt: folder, toItemAt: descendent)
         } catch {
             LogError(message: "Error checking folder relationships. \(error)")
             return false
@@ -304,11 +304,11 @@ class FolderManager {
 
     /// A convenience method to see if the current folder contains the item
     /// specified by the supplied file URL.
-    /// - Parameter child: A file URL to a child item.
+    /// - Parameter descendent: A file URL to a child item.
     /// - Returns: true if the current folder contains the child, otherwise false.
     ///
-    func currentFolderContains(_ child: URL) -> Bool {
-        return folder(currentFolder, contains: child)
+    func currentFolderContains(_ descendent: URL) -> Bool {
+        return folder(currentFolder, contains: descendent)
     }
 
     /// Check if one folder is the immediate parent of another folder.

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -311,6 +311,24 @@ class FolderManager {
         return folder(currentFolder, contains: child)
     }
 
+    /// Check if one folder is the immediate parent of another folder.
+    ///
+    /// - Parameters:
+    ///   - parent: A file URL to the parent folder.
+    ///   - child: A file URL to the child folder.
+    /// - Returns: true if there is a parent/child relationship.
+    ///
+    func folder(_ folder: URL, isParentOf child: URL) -> Bool {
+        let parent = child.deletingLastPathComponent()
+        guard
+            let folderRef = folder.getFileReferenceURL(),
+            let parentRef = parent.getFileReferenceURL()
+        else {
+            return false
+        }
+        return folderRef.isEqual(parentRef)
+    }
+
     /// Converts a file URL to bookkmark data.
     ///
     /// - Parameter url: A file URL.

--- a/Newspack/Newspack/Models/Site+CoreDataProperties.swift
+++ b/Newspack/Newspack/Models/Site+CoreDataProperties.swift
@@ -34,9 +34,9 @@ extension Site {
     @NSManaged public var postItems: Set<PostItem>!
     @NSManaged public var postQueries: Set<PostQuery>!
     @NSManaged public var posts: Set<Post>!
-    @NSManaged public var stagedMedia: Set<Status>!
+    @NSManaged public var stagedMedia: Set<StagedMedia>!
     @NSManaged public var statuses: Set<Status>!
-    @NSManaged public var storyFolders: Set<Status>!
+    @NSManaged public var storyFolders: Set<StoryFolder>!
     @NSManaged public var users: Set<User>!
 
 }

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -113,8 +113,8 @@ extension FolderStore {
     ///   - addSuffix: Whether to add a numeric suffix to the folder name if there
     /// is already a folder with that name.
     ///
-    func createStoryFolder(path: String = Constants.defaultStoryFolderName, addSuffix: Bool = false) {
-        createStoryFoldersForPaths(paths: [path], addSuffix: addSuffix)
+    func createStoryFolder(path: String = Constants.defaultStoryFolderName, addSuffix: Bool = false, onComplete:(()-> Void)? = nil) {
+        createStoryFoldersForPaths(paths: [path], addSuffix: addSuffix, onComplete: onComplete)
     }
 
     /// Create new StoryFolders for each of the specified folder names.
@@ -125,7 +125,7 @@ extension FolderStore {
     ///   - addSuffix: Whether to add a numeric suffix to the folder name if there
     /// is already a folder with that name.
     ///
-    func createStoryFoldersForPaths(paths: [String], addSuffix: Bool = false) {
+    func createStoryFoldersForPaths(paths: [String], addSuffix: Bool = false, onComplete:(()-> Void)? = nil) {
         var urls = [URL]()
         for path in paths {
             guard let url = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: addSuffix) else {
@@ -136,13 +136,13 @@ extension FolderStore {
             urls.append(url)
         }
 
-        createStoryFoldersForURLs(urls: urls)
+        createStoryFoldersForURLs(urls: urls, onComplete: onComplete)
     }
 
     /// Create new story folders for each of the specified URLs.
     /// - Parameter urls: An array of file URLs
     ///
-    func createStoryFoldersForURLs(urls: [URL]) {
+    func createStoryFoldersForURLs(urls: [URL], onComplete:(()-> Void)? = nil) {
         guard
             let siteID = currentSiteID,
             let siteObjID = StoreContainer.shared.siteStore.getSiteByUUID(siteID)?.objectID
@@ -169,6 +169,7 @@ extension FolderStore {
 
             DispatchQueue.main.async {
                 self?.selectDefaultStoryFolderIfNeeded()
+                onComplete?()
             }
         }
     }
@@ -276,7 +277,7 @@ extension FolderStore {
     ///
     /// - Parameter folders: An array of StoryFolders
     ///
-    func deleteStoryFolders(folders: [StoryFolder]) {
+    func deleteStoryFolders(folders: [StoryFolder], onComplete:(()->Void)? = nil) {
         // For each story folder, remove its bookmarked content and then delete.
 
         let uuids: [UUID] = folders.map { (folder) -> UUID in
@@ -311,6 +312,7 @@ extension FolderStore {
 
             DispatchQueue.main.async {
                 self?.createDefaultStoryFolderIfNeeded()
+                onComplete?()
             }
         }
     }
@@ -359,10 +361,6 @@ extension FolderStore {
         }
 
         return 0
-    }
-
-    func listStoryFolders() -> [URL] {
-        return folderManager.enumerateFolders(url: folderManager.currentFolder)
     }
 
     func getStoryFolderByID(uuid: UUID) -> StoryFolder? {

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -114,31 +114,56 @@ extension FolderStore {
     /// is already a folder with that name.
     ///
     func createStoryFolder(path: String = Constants.defaultStoryFolderName, addSuffix: Bool = false) {
+        createStoryFoldersForPaths(paths: [path], addSuffix: addSuffix)
+    }
+
+    /// Create new StoryFolders for each of the specified folder names.
+    /// - Parameters:
+    ///   - paths: An array of folder name and (optionally) a path to the story folder.
+    ///   If a path, only the last path component will be used for the StoryFolder
+    ///   name in core data.
+    ///   - addSuffix: Whether to add a numeric suffix to the folder name if there
+    /// is already a folder with that name.
+    ///
+    func createStoryFoldersForPaths(paths: [String], addSuffix: Bool = false) {
+        var urls = [URL]()
+        for path in paths {
+            guard let url = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: addSuffix) else {
+                LogError(message: "Unable to create the folder at \(path)")
+                continue
+            }
+            LogDebug(message: "Success: \(url.path)")
+            urls.append(url)
+        }
+
+        createStoryFoldersForURLs(urls: urls)
+    }
+
+    /// Create new story folders for each of the specified URLs.
+    /// - Parameter urls: An array of file URLs
+    ///
+    func createStoryFoldersForURLs(urls: [URL]) {
         guard
             let siteID = currentSiteID,
             let siteObjID = StoreContainer.shared.siteStore.getSiteByUUID(siteID)?.objectID
         else {
-            LogError(message: "Attempted to create story folder, but no site was found,")
+            LogError(message: "Attempted to create story folders, but no site was found,")
             return
         }
-
-        guard let url = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: addSuffix) else {
-            LogError(message: "Unable to create the folder at \(path)")
-            return
-        }
-        LogDebug(message: "Success: \(url.path)")
 
         // Create the core data proxy for the story folder.
         CoreDataManager.shared.performOnWriteContext { [weak self] context in
             let site = context.object(with: siteObjID) as! Site
             let folderManager = SessionManager.shared.folderManager
 
-            let storyFolder = StoryFolder(context: context)
-            storyFolder.uuid = UUID()
-            storyFolder.date = Date()
-            storyFolder.name = url.pathComponents.last
-            storyFolder.site = site
-            storyFolder.bookmark = folderManager.bookmarkForURL(url: url)
+            for url in urls {
+                let storyFolder = StoryFolder(context: context)
+                storyFolder.uuid = UUID()
+                storyFolder.date = Date()
+                storyFolder.name = url.pathComponents.last
+                storyFolder.site = site
+                storyFolder.bookmark = folderManager.bookmarkForURL(url: url)
+            }
 
             CoreDataManager.shared.saveContext(context: context)
 
@@ -147,7 +172,6 @@ extension FolderStore {
             }
         }
     }
-
 
     /// Rename a story folder. This updates the name of the story folder's underlying
     /// directory as well as the name field in core data.
@@ -186,20 +210,26 @@ extension FolderStore {
 
     /// Ensure the selected story folder is any folder other than the one listed.
     ///
-    /// - Parameter uuid: The uuid of the story folder we do not want selected.
+    /// - Parameter uuids: The uuids of the story folders we do not want selected.
     ///
-    func selectStoryOtherThan(uuid: UUID) {
+    func selectStoryOtherThan(uuids: [UUID]) {
         // If this isn't the currently selected folder then there is nothing to do.
         guard
-            currentStoryFolderID == uuid,
+            uuids.contains(currentStoryFolderID),
             let siteID = currentSiteID
         else {
             return
         }
 
+        // Make an array of uuids without the currently selected one and use this
+        // to filter results from our fetch request.
+        let uuidsToExclude = uuids.filter { (uuid) -> Bool in
+            return uuid != currentStoryFolderID
+        }
+
         let context = CoreDataManager.shared.mainContext
         let fetchRequest: NSFetchRequest<NSFetchRequestResult> = StoryFolder.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "site.uuid = %@", siteID as CVarArg)
+        fetchRequest.predicate = NSPredicate(format: "site.uuid = %@ AND NOT (uuid IN %@)", siteID as CVarArg, uuidsToExclude)
         fetchRequest.sortDescriptors = currentSortDescriptors()
         fetchRequest.propertiesToFetch = ["uuid"]
         fetchRequest.resultType = .dictionaryResultType
@@ -216,7 +246,7 @@ extension FolderStore {
 
         // Get the index of the storyfolder that's selected.
         guard let index = (results.firstIndex { item -> Bool in
-            item["uuid"] == uuid
+            item["uuid"] == currentStoryFolderID
         }) else { return }
 
         // Normally we want to select the preceding item.
@@ -239,26 +269,44 @@ extension FolderStore {
             return
         }
 
-        guard let url = folderManager.urlFromBookmark(bookmark: storyFolder.bookmark) else {
-            return
+        deleteStoryFolders(folders: [storyFolder])
+    }
+
+    /// Delete each of the specified story folders.
+    ///
+    /// - Parameter folders: An array of StoryFolders
+    ///
+    func deleteStoryFolders(folders: [StoryFolder]) {
+        // For each story folder, remove its bookmarked content and then delete.
+
+        let uuids: [UUID] = folders.map { (folder) -> UUID in
+            return folder.uuid
         }
 
         // If the story folder is the current folder, choose a different folder and select it.
-        selectStoryOtherThan(uuid: storyFolder.uuid)
+        selectStoryOtherThan(uuids: uuids)
 
-        // Remove the underlying directory
-        if !folderManager.deleteFolder(at: url) {
-            // TODO: For now emit change even if not successful. We'll wire up
-            // proper error handling later.
-            LogError(message: "Unable to delete the folder at \(url)")
+        var objIDs = [NSManagedObjectID]()
+        for folder in folders {
+            objIDs.append(folder.objectID)
+
+            guard let url = folderManager.urlFromBookmark(bookmark: folder.bookmark) else {
+                continue
+            }
+
+            // Remove the underlying directory
+            if !folderManager.deleteFolder(at: url) {
+                // TODO: For now emit change even if not successful. We'll wire up
+                // proper error handling later.
+                LogError(message: "Unable to delete the folder at \(url)")
+            }
         }
 
-        // Clean up core data.
-        let objID = storyFolder.objectID
         CoreDataManager.shared.performOnWriteContext { [weak self] context in
-            let folder = context.object(with: objID) as! StoryFolder
-            context.delete(folder)
-
+            for objID in objIDs {
+                let folder = context.object(with: objID) as! StoryFolder
+                context.delete(folder)
+            }
             CoreDataManager.shared.saveContext(context: context)
 
             DispatchQueue.main.async {
@@ -268,6 +316,7 @@ extension FolderStore {
     }
 
     /// Returns an array of StoryFolder instances for the current site.
+    ///
     /// - Returns: An array of StoryFolder instances.
     ///
     func getStoryFolders() -> [StoryFolder] {

--- a/Newspack/Newspack/Stores/SiteStore.swift
+++ b/Newspack/Newspack/Stores/SiteStore.swift
@@ -169,6 +169,41 @@ extension SiteStore {
 
 extension SiteStore {
 
+    /// Check if a folder exists for the current site.
+    ///
+    /// - Returns: True if a folder exists, otherwise false.
+    ///
+    func currentSiteFolderExists() -> Bool {
+        guard let _ = currentSiteFolderURL() else {
+            return false
+        }
+        return true
+    }
+
+    /// Get the file URL for the current site's folder if it exists.
+    ///
+    /// - Returns: A file URL for the current site's folder or nil if one does
+    /// not exist.
+    ///
+    func currentSiteFolderURL() -> URL? {
+        var isStale = false
+        let folderManager = SessionManager.shared.folderManager
+        guard
+            let siteID = currentSiteID,
+            let site = getSiteByUUID(siteID),
+            let bookmarkData = site.siteFolder,
+            let url = folderManager.urlFromBookmark(bookmark: bookmarkData, bookmarkIsStale: &isStale)
+        else {
+            return nil
+        }
+
+        if isStale {
+            return nil
+        }
+
+        return url
+    }
+
     /// Get a folder name for the specified site.
     ///
     /// - Parameter site: A Site instance.

--- a/Newspack/Newspack/System/AppDelegate.swift
+++ b/Newspack/Newspack/System/AppDelegate.swift
@@ -3,6 +3,9 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    // We want a single instance of the Reconciler for the lifecycle of the app.
+    // We'll instantiate it here for convenience.
+    private let reconciler = Reconciler()
     var sessionReceipt: Any?
     var window: UIWindow?
 

--- a/Newspack/Newspack/System/Reconciler.swift
+++ b/Newspack/Newspack/System/Reconciler.swift
@@ -6,7 +6,7 @@ import UIKit
 ///
 class Reconciler {
 
-    var sessionReceipt: Any?
+    private var sessionReceipt: Any?
 
     deinit {
         NotificationCenter.default.removeObserver(self)
@@ -90,11 +90,7 @@ class Reconciler {
     func hasInconsistentStoryFolders() -> Bool {
         let (rawFolders, removedStories) = getInconsistentStoryFolders()
 
-        if rawFolders.count > 0 || removedStories.count > 0 {
-            return true
-        }
-
-        return false
+        return rawFolders.count > 0 || removedStories.count > 0
     }
 
     /// Get any inconsistencies between the file system and story folders.

--- a/Newspack/Newspack/System/Reconciler.swift
+++ b/Newspack/Newspack/System/Reconciler.swift
@@ -1,0 +1,116 @@
+import Foundation
+import UIKit
+
+/// Responsible for resolving any differences between what is currently in the
+/// file system with what is currently stored in core data.
+///
+class Reconciler {
+
+    var sessionReceipt: Any?
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    init() {
+        listenForSessionChanges()
+        listenForNotifications()
+    }
+
+    /// Tells the reconciler to check for inconsistencies between the file system
+    /// and what is stored in core data.  If any are found they will be reconciled.
+    ///
+    func process() {
+        guard hasInitializedSession() else {
+            return
+        }
+
+        guard detect() else {
+            return
+        }
+
+        reconcile()
+    }
+
+    /// Checks for inconsistencies between the file system and what is stored in
+    /// core data.
+    ///
+    /// - Returns: Returns true if any inconsistencies are found. False otherwise.
+    ///
+    func detect() -> Bool {
+        // Check site
+
+
+        // Check story folders
+
+
+        // TODO: check story folder contents
+
+
+        return false
+    }
+
+    /// Reconciles any inconsistencies between the file system and what is stored
+    /// in core data.
+    ///
+    func reconcile() {
+        // reconcile site
+        // if recreated we can bail
+
+
+        // Check story folders
+        // if any are recreated we can bail on their contents.
+
+
+        // TODO: check folder contents
+    }
+
+}
+
+
+// Notification related
+//
+extension Reconciler {
+
+    /// Listen for system notifications that would tell us we might need to
+    /// reconcile the file system and core data.
+    /// Note that .didBecomeActiveNotification is dispatched more often than
+    /// .willEnterForgroundNotification. If reconciliation is too frequent or
+    /// aggressive we can try switching notifications.
+    ///
+    func listenForNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(handleDidBecomeActive(notification:)), name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+
+    @objc
+    func handleDidBecomeActive(notification: Notification) {
+        process()
+    }
+
+}
+
+
+// Session related
+//
+extension Reconciler {
+
+    func hasInitializedSession() -> Bool {
+        let sessionState = SessionManager.shared.state
+        return sessionState == .initialized
+    }
+
+    func listenForSessionChanges() {
+        guard sessionReceipt == nil else {
+            return
+        }
+
+        sessionReceipt = SessionManager.shared.onChange {
+            self.handleSessionChange()
+        }
+    }
+
+    func handleSessionChange() {
+        process()
+    }
+
+}

--- a/Newspack/Newspack/System/Reconciler.swift
+++ b/Newspack/Newspack/System/Reconciler.swift
@@ -44,11 +44,13 @@ class Reconciler {
         // Check site
         let siteStore = StoreContainer.shared.siteStore
         if !siteStore.currentSiteFolderExists() {
+            LogDebug(message: "Folder for current site is missing.")
             return true
         }
 
         // Check story folders
         if hasInconsistentStoryFolders() {
+            LogDebug(message: "StoryFolders where missing, or new folders were found.")
             return true
         }
 
@@ -65,6 +67,7 @@ class Reconciler {
         // if recreated we can bail
         let siteStore = StoreContainer.shared.siteStore
         if !siteStore.currentSiteFolderExists() {
+            LogDebug(message: "Recreating folder for current site.")
             siteStore.createSiteFolderIfNeeded()
             return
         }
@@ -72,8 +75,9 @@ class Reconciler {
         // Get story folder inconsistencies
         let (rawFolders, removedStories) = getInconsistentStoryFolders()
         let folderStore = StoreContainer.shared.folderStore
-
+        LogDebug(message: "Creating StoryFolders for discovered folders.")
         folderStore.createStoryFoldersForURLs(urls: rawFolders)
+        LogDebug(message: "Deleting StoryFolders for missing folders.")
         folderStore.deleteStoryFolders(folders: removedStories)
 
         // TODO: check folder contents

--- a/Newspack/NewspackTests/Extensions/URLFileReferenceTests.swift
+++ b/Newspack/NewspackTests/Extensions/URLFileReferenceTests.swift
@@ -1,0 +1,74 @@
+
+import XCTest
+@testable import Newspack
+
+class URLFileReferenceTests: XCTestCase {
+
+    var folderManager: FolderManager!
+
+    override func setUpWithError() throws {
+        let tempDirectory = FolderManager.createTemporaryDirectory()
+        folderManager = FolderManager(rootFolder: tempDirectory)
+    }
+
+    func testURLFileReferenceCreated() {
+        let path = "TestFolder"
+        guard let url = folderManager.createFolderAtPath(path: path) else {
+            XCTFail("URL is expected to not be nil")
+            return
+        }
+        XCTAssertNotNil(url)
+        XCTAssertTrue(url.lastPathComponent.hasSuffix(path))
+        XCTAssertTrue(folderManager.folderExists(url: url))
+        
+        let refURL = url.getFileReferenceURL()
+        XCTAssertNotNil(refURL)
+    }
+
+    func testURLFileReferenceEquality() {
+        // Create a test target.
+        let path = "TestFolder/TestChildFolder"
+        guard let url = folderManager.createFolderAtPath(path: path) else {
+            XCTFail("URL is expected to not be nil")
+            return
+        }
+        XCTAssertNotNil(url)
+        XCTAssertTrue(folderManager.folderExists(url: url))
+
+        // Create a bunch of different URLs that point to the same destination, just in different ways.
+
+        let rootURL = folderManager.currentFolder.absoluteURL
+
+        let url1 = URL(fileURLWithPath: path, isDirectory: false, relativeTo: rootURL)
+        XCTAssertTrue(folderManager.folderExists(url: url1))
+
+        let url2 = URL(fileURLWithPath: path, isDirectory: true, relativeTo: rootURL)
+        XCTAssertTrue(folderManager.folderExists(url: url2))
+
+        let combinedPath = rootURL.path + "/" + path
+
+        let url3 = URL(fileURLWithPath: combinedPath, isDirectory: false)
+        XCTAssertTrue(folderManager.folderExists(url: url3))
+
+        let url4 = URL(fileURLWithPath: combinedPath + "/", isDirectory: true)
+        XCTAssertTrue(folderManager.folderExists(url: url4))
+
+        // None of the URLs should be equal because they have different paths and bases.
+        XCTAssertFalse(url1 == url2)
+        XCTAssertFalse(url2 == url3)
+        XCTAssertFalse(url3 == url4)
+        XCTAssertFalse(url1 == url4)
+        XCTAssertFalse(url1 == url3)
+        XCTAssertFalse(url2 == url4)
+
+        let ref1 = url.getFileReferenceURL()!
+        let ref2 = url2.getFileReferenceURL()!
+        let ref3 = url3.getFileReferenceURL()!
+        let ref4 = url4.getFileReferenceURL()!
+
+        XCTAssertTrue(ref1.isEqual(ref2))
+        XCTAssertTrue(ref2.isEqual(ref3))
+        XCTAssertTrue(ref3.isEqual(ref4))
+    }
+
+}

--- a/Newspack/NewspackTests/Extensions/URLFileReferenceTests.swift
+++ b/Newspack/NewspackTests/Extensions/URLFileReferenceTests.swift
@@ -20,7 +20,7 @@ class URLFileReferenceTests: XCTestCase {
         XCTAssertNotNil(url)
         XCTAssertTrue(url.lastPathComponent.hasSuffix(path))
         XCTAssertTrue(folderManager.folderExists(url: url))
-        
+
         let refURL = url.getFileReferenceURL()
         XCTAssertNotNil(refURL)
     }

--- a/Newspack/NewspackTests/Folders/FolderManagerTests.swift
+++ b/Newspack/NewspackTests/Folders/FolderManagerTests.swift
@@ -164,7 +164,7 @@ class FolderManagerTests: XCTestCase {
     }
 
     func testFolderContainsChild() {
-        let path = "TestFolder"
+        let path = "TestFolder/Subfolder"
         let url = folderManager.createFolderAtPath(path: path, ifExistsAppendSuffix: true)!
         let failURL = FolderManager.createTemporaryDirectory()!
 
@@ -172,6 +172,21 @@ class FolderManagerTests: XCTestCase {
         XCTAssertFalse(folderManager.folder(url, contains: url))
         XCTAssertFalse(folderManager.folder(url, contains: failURL))
         XCTAssertFalse(folderManager.folder(failURL, contains: url))
+    }
+
+    func testFolderIsParent() {
+        let childPath = "TestFolder"
+        let childURL = folderManager.createFolderAtPath(path: childPath, ifExistsAppendSuffix: true)!
+        let grandChildPath = "TestFolder/ChildFolder"
+        let grandChildURL = folderManager.createFolderAtPath(path: grandChildPath, ifExistsAppendSuffix: true)!
+        let failURL = FolderManager.createTemporaryDirectory()!
+
+        XCTAssertTrue(folderManager.folder(folderManager.currentFolder, isParentOf: childURL))
+        XCTAssertFalse(folderManager.folder(folderManager.currentFolder, isParentOf: grandChildURL))
+
+        XCTAssertFalse(folderManager.folder(childURL, isParentOf: childURL))
+        XCTAssertFalse(folderManager.folder(folderManager.currentFolder, contains: failURL))
+        XCTAssertFalse(folderManager.folder(failURL, contains: folderManager.currentFolder))
     }
 
     func testSanitizedFolderNames() {

--- a/Newspack/NewspackTests/Stores/FolderStoreTests.swift
+++ b/Newspack/NewspackTests/Stores/FolderStoreTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+import CoreData
+import WordPressFlux
+@testable import Newspack
+
+class FolderStoreTests: BaseTest {
+
+    var account: Account!
+    var site: Site!
+    var folderStore: FolderStore!
+    var siteStore: SiteStore!
+
+    override func setUp() {
+        super.setUp()
+
+        // Test account and site
+        site = ModelFactory.getTestSite(context: CoreDataManager.shared.mainContext)
+
+        account = accountStore!.createAccount(authToken: "testToken", forNetworkAt: site.url)
+        site.account = account
+
+        CoreDataManager.shared.saveContext(context: CoreDataManager.shared.mainContext)
+
+        siteStore = SiteStore(dispatcher: testDispatcher, siteID: site.uuid)
+
+        folderStore = FolderStore(dispatcher: testDispatcher, siteID: site.uuid)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        account = nil
+        site = nil
+    }
+
+    func testCreateStoryFoldersForPaths() {
+        // Create 10 story folders.
+        let paths = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta", "Iota", "Kappa"]
+
+        let expect = expectation(description: "expect")
+        folderStore.createStoryFoldersForPaths(paths: paths, onComplete: {
+            CoreDataManager.shared.mainContext.refresh(self.site, mergeChanges: true)
+            // One story folder was created by default, so account for it in the total.
+            XCTAssertTrue(self.site.storyFolders.count == 11)
+            expect.fulfill()
+        })
+
+        wait(for: [expect], timeout: 1)
+    }
+
+    func testSelectStoryOtherThan() {
+        // Create 10 story folders.
+        let paths = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta", "Iota", "Kappa"]
+
+        let expect = expectation(description: "expect")
+        folderStore.createStoryFoldersForPaths(paths: paths, onComplete: {
+            CoreDataManager.shared.mainContext.refresh(self.site, mergeChanges: true)
+            // One story folder was created by default, so account for it in the total.
+            XCTAssertTrue(self.site.storyFolders.count == 11)
+            expect.fulfill()
+        })
+
+        wait(for: [expect], timeout: 1)
+
+        let folders = folderStore.getStoryFolders()
+        let delta = folders[4]
+        folderStore.selectStoryFolder(folder: delta)
+        XCTAssertTrue(folderStore.currentStoryFolderID == delta.uuid)
+
+        // UUIDs for Gamma, Delta, Epsilon
+        let otherThanFolderUUIDs = folders[3...5].map { (folder) -> UUID in
+            return folder.uuid
+        }
+        folderStore.selectStoryOtherThan(uuids: otherThanFolderUUIDs)
+
+        let beta = folders[2]
+        XCTAssertTrue(folderStore.currentStoryFolderID == beta.uuid)
+    }
+
+    func testDeleteStoryFolders() {
+        // Create 10 story folders.
+        let paths = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta", "Iota", "Kappa"]
+
+        let expect = expectation(description: "expect")
+        folderStore.createStoryFoldersForPaths(paths: paths, onComplete: {
+            CoreDataManager.shared.mainContext.refresh(self.site, mergeChanges: true)
+            // One story folder was created by default, so account for it in the total.
+            XCTAssertTrue(self.site.storyFolders.count == 11)
+            expect.fulfill()
+        })
+
+        wait(for: [expect], timeout: 1)
+
+        let folders = folderStore.getStoryFolders()
+
+        // Get an array from an array slice
+        let foldersToDelete = Array(folders[3...5])
+
+        let expect1 = expectation(description: "expect1")
+        folderStore.deleteStoryFolders(folders: foldersToDelete, onComplete: {
+            CoreDataManager.shared.mainContext.refresh(self.site, mergeChanges: true)
+            // One story folder was created by default, so account for it in the total.
+            XCTAssertTrue(self.site.storyFolders.count == 8)
+
+            for folder in foldersToDelete {
+                XCTAssertTrue(folder.isDeleted)
+            }
+
+            expect1.fulfill()
+        })
+        wait(for: [expect1], timeout: 1)
+    }
+}

--- a/Newspack/NewspackTests/Stores/FolderStoreTests.swift
+++ b/Newspack/NewspackTests/Stores/FolderStoreTests.swift
@@ -35,7 +35,7 @@ class FolderStoreTests: BaseTest {
 
     func testCreateStoryFoldersForPaths() {
         // Create 10 story folders.
-        let paths = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta", "Iota", "Kappa"]
+        let paths = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta", "iota", "kappa"]
 
         let expect = expectation(description: "expect")
         folderStore.createStoryFoldersForPaths(paths: paths, onComplete: {
@@ -50,7 +50,7 @@ class FolderStoreTests: BaseTest {
 
     func testSelectStoryOtherThan() {
         // Create 10 story folders.
-        let paths = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta", "Iota", "Kappa"]
+        let paths = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta", "iota", "kappa"]
 
         let expect = expectation(description: "expect")
         folderStore.createStoryFoldersForPaths(paths: paths, onComplete: {
@@ -67,7 +67,7 @@ class FolderStoreTests: BaseTest {
         folderStore.selectStoryFolder(folder: delta)
         XCTAssertTrue(folderStore.currentStoryFolderID == delta.uuid)
 
-        // UUIDs for Gamma, Delta, Epsilon
+        // UUIDs for gamma, delta, epsilon
         let otherThanFolderUUIDs = folders[3...5].map { (folder) -> UUID in
             return folder.uuid
         }
@@ -79,7 +79,7 @@ class FolderStoreTests: BaseTest {
 
     func testDeleteStoryFolders() {
         // Create 10 story folders.
-        let paths = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta", "Iota", "Kappa"]
+        let paths = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta", "iota", "kappa"]
 
         let expect = expectation(description: "expect")
         folderStore.createStoryFoldersForPaths(paths: paths, onComplete: {

--- a/Newspack/NewspackTests/Stores/SiteStoreTests.swift
+++ b/Newspack/NewspackTests/Stores/SiteStoreTests.swift
@@ -236,4 +236,50 @@ class SiteStoreTests: BaseTest {
         XCTAssertTrue(name == site.uuid.uuidString)
     }
 
+    func testCurrentSiteFolderURL() {
+        let account = self.account!
+        let remoteSettings = self.remoteSettings!
+
+        let expect = expectation(description: "expect")
+        siteStore.createSites(sites: [remoteSettings], accountID: account.uuid, onComplete: {
+            guard let site = account.sites.first else {
+                XCTFail("The site can not be nil.")
+                return
+            }
+            XCTAssertEqual(site.url, self.siteURL) // NOTE: The url is defined in the mock data. The actual endpoint does not currently return this value.
+            XCTAssertEqual(site.title, remoteSettings.title)
+
+            expect.fulfill()
+        })
+
+        wait(for: [expect], timeout: 1)
+
+        let site = account.sites.first!
+        let store = SiteStore(dispatcher: .global, siteID: site.uuid)
+        XCTAssertNotNil(store.currentSiteFolderURL())
+    }
+
+    func testCurrentSiteFolderExists() {
+        let account = self.account!
+        let remoteSettings = self.remoteSettings!
+
+        let expect = expectation(description: "expect")
+        siteStore.createSites(sites: [remoteSettings], accountID: account.uuid, onComplete: {
+            guard let site = account.sites.first else {
+                XCTFail("The site can not be nil.")
+                return
+            }
+            XCTAssertEqual(site.url, self.siteURL) // NOTE: The url is defined in the mock data. The actual endpoint does not currently return this value.
+            XCTAssertEqual(site.title, remoteSettings.title)
+
+            expect.fulfill()
+        })
+
+        wait(for: [expect], timeout: 1)
+
+        let site = account.sites.first!
+        let store = SiteStore(dispatcher: .global, siteID: site.uuid)
+        XCTAssertTrue(store.currentSiteFolderExists())
+    }
+
 }

--- a/Newspack/NewspackTests/SystemTests/ReconcilerTests.swift
+++ b/Newspack/NewspackTests/SystemTests/ReconcilerTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+import CoreData
+import WordPressFlux
+@testable import Newspack
+
+class ReconcilerTests: BaseTest {
+
+    var account: Account!
+    var site: Site!
+    var folderStore: FolderStore!
+    var siteStore: SiteStore!
+
+    var epsilon: URL!
+    var zeta: URL!
+
+    override func setUp() {
+        super.setUp()
+
+        // Test account and site
+        site = ModelFactory.getTestSite(context: CoreDataManager.shared.mainContext)
+
+        account = accountStore!.createAccount(authToken: "testToken", forNetworkAt: site.url)
+        site.account = account
+
+        CoreDataManager.shared.saveContext(context: CoreDataManager.shared.mainContext)
+        StoreContainer.shared.resetStores(dispatcher: testDispatcher, site: site)
+
+        var expect = expectation(forNotification: .NSManagedObjectContextObjectsDidChange, object: CoreDataManager.shared.mainContext) { (_) -> Bool in
+            return true
+        }
+        wait(for: [expect], timeout: 1)
+
+        // Wait after initializing each store so it can handle its initial work.
+        siteStore = StoreContainer.shared.siteStore
+        folderStore = StoreContainer.shared.folderStore
+
+        // Create four more story folders.
+        expect = expectation(description: "expect")
+        let paths = ["alpha", "beta", "gamma", "delta"]
+        folderStore.createStoryFoldersForPaths(paths: paths, addSuffix: false) {
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 1)
+
+        let folderManager = SessionManager.shared.folderManager
+        // Delete folders for Gamma and Delta
+        let urls = folderManager.enumerateFolders(url: folderManager.currentFolder)
+        _ = urls.map { url in
+            if ["gamma", "delta"].contains(url.lastPathComponent) {
+                folderManager.deleteFolder(at: url)
+            }
+        }
+
+        // Create folders for epsilon and zeta
+        epsilon = folderManager.createFolderAtPath(path: "epsilon")
+        zeta = folderManager.createFolderAtPath(path: "zeta")
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        account = nil
+        site = nil
+        folderStore = nil
+        siteStore = nil
+        epsilon = nil
+        zeta = nil
+    }
+
+    func testHasInconsistencies() {
+
+        let recon = Reconciler()
+        XCTAssertTrue(recon.hasInconsistencies())
+    }
+
+    func testReconcile() {
+        // Maybe wait?
+        let startingFolders = folderStore.getStoryFolders()
+        XCTAssertTrue(startingFolders.count > 1)
+
+        let recon = Reconciler()
+        recon.reconcile()
+
+        let expect = expectation(forNotification: .NSManagedObjectContextObjectsDidChange, object: CoreDataManager.shared.mainContext) { (_) -> Bool in
+            return true
+        }
+        wait(for: [expect], timeout: 1)
+
+        let folders = folderStore.getStoryFolders()
+        // gamma and delta should no longer exist
+        let deletedFolders = folders.filter { (folder) -> Bool in
+            return ["gamma", "delta"].contains(folder.name)
+        }
+        XCTAssertTrue(deletedFolders.count == 0)
+
+        // There should be story folders for epsilon and zeta
+        let newFolders = folders.filter { (folder) -> Bool in
+            return ["epsilon", "zeta"].contains(folder.name)
+        }
+        XCTAssertTrue(newFolders.count == 2)
+    }
+
+}


### PR DESCRIPTION
Closes #58 

This is the final PR in the series of file system / core data reconciliation patches for Site and StoryFolders. Another round will follow for StoryFolder contents in the future. 

This PR introduces a Reconciler that checks for inconsistencies between the file system and core data whenever a new session is started, or when the app becomes active.  If inconsistencies are detected the Reconciler attempts to remove items from core data that no longer have counterparts in the file system, and creates new entries in core data for anything discovered in the filesystem.

To test:
- As always, make sure all unit tests pass.  The new unit tests for the Reconciler can take a moment or two.

Test Case:
- Open the app and create a bunch of StoryFolders. 
- Background the app and open the Files app. 
- Find the Newspack contents, and find the folders for the StoryFolders you created.
- Delete a few. 
- Long press to get a dialog to create a new folder. Do so, and give the new folder a name. 
- Return to Newspack and check that the list of story folders updates to reflect the file system changes. 

@jleandroperez are you game for a Newspack PR?