### PR TITLE
Issues/75 asset reconciliation

### DIFF
--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -10,7 +10,7 @@ class AssetStore: Store {
 
     // TODO: This is a stub for now and will be improved as features are added.
     var allowedExtensions: [String] {
-        return ["png","jpg","jpeg"]
+        return ["png", "jpg", "jpeg"]
     }
 
     override init(dispatcher: ActionDispatcher = .global) {

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -8,6 +8,11 @@ class AssetStore: Store {
 
     private let folderManager: FolderManager
 
+    // TODO: This is a stub for now and will be improved as features are added.
+    var allowedExtensions: [String] {
+        return ["png","jpg","jpeg"]
+    }
+
     override init(dispatcher: ActionDispatcher = .global) {
 
         folderManager = SessionManager.shared.folderManager
@@ -46,7 +51,7 @@ extension AssetStore {
                 return
             }
             let folder = context.object(with: objID) as! StoryFolder
-            let asset = self.createAsset(name: name, url: nil, folder: folder, in: context)
+            let asset = self.createAsset(name: name, url: nil, storyFolder: folder, in: context)
             asset.text = text
             asset.assetType = .textNote
             CoreDataManager.shared.saveContext(context: context)
@@ -56,15 +61,9 @@ extension AssetStore {
         }
     }
 
-    func createAssetsForURLs(urls: [URL], onComplete:(() -> Void)? = nil) {
-        guard let folder = StoreContainer.shared.folderStore.currentStoryFolder else {
-            LogError(message: "Attempted to create story assets, but a current story folder was not found.")
-            onComplete?()
-            return
-        }
-
+    func createAssetsForURLs(urls: [URL], storyFolder: StoryFolder, onComplete:(() -> Void)? = nil) {
         // Create the core data proxy for the story asset.
-        let objID = folder.objectID
+        let objID = storyFolder.objectID
         CoreDataManager.shared.performOnWriteContext { [weak self] context in
             guard let self = self else {
                 onComplete?()
@@ -73,9 +72,11 @@ extension AssetStore {
             let folder = context.object(with: objID) as! StoryFolder
 
             for url in urls {
-                let _ = self.createAsset(name: url.lastPathComponent, url: url, folder: folder, in: context)
+                let asset = self.createAsset(name: url.lastPathComponent, url: url, storyFolder: folder, in: context)
                 // TODO: There is more to do depending on the type of item.
                 // But we'll deal with this as we build out the individual features.
+                // For testing purposes we'll default to image for now.
+                asset.assetType = .image
             }
 
             CoreDataManager.shared.saveContext(context: context)
@@ -86,7 +87,7 @@ extension AssetStore {
         }
     }
 
-    func createAsset(name: String, url: URL?, folder: StoryFolder, in context: NSManagedObjectContext) -> StoryAsset {
+    func createAsset(name: String, url: URL?, storyFolder: StoryFolder, in context: NSManagedObjectContext) -> StoryAsset {
         let asset = StoryAsset(context: context)
         if let url = url {
             asset.bookmark = folderManager.bookmarkForURL(url: url)
@@ -94,7 +95,7 @@ extension AssetStore {
         asset.name = assetName(from: name)
         asset.date = Date()
         asset.uuid = UUID()
-        asset.folder = folder
+        asset.folder = storyFolder
 
         return asset
     }
@@ -198,11 +199,10 @@ extension AssetStore {
 
     /// Get the assets for the currently selected story folder, sorted by date.
     ///
+    /// - Parameter storyFolder: storyFolder description
     /// - Returns: An array of StoryAssets for the currently selected story folder.
-    func getStoryAssets() -> [StoryAsset] {
-        guard let storyFolder = StoreContainer.shared.folderStore.currentStoryFolder else {
-            fatalError()
-        }
+    ///
+    func getStoryAssets(storyFolder: StoryFolder) -> [StoryAsset] {
         let context = CoreDataManager.shared.mainContext
         let fetchRequest = StoryAsset.defaultFetchRequest()
         fetchRequest.predicate = NSPredicate(format: "folder = %@", storyFolder)

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -33,7 +33,7 @@ class AssetStore: Store {
 extension AssetStore {
 
     func createAssetFor(text: String, onComplete: (() -> Void)? = nil) {
-        guard let folder = StoreContainer.shared.folderStore.getCurrentStoryFolder() else {
+        guard let folder = StoreContainer.shared.folderStore.currentStoryFolder else {
             LogError(message: "Attempted to create story asset, but a current story folder was not found.")
             onComplete?()
             return
@@ -57,7 +57,7 @@ extension AssetStore {
     }
 
     func createAssetsForURLs(urls: [URL], onComplete:(() -> Void)? = nil) {
-        guard let folder = StoreContainer.shared.folderStore.getCurrentStoryFolder() else {
+        guard let folder = StoreContainer.shared.folderStore.currentStoryFolder else {
             LogError(message: "Attempted to create story assets, but a current story folder was not found.")
             onComplete?()
             return
@@ -166,7 +166,7 @@ extension AssetStore {
     /// - Returns: An NSFetchedResultsController instance
     ///
     func getResultsController() -> NSFetchedResultsController<StoryAsset> {
-        guard let storyFolder = StoreContainer.shared.folderStore.getCurrentStoryFolder() else {
+        guard let storyFolder = StoreContainer.shared.folderStore.currentStoryFolder else {
             fatalError()
         }
         let fetchRequest = StoryAsset.defaultFetchRequest()
@@ -200,7 +200,7 @@ extension AssetStore {
     ///
     /// - Returns: An array of StoryAssets for the currently selected story folder.
     func getStoryAssets() -> [StoryAsset] {
-        guard let storyFolder = StoreContainer.shared.folderStore.getCurrentStoryFolder() else {
+        guard let storyFolder = StoreContainer.shared.folderStore.currentStoryFolder else {
             fatalError()
         }
         let context = CoreDataManager.shared.mainContext

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -19,6 +19,12 @@ class FolderStore: Store {
         return SortRulesBook(storageKey: "FolderStoreSortRules", fields: ["date", "name"], defaults: ["date": false], caseInsensitiveFields: ["name"])
     }()
 
+    /// A convenience getter to get the current story folder.
+    ///
+    var currentStoryFolder: StoryFolder? {
+        getStoryFolderByID(uuid: currentStoryFolderID)
+    }
+
     init(dispatcher: ActionDispatcher = .global, siteID: UUID? = nil) {
         currentSiteID = siteID
 
@@ -387,15 +393,6 @@ extension FolderStore {
             LogError(message: error.localizedDescription)
         }
         return nil
-    }
-
-    // TODO: Make this a computed property
-    /// A convenience method to get the current story folder.
-    ///
-    /// - Returns: The current story folder or nil.
-    ///
-    func getCurrentStoryFolder() -> StoryFolder? {
-        return getStoryFolderByID(uuid: currentStoryFolderID)
     }
 
     /// Set the specified story folder as the selected folder.

--- a/Newspack/Newspack/System/Reconciler.swift
+++ b/Newspack/Newspack/System/Reconciler.swift
@@ -57,11 +57,9 @@ class Reconciler {
 
         let folderStore = StoreContainer.shared.folderStore
         let folders = folderStore.getStoryFolders()
-        for folder in folders {
-            if hasInconsistentAssets(storyFolder: folder) {
-                LogInfo(message: "StoryAssets where missing, or new assets were found for story: \(folder.name ?? "").")
-                return true
-            }
+        for folder in folders where hasInconsistentAssets(storyFolder: folder) {
+            LogInfo(message: "StoryAssets where missing, or new assets were found for story: \(folder.name ?? "").")
+            return true
         }
         return false
     }


### PR DESCRIPTION
Closes #75 

This PR implements the basics for Story Asset filesystem/core data reconciliation.  Because actual features are not yet implemented some of the behaviors are stubbed and will be improved upon in future PRs.  With these changes, images (pngs and jpgs) added to or removed from a story folder via the file system should be detected by the Reconciler when the app is launched/resumed and text notes should remain unchanged.

To test: 
Confirm all tests still pass.

Prep:
- Launch the app and create a few story folders. For each story folder, create a few text notes.

Scenario 1:
- Open the Photos app.
- Select a few photos and use the share feature to _copy_ them to the pasteboard.
- Open the Files app.
- Browse to one of your story's folders and paste the images into the folder.
- Resume Newspack.  Note in the console that an Info log shows new assets were detected and added, and that the amount is correct.
- Browse to the story folder and check its contents. Confirm that you see the pasted images. 

Note that if you copied HEIC or HEIF files these will not currently be recongnized. Stick with png or jpgs.

Scenario 2:
- After completing Scenario 1 background Newspack
- Open the Files app and browse to the images you pasted. 
- Delete some (but not all) of the images.
- Resume Newspack.  Note in the console that an Info log shows the missing assets were detected and removed, and that the amount is correct.
- Browse to the story folder and check its contents. Confirm that the images you deleted are no longer shown in the list of assets.

@jleandroperez are you game for a quick review?