### PR TITLE
Story Folder Sorting

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		E6B8CFE024ABD6EB0068C6BE /* ReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */; };
 		E6BA1322243F9D1E00635A8A /* AssetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */; };
 		E6C3988C24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C3988B24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift */; };
+		E6C398BE24AD259300E0EBE6 /* SortRulesBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C398BD24AD259300E0EBE6 /* SortRulesBook.swift */; };
 		E6CE56AF22B19001004895E5 /* ModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CE56AE22B19001004895E5 /* ModelFactory.swift */; };
 		E6D44DEC234BC56C00B51438 /* MediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEB234BC56C00B51438 /* MediaViewController.swift */; };
 		E6D44DEF234BDB8400B51438 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEE234BDB8400B51438 /* MediaStore.swift */; };
@@ -417,6 +418,7 @@
 		E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcilerTests.swift; sourceTree = "<group>"; };
 		E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsViewController.swift; sourceTree = "<group>"; };
 		E6C3988B24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Newspack.swift"; sourceTree = "<group>"; };
+		E6C398BD24AD259300E0EBE6 /* SortRulesBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortRulesBook.swift; sourceTree = "<group>"; };
 		E6CE56AE22B19001004895E5 /* ModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFactory.swift; sourceTree = "<group>"; };
 		E6D44DEB234BC56C00B51438 /* MediaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewController.swift; sourceTree = "<group>"; };
 		E6D44DEE234BDB8400B51438 /* MediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStore.swift; sourceTree = "<group>"; };
@@ -832,6 +834,7 @@
 				E61D8F6B2375EC3E005FECED /* StagedMediaStore.swift */,
 				E640D27723883ED800887FD9 /* StagedMediaImporter.swift */,
 				E640D27923883EE700887FD9 /* StagedMediaUploader.swift */,
+				E6C398BD24AD259300E0EBE6 /* SortRulesBook.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -1302,6 +1305,7 @@
 				E61BBD6822FA0470008A6D4C /* StartupHelper.swift in Sources */,
 				E636C26C234FEAD800564B63 /* MediaQuery+CoreDataProperties.swift in Sources */,
 				E66CCA112303527C00F1CA59 /* AccountCapabilities+CoreDataClass.swift in Sources */,
+				E6C398BE24AD259300E0EBE6 /* SortRulesBook.swift in Sources */,
 				E66CCA152303527D00F1CA59 /* AccountCapabilities+CoreDataProperties.swift in Sources */,
 				E638804E22DFC07900B3C16A /* PostItemStore.swift in Sources */,
 				E6138FD22211FE86004E5B91 /* AppDelegate.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		E6D44DEF234BDB8400B51438 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEE234BDB8400B51438 /* MediaStore.swift */; };
 		E6D44DF1234BDBA000B51438 /* MediaApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DF0234BDBA000B51438 /* MediaApiService.swift */; };
 		E6D44DF3234BDBB500B51438 /* MediaServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DF2234BDBB500B51438 /* MediaServiceRemote.swift */; };
+		E6DCB05224AE3BF300C4FD01 /* SortRulesBookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DCB05124AE3BF300C4FD01 /* SortRulesBookTests.swift */; };
 		E6DF5575242E7139007DDC47 /* FolderManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DF5574242E7139007DDC47 /* FolderManager.swift */; };
 		E6DF5578242E7242007DDC47 /* FolderManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DF5577242E7242007DDC47 /* FolderManagerTests.swift */; };
 		E6E1834D22D6D44D009C2D0A /* remote-post-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6E1834B22D6D44C009C2D0A /* remote-post-edit.json */; };
@@ -424,6 +425,7 @@
 		E6D44DEE234BDB8400B51438 /* MediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStore.swift; sourceTree = "<group>"; };
 		E6D44DF0234BDBA000B51438 /* MediaApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaApiService.swift; sourceTree = "<group>"; };
 		E6D44DF2234BDBB500B51438 /* MediaServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaServiceRemote.swift; sourceTree = "<group>"; };
+		E6DCB05124AE3BF300C4FD01 /* SortRulesBookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortRulesBookTests.swift; sourceTree = "<group>"; };
 		E6DF5574242E7139007DDC47 /* FolderManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderManager.swift; sourceTree = "<group>"; };
 		E6DF5577242E7242007DDC47 /* FolderManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderManagerTests.swift; sourceTree = "<group>"; };
 		E6E1834B22D6D44C009C2D0A /* remote-post-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-post-edit.json"; sourceTree = "<group>"; };
@@ -620,6 +622,7 @@
 				E62C7C6A2235F042000FEB33 /* Services */,
 				E62C7C672235E729000FEB33 /* Stores */,
 				E6B8CFDE24ABD6B20068C6BE /* SystemTests */,
+				E6DCB05024AE3BBF00C4FD01 /* Utils */,
 				E6138FEB2211FE88004E5B91 /* Info.plist */,
 			);
 			path = NewspackTests;
@@ -927,6 +930,14 @@
 				E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */,
 			);
 			path = SystemTests;
+			sourceTree = "<group>";
+		};
+		E6DCB05024AE3BBF00C4FD01 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				E6DCB05124AE3BF300C4FD01 /* SortRulesBookTests.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 		E6DF5573242E7115007DDC47 /* Folders */ = {
@@ -1417,6 +1428,7 @@
 				E61A28CF22D53EFD003E214F /* PostServiceRemoteTests.swift in Sources */,
 				E61FC603229F2EEE009E1748 /* UserServiceRemoteTests.swift in Sources */,
 				E607385D22A9A5C300504EA4 /* SiteStoreTests.swift in Sources */,
+				E6DCB05224AE3BF300C4FD01 /* SortRulesBookTests.swift in Sources */,
 				E6B8CFDB24AB91430068C6BE /* URLFileReferenceTests.swift in Sources */,
 				E6051DEF23075F8A005AAF0B /* DateTests.swift in Sources */,
 				E6B8CFDD24ABC48C0068C6BE /* FolderStoreTests.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -819,17 +819,17 @@
 				E641A66422A75866008BBD85 /* AccountCapabilitiesStore.swift */,
 				E641A66222A7584A008BBD85 /* AccountDetailsStore.swift */,
 				E68B29FE23048C6C0021283C /* EditCoordinator.swift */,
+				E6A800F224380A5300A14E6C /* FolderStore.swift */,
+				E6500F992368B63800CB8C6C /* ImageStore.swift */,
 				E6FB520522B973A60010FDF8 /* PostStore.swift */,
 				E638804D22DFC07900B3C16A /* PostItemStore.swift */,
-				E641A66022A71A83008BBD85 /* SiteStore.swift */,
 				E637A6E122F0ED5D00229C1D /* RequestQueue.swift */,
+				E641A66022A71A83008BBD85 /* SiteStore.swift */,
 				E6D44DEE234BDB8400B51438 /* MediaStore.swift */,
 				E636C25F234FBACC00564B63 /* MediaItemStore.swift */,
-				E6500F992368B63800CB8C6C /* ImageStore.swift */,
 				E61D8F6B2375EC3E005FECED /* StagedMediaStore.swift */,
 				E640D27723883ED800887FD9 /* StagedMediaImporter.swift */,
 				E640D27923883EE700887FD9 /* StagedMediaUploader.swift */,
-				E6A800F224380A5300A14E6C /* FolderStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		E6B8CFDD24ABC48C0068C6BE /* FolderStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDC24ABC48C0068C6BE /* FolderStoreTests.swift */; };
 		E6B8CFE024ABD6EB0068C6BE /* ReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */; };
 		E6BA1322243F9D1E00635A8A /* AssetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */; };
+		E6C3988C24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C3988B24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift */; };
 		E6CE56AF22B19001004895E5 /* ModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CE56AE22B19001004895E5 /* ModelFactory.swift */; };
 		E6D44DEC234BC56C00B51438 /* MediaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEB234BC56C00B51438 /* MediaViewController.swift */; };
 		E6D44DEF234BDB8400B51438 /* MediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D44DEE234BDB8400B51438 /* MediaStore.swift */; };
@@ -415,6 +416,7 @@
 		E6B8CFDC24ABC48C0068C6BE /* FolderStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderStoreTests.swift; sourceTree = "<group>"; };
 		E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcilerTests.swift; sourceTree = "<group>"; };
 		E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsViewController.swift; sourceTree = "<group>"; };
+		E6C3988B24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Newspack.swift"; sourceTree = "<group>"; };
 		E6CE56AE22B19001004895E5 /* ModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFactory.swift; sourceTree = "<group>"; };
 		E6D44DEB234BC56C00B51438 /* MediaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaViewController.swift; sourceTree = "<group>"; };
 		E6D44DEE234BDB8400B51438 /* MediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaStore.swift; sourceTree = "<group>"; };
@@ -951,6 +953,7 @@
 				E68A965D246098C700BE664B /* NSObject+Helpers.swift */,
 				E696340F2440C1C400D906E0 /* UITableViewCell+Helpers.swift */,
 				E63FF0EB24AA864C0002A32F /* URL+FileReference.swift */,
+				E6C3988B24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1318,6 +1321,7 @@
 				E6871F1B22C3FDE7008D3D46 /* PostListViewController.swift in Sources */,
 				E632F9A123515116003737BF /* SiteMediaDataSource.swift in Sources */,
 				E62C7C662235E16E000FEB33 /* AccountStore.swift in Sources */,
+				E6C3988C24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift in Sources */,
 				E6E43EA4230F1D2B00A1974E /* EditAction.swift in Sources */,
 				E695A7E6244FD686007B29BB /* StoryFolder+CoreDataProperties.swift in Sources */,
 				E69E59FB22540D5000899DE2 /* ServiceRemoteCoreRest.swift in Sources */,

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -80,7 +80,14 @@ extension FoldersViewController {
         }
 
         cell.textField.text = storyFolder.name
-        cell.textChangedHandler = { text in
+        cell.textChangedHandler = { text, aCell in
+            // NOTE: Get the index path from the passed cell to ensure we're not
+            // capturing the value of cellFor's passed IndexPath. This can lead to
+            // referencing an incoreect index path leading to the wrong folder being renamed
+            // or an out of bounds error.
+            guard let indexPath = tableView.indexPath(for: aCell) else {
+                return
+            }
             self.handleFolderNameChanged(indexPath: indexPath, newName: text)
         }
         cell.accessoryType = storyFolder.uuid == StoreContainer.shared.folderStore.currentStoryFolderID ? .detailDisclosureButton : .disclosureIndicator
@@ -110,14 +117,14 @@ extension FoldersViewController {
 class FolderCell: UITableViewCell {
 
     @IBOutlet var textField: UITextField!
-    var textChangedHandler: ((String?) -> Void)?
+    var textChangedHandler: ((String?, UITableViewCell) -> Void)?
 
 }
 
 extension FolderCell: UITextFieldDelegate {
 
     func textFieldDidEndEditing(_ textField: UITextField) {
-        textChangedHandler?(textField.text)
+        textChangedHandler?(textField.text, self)
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/Newspack/Newspack/Extensions/UserDefaults+Newspack.swift
+++ b/Newspack/Newspack/Extensions/UserDefaults+Newspack.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension UserDefaults {
+
+    static let testDefaults = UserDefaults(suiteName: "NewspackTests")!
+
+    static var shared: UserDefaults {
+        return Environment.isTesting() ? testDefaults : standard
+    }
+
+}

--- a/Newspack/Newspack/Stores/Actions/FolderAction.swift
+++ b/Newspack/Newspack/Stores/Actions/FolderAction.swift
@@ -4,6 +4,7 @@ import WordPressFlux
 /// Supported Actions for changes to the FolderStore
 ///
 enum FolderAction: Action {
+    case sortBy(field: String, ascending: Bool)
     case createStoryFolder
     case createStoryFolderNamed(path: String, addSuffix: Bool)
     case renameStoryFolder(folderID: UUID, name: String)

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -261,8 +261,8 @@ extension FolderStore {
             return
         }
 
-        guard results.count > 0 else {
-            // Nothing to select.
+        guard results.count > 1 else {
+            // Nothing new to select.
             return
         }
 

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -23,7 +23,7 @@ class FolderStore: Store {
     private(set) var currentStoryFolderID = UUID()
 
     lazy private(set) var sortRules: SortRulesBook = {
-        return SortRulesBook(storageKey: "FolderStoreSortRules", fields: ["date", "name"], defaults: ["date": false])
+        return SortRulesBook(storageKey: "FolderStoreSortRules", fields: ["date", "name"], defaults: ["date": false], caseInsensitiveFields: ["name"])
     }()
 
     init(dispatcher: ActionDispatcher = .global, siteID: UUID? = nil) {

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -266,17 +266,19 @@ extension FolderStore {
             return
         }
 
-        // Get the index of the storyfolder that's selected.
-        guard let index = (results.firstIndex { item -> Bool in
+        // Default to 1 if, for some reason there is not a current selected index found.
+        var index = 0
+        if let currentSelectedIndex = (results.firstIndex { item -> Bool in
             item["uuid"] == currentStoryFolderID
-        }) else { return }
+        }) {
+            index = currentSelectedIndex
+        }
 
-        // Normally we want to select the preceding item.
-        var newIndex = index - 1
-        // However, if that would be a negative index, we want to select the
-        // following item.
-        newIndex = max(newIndex, 0)
-
+        // If the index is greater than zero we can just select the preceding item.
+        // If the index is zero it means the currently selected story is index zero.
+        // In this scenario we want the new index to be 1, so the next item in
+        // in the list is selected.
+        let newIndex = (index > 0) ? index - 1 : 1
         selectStoryFolder(uuid: results[newIndex]["uuid"]!)
     }
 

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -22,6 +22,10 @@ class FolderStore: Store {
     /// before it is used.
     private(set) var currentStoryFolderID = UUID()
 
+    lazy private(set) var sortRules: SortRulesBook = {
+        return SortRulesBook(storageKey: "FolderStoreSortRules", fields: ["date", "name"], defaults: ["date": false])
+    }()
+
     init(dispatcher: ActionDispatcher = .global, siteID: UUID? = nil) {
         currentSiteID = siteID
 
@@ -38,6 +42,8 @@ class FolderStore: Store {
     override func onDispatch(_ action: Action) {
         if let action = action as? FolderAction {
             switch action {
+            case .sortBy(let field, let ascending):
+                sortFolders(by: field, ascending: ascending)
             case .createStoryFolder:
                 // Create a story folder with the default name, appending a suffix if needed.
                 createStoryFolder(path: Constants.defaultStoryFolderName, addSuffix: true)
@@ -70,7 +76,7 @@ extension FolderStore {
 
         let fetchRequest = StoryFolder.defaultFetchRequest()
         fetchRequest.predicate = NSPredicate(format: "site.uuid = %@", siteID as CVarArg)
-        fetchRequest.sortDescriptors = currentSortDescriptors()
+        fetchRequest.sortDescriptors = sortRules.descriptors()
         return NSFetchedResultsController(fetchRequest: fetchRequest,
                                           managedObjectContext: CoreDataManager.shared.mainContext,
                                           sectionNameKeyPath: nil,
@@ -80,6 +86,21 @@ extension FolderStore {
 }
 
 extension FolderStore {
+
+    /// Update sort rules for folders and refetch data if the sort order has changed.
+    ///
+    /// - Parameters:
+    ///   - field: The field to sort by.
+    ///   - ascending: true if the sort order should be ascending, or false if descending.
+    ///
+    private func sortFolders(by field: String, ascending: Bool) {
+        guard !sortRules.hasRule(field: field, ascending: ascending) else {
+            return
+        }
+        var rules = SortRules()
+        rules[field] = ascending
+        sortRules.setRules(rules: rules)
+    }
 
     /// Creates a single, default, folder under the site's folder if there is a
     /// site, and there are currently no folders.
@@ -231,7 +252,7 @@ extension FolderStore {
         let context = CoreDataManager.shared.mainContext
         let fetchRequest: NSFetchRequest<NSFetchRequestResult> = StoryFolder.fetchRequest()
         fetchRequest.predicate = NSPredicate(format: "site.uuid = %@ AND NOT (uuid IN %@)", siteID as CVarArg, uuidsToExclude)
-        fetchRequest.sortDescriptors = currentSortDescriptors()
+        fetchRequest.sortDescriptors = sortRules.descriptors()
         fetchRequest.propertiesToFetch = ["uuid"]
         fetchRequest.resultType = .dictionaryResultType
 
@@ -330,17 +351,13 @@ extension FolderStore {
         let context = CoreDataManager.shared.mainContext
         let fetchRequest = StoryFolder.defaultFetchRequest()
         fetchRequest.predicate = NSPredicate(format: "site.uuid = %@", siteID as CVarArg)
-        fetchRequest.sortDescriptors = currentSortDescriptors()
+        fetchRequest.sortDescriptors = sortRules.descriptors()
 
         if let results = try? context.fetch(fetchRequest) {
             return results
         }
 
         return [StoryFolder]()
-    }
-
-    func currentSortDescriptors() -> [NSSortDescriptor] {
-        return [NSSortDescriptor(key: "date", ascending: false)]
     }
 
     /// Get the number of story folders for the current site.

--- a/Newspack/Newspack/Stores/SortRulesBook.swift
+++ b/Newspack/Newspack/Stores/SortRulesBook.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+typealias SortRules = [String: Bool]
+
+/// A class for wrangling list sort rules. An instance is configured with a unique
+/// storage key used to record sort rules in UserDefaults, an array of field names
+/// that may be sorted, and a default sort rule.
+/// Sort rules are serialized to UserDefaults and the list is used to
+/// generate an array of NSSortDescriptors for use with FetchRequests.
+///
+class SortRulesBook {
+
+    private let storageKey: String
+    private let fields: [String]
+    private let defaults: SortRules
+
+    /// Creates a new instance of a SortRulesManager
+    ///
+    /// - Parameters:
+    ///   - storageKey: A key to use with UserDefaults.
+    ///   - fields: A list of allowed fields to sort by.
+    ///   - defaults: Default SortRules.  This should not be empty.
+    ///
+    init(storageKey: String, fields: [String], defaults: SortRules) {
+        self.storageKey = storageKey
+        self.fields = fields
+        self.defaults = defaults
+
+        setup()
+    }
+
+    /// Responsible for priming UserDefaults if no sort rules are currently
+    /// stored there for the `key`.  Should only be called once during init.
+    ///
+    private func setup() {
+        guard UserDefaults.shared.dictionary(forKey: storageKey) == nil else {
+            return
+        }
+        reset()
+    }
+
+    /// Resets the stored SortRules to the default rules.
+    ///
+    func reset() {
+        UserDefaults.shared.set(defaults, forKey: storageKey)
+    }
+
+    /// Get a list of NSSortDescriptors derived from the current SortRules.
+    ///
+    /// - Returns: An array of NSSortDescriptors
+    ///
+    func descriptors() -> [NSSortDescriptor] {
+        let dict = rules()
+
+        var arr = [NSSortDescriptor]()
+        for (key, value) in dict {
+            arr.append(NSSortDescriptor(key: key, ascending: value))
+        }
+
+        return arr
+    }
+
+    /// Check if there is an existing rule matching the specified field and value.
+    /// - Parameters:
+    ///   - field: The field name.
+    ///   - ascending: true for ascending, flase for descending.
+    /// - Returns: True if a rule exists, otherwise false.
+    ///
+    func hasRule(field: String, ascending: Bool) -> Bool {
+        return rules().contains { element -> Bool in
+            return element.key == field && element.value == ascending
+        }
+    }
+
+    /// Creates or updates a SortRule and stores it to UserDefaults.
+    ///
+    /// - Parameters:
+    ///   - field: The name of the field to sort by. This must be one of the items in the fields array.
+    ///   - ascending: true if the sort order should be ascending, or false if it should be descending
+    ///
+    func setRule(field: String, ascending: Bool) {
+        guard fields.contains(field) else {
+            return
+        }
+
+        guard !hasRule(field: field, ascending: ascending) else {
+            return
+        }
+
+        var dict = rules()
+        dict[field] = ascending
+        UserDefaults.shared.set(dict, forKey: storageKey)
+    }
+
+    /// Sets the stored rules. Note that any keys missing from fields will be
+    /// excluded.
+    ///
+    /// - Parameter rules: A SortRules instance.
+    ///
+    func setRules(rules: SortRules) {
+        var dict = SortRules()
+        for rule in rules {
+            if fields.contains(rule.key) {
+                dict[rule.key] = rule.value
+            }
+        }
+        UserDefaults.shared.set(dict, forKey: storageKey)
+    }
+
+    /// Returns the current SortRules
+    ///
+    /// - Returns: An array of SortRules
+    ///
+    func rules() -> SortRules {
+        guard let dict = UserDefaults.shared.dictionary(forKey: storageKey) as? SortRules else {
+            return defaults
+        }
+        return dict
+    }
+
+}

--- a/Newspack/Newspack/Stores/SortRulesBook.swift
+++ b/Newspack/Newspack/Stores/SortRulesBook.swift
@@ -13,6 +13,7 @@ class SortRulesBook {
     private let storageKey: String
     private let fields: [String]
     private let defaults: SortRules
+    private let caseInsensitiveFields: [String]
 
     /// Creates a new instance of a SortRulesManager
     ///
@@ -20,11 +21,13 @@ class SortRulesBook {
     ///   - storageKey: A key to use with UserDefaults.
     ///   - fields: A list of allowed fields to sort by.
     ///   - defaults: Default SortRules.  This should not be empty.
+    ///   - caseInsensitiveFields: Optional. An array of case insensitive fields. These should only be string fields.
     ///
-    init(storageKey: String, fields: [String], defaults: SortRules) {
+    init(storageKey: String, fields: [String], defaults: SortRules, caseInsensitiveFields: [String] = []) {
         self.storageKey = storageKey
         self.fields = fields
         self.defaults = defaults
+        self.caseInsensitiveFields = caseInsensitiveFields
 
         setup()
     }
@@ -54,7 +57,11 @@ class SortRulesBook {
 
         var arr = [NSSortDescriptor]()
         for (key, value) in dict {
-            arr.append(NSSortDescriptor(key: key, ascending: value, selector: #selector(NSString.caseInsensitiveCompare)))
+            if caseInsensitiveFields.contains(key) {
+                arr.append(NSSortDescriptor(key: key, ascending: value, selector: #selector(NSString.caseInsensitiveCompare)))
+            } else {
+                arr.append(NSSortDescriptor(key: key, ascending: value))
+            }
         }
 
         return arr

--- a/Newspack/Newspack/Stores/SortRulesBook.swift
+++ b/Newspack/Newspack/Stores/SortRulesBook.swift
@@ -54,7 +54,7 @@ class SortRulesBook {
 
         var arr = [NSSortDescriptor]()
         for (key, value) in dict {
-            arr.append(NSSortDescriptor(key: key, ascending: value))
+            arr.append(NSSortDescriptor(key: key, ascending: value, selector: #selector(NSString.caseInsensitiveCompare)))
         }
 
         return arr

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hEm-rr-Shu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hEm-rr-Shu">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -30,14 +30,40 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <stackView key="tableHeaderView" opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" id="QLX-ao-DFN">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="110"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <subviews>
+                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="EkV-Vg-qa5">
+                                    <rect key="frame" x="0.0" y="0.0" width="194.5" height="111"/>
+                                    <segments>
+                                        <segment title="Date"/>
+                                        <segment title="Name"/>
+                                    </segments>
+                                    <connections>
+                                        <action selector="handleSortNameChangedWithSender:" destination="o5i-8K-DIP" eventType="valueChanged" id="zNc-rc-rGI"/>
+                                    </connections>
+                                </segmentedControl>
+                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="KoB-kO-fC0">
+                                    <rect key="frame" x="194.5" y="0.0" width="180.5" height="111"/>
+                                    <segments>
+                                        <segment title="Asc"/>
+                                        <segment title="Desc"/>
+                                    </segments>
+                                    <connections>
+                                        <action selector="handleSortDirectionChangedWithSender:" destination="o5i-8K-DIP" eventType="valueChanged" id="heq-nl-JaI"/>
+                                    </connections>
+                                </segmentedControl>
+                            </subviews>
+                        </stackView>
                         <view key="tableFooterView" contentMode="scaleToFill" id="T7a-7n-C8K">
-                            <rect key="frame" x="0.0" y="98.5" width="375" height="44"/>
+                            <rect key="frame" x="0.0" y="208.5" width="375" height="44"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         </view>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="FolderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FolderCell" id="O2R-uA-A0M" customClass="FolderCell" customModule="Newspack" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="42.5"/>
+                                <rect key="frame" x="0.0" y="138" width="375" height="42.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="O2R-uA-A0M" id="W0e-Zt-FK0">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="42.5"/>
@@ -82,6 +108,10 @@
                         </barButtonItem>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <connections>
+                        <outlet property="sortDirection" destination="KoB-kO-fC0" id="E3B-uI-NFv"/>
+                        <outlet property="sortField" destination="EkV-Vg-qa5" id="VVV-E8-jE3"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DK2-Ey-tPA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -41,7 +41,7 @@
                                         <segment title="Name"/>
                                     </segments>
                                     <connections>
-                                        <action selector="handleSortNameChangedWithSender:" destination="o5i-8K-DIP" eventType="valueChanged" id="zNc-rc-rGI"/>
+                                        <action selector="handleSortChangedWithSender:" destination="o5i-8K-DIP" eventType="valueChanged" id="6Ig-Ng-b50"/>
                                     </connections>
                                 </segmentedControl>
                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="KoB-kO-fC0">
@@ -51,7 +51,7 @@
                                         <segment title="Desc"/>
                                     </segments>
                                     <connections>
-                                        <action selector="handleSortDirectionChangedWithSender:" destination="o5i-8K-DIP" eventType="valueChanged" id="heq-nl-JaI"/>
+                                        <action selector="handleSortChangedWithSender:" destination="o5i-8K-DIP" eventType="valueChanged" id="J5x-VT-H4L"/>
                                     </connections>
                                 </segmentedControl>
                             </subviews>

--- a/Newspack/Newspack/System/SessionManager.swift
+++ b/Newspack/Newspack/System/SessionManager.swift
@@ -21,9 +21,7 @@ class SessionManager: StatefulStore<SessionState> {
 
     /// Used with UserDefaults to store the current site's uuid for later recovery.
     ///
-    private var currentSiteIDKey: String {
-        return Environment.isTesting() ? "testingCurrentSiteIDKey" :  "currentSiteIDKey"
-    }
+    private var currentSiteIDKey = "currentSiteIDKey"
 
     /// Read only.  The ActionDispatcher for the current session.
     ///
@@ -34,10 +32,7 @@ class SessionManager: StatefulStore<SessionState> {
     ///
     private(set) var currentSite: Site? {
         didSet {
-            let defaults = UserDefaults.standard
-            defer {
-                defaults.synchronize()
-            }
+            let defaults = UserDefaults.shared
             guard let uuid = currentSite?.uuid else {
                 defaults.removeObject(forKey: currentSiteIDKey)
                 return
@@ -119,7 +114,7 @@ class SessionManager: StatefulStore<SessionState> {
     ///
     private func retrieveSite() -> Site? {
         guard
-            let uuidString = UserDefaults.standard.string(forKey: currentSiteIDKey),
+            let uuidString = UserDefaults.shared.string(forKey: currentSiteIDKey),
             let uuid = UUID(uuidString: uuidString)
             else {
                 return nil

--- a/Newspack/Newspack/System/UserAgent.swift
+++ b/Newspack/Newspack/System/UserAgent.swift
@@ -23,7 +23,7 @@ class UserAgent {
     /// Returns the user agent used by WKWebViews
     ///
     static var webUserAgent: String {
-        return UserDefaults.standard.string(forKey: Constants.webUserAgentKey) ?? String()
+        return UserDefaults.shared.string(forKey: Constants.webUserAgentKey) ?? String()
     }
 
     /// Returns the version number of the app.
@@ -44,7 +44,7 @@ class UserAgent {
     ///
     private func configureIfNecessary() {
         // If a stored user agent exists there's nothing to do.
-        guard UserDefaults.standard.string(forKey: Constants.webUserAgentKey) == nil else {
+        guard UserDefaults.shared.string(forKey: Constants.webUserAgentKey) == nil else {
             return
         }
         webView = WKWebView()
@@ -61,7 +61,7 @@ class UserAgent {
     /// - Parameter agent: The string for the user agent.
     ///
     private func storeUserAgent(agent: String) {
-        UserDefaults.standard.set(agent, forKey: Constants.webUserAgentKey)
+        UserDefaults.shared.set(agent, forKey: Constants.webUserAgentKey)
     }
 }
 

--- a/Newspack/NewspackTests/Utils/SortRulesBookTests.swift
+++ b/Newspack/NewspackTests/Utils/SortRulesBookTests.swift
@@ -14,6 +14,10 @@ class SortRulesBookTests: XCTestCase {
         sortRules = SortRulesBook(storageKey: storageKey, fields: fields, defaults: defaults)
     }
 
+    override func tearDownWithError() throws {
+        sortRules.reset()
+    }
+
     func testReset() {
         var rules = SortRules()
         for field in fields {

--- a/Newspack/NewspackTests/Utils/SortRulesBookTests.swift
+++ b/Newspack/NewspackTests/Utils/SortRulesBookTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import XCTest
+import CoreData
+@testable import Newspack
+
+class SortRulesBookTests: XCTestCase {
+
+    let storageKey = "TestSortRules"
+    let fields = ["alpha", "beta", "gamma"]
+    let defaults = ["alpha": false]
+    var sortRules: SortRulesBook!
+
+    override func setUpWithError() throws {
+        sortRules = SortRulesBook(storageKey: storageKey, fields: fields, defaults: defaults)
+    }
+
+    func testReset() {
+        var rules = SortRules()
+        for field in fields {
+            rules[field] = true
+        }
+
+        sortRules.setRules(rules: rules)
+        XCTAssertFalse(NSDictionary(dictionary: defaults).isEqual(to: sortRules.rules()))
+
+        sortRules.reset()
+        XCTAssertTrue(NSDictionary(dictionary: defaults).isEqual(to: sortRules.rules()))
+    }
+
+    func testHasRule() {
+        XCTAssertTrue(sortRules.hasRule(field: "alpha", ascending: false))
+        XCTAssertFalse(sortRules.hasRule(field: "alpha", ascending: true))
+        XCTAssertFalse(sortRules.hasRule(field: "beta", ascending: false))
+        XCTAssertFalse(sortRules.hasRule(field: "beta", ascending: true))
+    }
+
+    func testSetRule() {
+        XCTAssertTrue(sortRules.hasRule(field: "alpha", ascending: false))
+        sortRules.setRule(field: "alpha", ascending: true)
+        XCTAssertFalse(sortRules.hasRule(field: "alpha", ascending: false))
+        XCTAssertTrue(sortRules.hasRule(field: "alpha", ascending: true))
+
+        XCTAssertFalse(sortRules.hasRule(field: "beta", ascending: true))
+        XCTAssertFalse(sortRules.hasRule(field: "beta", ascending: false))
+        sortRules.setRule(field: "beta", ascending: true)
+        XCTAssertTrue(sortRules.hasRule(field: "beta", ascending: true))
+        XCTAssertTrue(sortRules.hasRule(field: "alpha", ascending: true))
+    }
+
+    func testSetRules() {
+        var rules = SortRules()
+        for field in fields {
+            rules[field] = true
+        }
+        sortRules.setRules(rules: rules)
+
+        let setRules = sortRules.rules()
+        for (key, value) in setRules {
+            XCTAssertTrue(fields.contains(key))
+            XCTAssertTrue(value)
+        }
+    }
+
+    func testDescriptors() {
+        let descriptors = sortRules.descriptors()
+        for descriptor in descriptors {
+            XCTAssertTrue(fields.contains(descriptor.key!))
+            XCTAssertFalse(descriptor.ascending)
+        }
+    }
+
+}


### PR DESCRIPTION
Refs #59 

This PR makes the StoryFolder list sortable.  The UI is very much placeholder, but let's us illustrate the functionality. Things of note:
- There is a new NSUserDefaults extension that adds a `shared` singleton and should be used in favor of the normal `standard`. The `shared` singleton will return `standard` during normal operation, but for Unit tests it returns a custom instance.  This allows unit tests to not pollute defaults.
- A SortRulesBook is introduced to wrangle sort rules, serializing them to UserDefaults, and acts as a factory for NSSortDescriptors.  The SortRuleBook is designed to be reusable by different Stores simply by initializing with the values particular to a Store.

To test:
Make sure all unit tests pass. 

- View the list of story folders. 
- Create a bunch folders if necessary.
- Use the two difference sort controls.  Ensure you can sort by name and date and by ascending and descending order.
- Tap back to the menu then back to the list of stories.  Ensure the sort order was remembered and restored.
- While sorting by name, tap into a story cell to rename that story.  Confirm that the rows are correctly reordered according to the new name of the story.

@jleandroperez Game for another? 