### PR TITLE
Issues/59 order assets

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		E6AC98B823CCD5DE00E95381 /* MainNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AC98B723CCD5DE00E95381 /* MainNavController.swift */; };
 		E6B4034D22D8E12500A0DDCA /* remote-posts-ids-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */; };
 		E6B4034E22D8E12500A0DDCA /* remote-posts-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */; };
+		E6B7728824BCD8DA00CA8AB8 /* SortOrganizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B7728724BCD8DA00CA8AB8 /* SortOrganizer.swift */; };
 		E6B8CFDB24AB91430068C6BE /* URLFileReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDA24AB91430068C6BE /* URLFileReferenceTests.swift */; };
 		E6B8CFDD24ABC48C0068C6BE /* FolderStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDC24ABC48C0068C6BE /* FolderStoreTests.swift */; };
 		E6B8CFE024ABD6EB0068C6BE /* ReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */; };
@@ -418,6 +419,7 @@
 		E6AC98B723CCD5DE00E95381 /* MainNavController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavController.swift; sourceTree = "<group>"; };
 		E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-ids-edit.json"; sourceTree = "<group>"; };
 		E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-edit.json"; sourceTree = "<group>"; };
+		E6B7728724BCD8DA00CA8AB8 /* SortOrganizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortOrganizer.swift; sourceTree = "<group>"; };
 		E6B8CFDA24AB91430068C6BE /* URLFileReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLFileReferenceTests.swift; sourceTree = "<group>"; };
 		E6B8CFDC24ABC48C0068C6BE /* FolderStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderStoreTests.swift; sourceTree = "<group>"; };
 		E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcilerTests.swift; sourceTree = "<group>"; };
@@ -934,6 +936,7 @@
 			isa = PBXGroup;
 			children = (
 				E6C398BD24AD259300E0EBE6 /* SortRulesBook.swift */,
+				E6B7728724BCD8DA00CA8AB8 /* SortOrganizer.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1398,6 +1401,7 @@
 				E63F3F3C236350BE00DB760E /* MediaTypeDiscerner.swift in Sources */,
 				E602E68F22C1637800795CBA /* PostApiActions.swift in Sources */,
 				E695A7E7244FD686007B29BB /* StoryAsset+CoreDataProperties.swift in Sources */,
+				E6B7728824BCD8DA00CA8AB8 /* SortOrganizer.swift in Sources */,
 				E641A66322A7584A008BBD85 /* AccountDetailsStore.swift in Sources */,
 				E636C262234FBE6800564B63 /* RemoteMedia.swift in Sources */,
 				E6DF5575242E7139007DDC47 /* FolderManager.swift in Sources */,

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -191,13 +191,12 @@ class AssetDataSource: UITableViewDiffableDataSource<Int, StoryAsset> {
     }
 
     override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        guard let storyAsset = resultsController.fetchedObjects?[indexPath.row] else {
+        guard editingStyle == .delete else {
             return
         }
-        if editingStyle == .delete {
-            let action = AssetAction.deleteAsset(assetID: storyAsset.uuid)
-            SessionManager.shared.sessionDispatcher.dispatch(action)
-        }
+        let storyAsset = resultsController.object(at: indexPath)
+        let action = AssetAction.deleteAsset(assetID: storyAsset.uuid)
+        SessionManager.shared.sessionDispatcher.dispatch(action)
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -4,12 +4,21 @@ import WordPressFlux
 
 class AssetsViewController: UITableViewController {
 
+    @IBOutlet var sortControl: UISegmentedControl!
+
     var dataSource: AssetDataSource!
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         configureDataSource()
+
+        // Temporary measure. The UI will change so right now this doesn't need to be pretty.
+        let headerView = tableView.tableHeaderView!
+        var frame = headerView.frame
+        frame.size.height = 44.0
+        headerView.frame = frame
+        tableView.tableHeaderView = headerView
     }
 
 }
@@ -21,6 +30,10 @@ extension AssetsViewController {
     @IBAction func handleAddTapped(sender: Any) {
         let action = AssetAction.createAssetFor(text: "New Text Note")
         SessionManager.shared.sessionDispatcher.dispatch(action)
+    }
+
+    @IBAction func handleSortChanged(sender: Any) {
+        print("changed")
     }
 
 }

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -181,7 +181,11 @@ class AssetDataSource: UITableViewDiffableDataSource<Int, StoryAsset> {
             snapshot.appendItems(items, toSection: i)
         }
 
-        let shouldAnimate = false// tableView?.window != nil
+        // Note: When animating cells, for some reason individual cells are not redrawn
+        // (i.e. cellForRow is not being called). Needs further exploration to figure out why.
+        // Also, when animating it makes reording look a little weird.
+        // For these reasons we'll disable animating when sorting or not in a window.
+        let shouldAnimate = tableView?.window != nil && tableView?.isEditing == false
         apply(snapshot, animatingDifferences: shouldAnimate, completion: nil)
     }
 

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -173,7 +173,7 @@ class AssetDataSource: UITableViewDiffableDataSource<Int, StoryAsset> {
         }
         var snapshot = NSDiffableDataSourceSnapshot<Int, StoryAsset>()
 
-        for (i , section) in sections.enumerated() {
+        for (i, section) in sections.enumerated() {
             snapshot.appendSections([i])
             guard let items = section.objects as? [StoryAsset] else {
                 continue

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -103,7 +103,7 @@ extension FoldersViewController {
     }
 
     func configureSortControl() {
-        let dict = StoreContainer.shared.folderStore.sortRules.rules()
+        let dict = StoreContainer.shared.folderStore.sortRules.rules
         for (key, value) in dict {
             sortDirection.selectedSegmentIndex = value ? 0 : 1
 
@@ -172,7 +172,7 @@ class FolderDataSource: UITableViewDiffableDataSource<FolderDataSource.Section, 
         let action = FolderAction.sortBy(field: field, ascending: ascending)
         SessionManager.shared.sessionDispatcher.dispatch(action)
 
-        resultsController.fetchRequest.sortDescriptors = StoreContainer.shared.folderStore.sortRules.descriptors()
+        resultsController.fetchRequest.sortDescriptors = StoreContainer.shared.folderStore.sortRules.descriptors
         try? resultsController.performFetch()
 
         update()

--- a/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
+++ b/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
@@ -257,7 +257,8 @@
         <attribute name="lastSync" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="modified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="name" attributeType="String"/>
-        <attribute name="order" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="order" attributeType="Integer 16" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="sorted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="text" optional="YES" attributeType="String"/>
         <attribute name="uuid" attributeType="UUID" usesScalarValueType="NO"/>
         <relationship name="folder" maxCount="1" deletionRule="Nullify" destinationEntity="StoryFolder" inverseName="assets" inverseEntity="StoryFolder"/>
@@ -299,7 +300,7 @@
         <element name="StagedEdits" positionX="-868.6484375" positionY="-275.66015625" width="128" height="118"/>
         <element name="StagedMedia" positionX="-2097.73828125" positionY="129.59765625" width="128" height="208"/>
         <element name="Status" positionX="-1600.76953125" positionY="-2.2265625" width="128" height="165"/>
-        <element name="StoryAsset" positionX="-1702.796875" positionY="382.8671875" width="128" height="193"/>
+        <element name="StoryAsset" positionX="-1702.796875" positionY="382.8671875" width="128" height="208"/>
         <element name="StoryFolder" positionX="-1515.86328125" positionY="210.171875" width="128" height="163"/>
         <element name="User" positionX="-976.9921875" positionY="-127.2734375" width="128" height="163"/>
     </elements>

--- a/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
+++ b/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
@@ -28,4 +28,18 @@ enum StoryAssetType: String {
     case image
     case video
     case audioNote
+
+    func displayName() -> String {
+        switch self {
+        case .textNote:
+            return NSLocalizedString("Text Note", comment: "Noun. A short note made up of simple text.")
+        case .image:
+            return NSLocalizedString("Image", comment: "Noun. An image or photo.")
+        case .video:
+            return NSLocalizedString("Video", comment: "Noun. A video recording.")
+        case .audioNote:
+            return NSLocalizedString("Audio Note", comment: "Noun: A short audio recording. Like a text note but audio, likely the user's own voice.")
+
+        }
+    }
 }

--- a/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
+++ b/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
@@ -4,6 +4,23 @@ import CoreData
 @objc(StoryAsset)
 public class StoryAsset: NSManagedObject {
 
+    public override func willSave() {
+        super.willSave()
+
+        updateSortedIfNeeded()
+    }
+
+
+    /// Called from willSave which will be called again if there are any changes
+    /// so only update the property if necessary.
+    ///
+    func updateSortedIfNeeded() {
+        let isSorted = order != -1
+        if sorted == isSorted {
+            return
+        }
+        sorted = isSorted
+    }
 }
 
 enum StoryAssetType: String {

--- a/Newspack/Newspack/Models/StoryAsset+CoreDataProperties.swift
+++ b/Newspack/Newspack/Models/StoryAsset+CoreDataProperties.swift
@@ -21,11 +21,12 @@ extension StoryAsset {
     @NSManaged public var bookmark: Data? // Text notes do not have local files. RemoteMedia may not have local files.
     @NSManaged public var name: String!
     @NSManaged public var uuid: UUID!
-    @NSManaged public var order: Int16 // Default is 0
+    @NSManaged public var order: Int16 // Default is -1
     @NSManaged public var date: Date!
     @NSManaged public var lastSync: Date?
     @NSManaged public var modified: Date?
     @NSManaged public var text: String?
+    @NSManaged public var sorted: Bool
     @NSManaged public var folder: StoryFolder!
 
 }

--- a/Newspack/Newspack/Stores/Actions/AssetAction.swift
+++ b/Newspack/Newspack/Stores/Actions/AssetAction.swift
@@ -5,6 +5,7 @@ import WordPressFlux
 ///
 enum AssetAction: Action {
     case sortMode(index: Int)
+    case applyOrder(order: [UUID: Int])
     case createAssetFor(text: String)
     case deleteAsset(assetID: UUID)
 }

--- a/Newspack/Newspack/Stores/Actions/AssetAction.swift
+++ b/Newspack/Newspack/Stores/Actions/AssetAction.swift
@@ -4,6 +4,7 @@ import WordPressFlux
 /// Supported Actions for changes to the AssetStore
 ///
 enum AssetAction: Action {
+    case sortMode(index: Int)
     case createAssetFor(text: String)
     case deleteAsset(assetID: UUID)
 }

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -170,13 +170,18 @@ extension AssetStore {
         guard let storyFolder = StoreContainer.shared.folderStore.currentStoryFolder else {
             fatalError()
         }
-        let fetchRequest = StoryAsset.defaultFetchRequest()
 
+        let sortDescriptors = [
+            NSSortDescriptor(key: "sorted", ascending: false),
+            NSSortDescriptor(key: "order", ascending: true),
+            NSSortDescriptor(key: "date", ascending: true)
+        ]
+        let fetchRequest = StoryAsset.defaultFetchRequest()
         fetchRequest.predicate = NSPredicate(format: "folder = %@", storyFolder)
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "order", ascending: true)]
+        fetchRequest.sortDescriptors = sortDescriptors
         return NSFetchedResultsController(fetchRequest: fetchRequest,
                                           managedObjectContext: CoreDataManager.shared.mainContext,
-                                          sectionNameKeyPath: nil,
+                                          sectionNameKeyPath: "sorted",
                                           cacheName: nil)
     }
 }

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -8,6 +8,7 @@ class AssetStore: Store {
 
     private let folderManager: FolderManager
 
+    /// Defines a SortOrganizer and its associated SortRules.
     lazy private(set) var sortOrganizer: SortOrganizer = {
         var typeRules: [SortRule] = [
             SortRule(field: "assetTypeValue", displayName: NSLocalizedString("Type", comment: "Noun. The type or category of something."), ascending: false),
@@ -43,6 +44,8 @@ class AssetStore: Store {
         return ["png", "jpg", "jpeg"]
     }
 
+    /// Whethher the StoryAssets managed by the store can be sorted. This applies
+    /// only to the assets wrangled by the SortOrganizer.
     var canSortAssets: Bool {
         // True if the selected sort option is orderSort.
         return sortOrganizer.selectedIndex == 1
@@ -84,6 +87,12 @@ extension AssetStore {
         sortOrganizer.select(index: index)
     }
 
+    /// Create a new TextNote StoryAsset
+    ///
+    /// - Parameters:
+    ///   - text: A string of text.
+    ///   - onComplete: A closeure to call when finished.
+    ///
     func createAssetFor(text: String, onComplete: (() -> Void)? = nil) {
         guard let folder = StoreContainer.shared.folderStore.currentStoryFolder else {
             LogError(message: "Attempted to create story asset, but a current story folder was not found.")
@@ -108,6 +117,13 @@ extension AssetStore {
         }
     }
 
+    /// Create new StoryAsset instances for the specified file URLs.
+    ///
+    /// - Parameters:
+    ///   - urls: An array of file URLs.
+    ///   - storyFolder: The parent StoryFolder for the new StoryAssets
+    ///   - onComplete: A closure to call when finished.
+    ///
     func createAssetsForURLs(urls: [URL], storyFolder: StoryFolder, onComplete:(() -> Void)? = nil) {
         // Create the core data proxy for the story asset.
         let objID = storyFolder.objectID
@@ -134,6 +150,15 @@ extension AssetStore {
         }
     }
 
+    /// Create a new StoryAsset.
+    ///
+    /// - Parameters:
+    ///   - name: The asset's name.
+    ///   - url: The file URL of the asset if there is a corresponding file system object.
+    ///   - storyFolder: The asset's StoryFolder.
+    ///   - context: A NSManagedObjectContext to use.
+    /// - Returns: A new StoryAsset
+    ///
     func createAsset(name: String, url: URL?, storyFolder: StoryFolder, in context: NSManagedObjectContext) -> StoryAsset {
         let asset = StoryAsset(context: context)
         if let url = url {
@@ -147,6 +172,11 @@ extension AssetStore {
         return asset
     }
 
+    /// Retursn the name to use for a story asset based on the supplied string.
+    ///
+    /// - Parameter string: A string from which to derived the StoryAsset's name.
+    /// - Returns: The name for a StoryAsset.
+    ///
     func assetName(from string: String) -> String {
         let maxLength = 50 // Fifty is an arbitrary number.
         guard let index = string.index(string.startIndex, offsetBy: maxLength, limitedBy: string.endIndex) else {
@@ -161,6 +191,10 @@ extension AssetStore {
         return str + "..."
     }
 
+    /// Deletes the specified StoryAsset.
+    ///
+    /// - Parameter assetID: The UUID of the specified StoryAsset.
+    ///
     func deleteAsset(assetID: UUID) {
         guard let asset = getStoryAssetByID(uuid: assetID) else {
             return
@@ -168,6 +202,12 @@ extension AssetStore {
         deleteAssets(assets: [asset])
     }
 
+    /// Deletes the specified assets and triggers the specified callback.
+    ///
+    /// - Parameters:
+    ///   - assets: An array of StoryAssets to delete.
+    ///   - onComplete: A closure to execute when finished, whether successful or not.
+    ///
     func deleteAssets(assets: [StoryAsset], onComplete: (() -> Void)? = nil) {
         // For each asset, remove its bookmarked content and then delete.
         var objIDs = [NSManagedObjectID]()
@@ -202,6 +242,12 @@ extension AssetStore {
         }
     }
 
+    /// Updates the sort order of the StoryAssets matching the specified UUIDs.
+    ///
+    /// - Parameter order: A dictionary representing the StoryAssets to update.
+    /// Keys should be the asset UUIDs and values should be the desired sort order
+    /// for the assets.
+    ///
     func applySortOrder(order: [UUID: Int]) {
         print(order.values)
         CoreDataManager.shared.performOnWriteContext { context in

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -43,6 +43,11 @@ class AssetStore: Store {
         return ["png", "jpg", "jpeg"]
     }
 
+    var canSortAssets: Bool {
+        // True if the selected sort option is orderSort.
+        return sortOrganizer.selectedIndex == 1
+    }
+
     override init(dispatcher: ActionDispatcher = .global) {
 
         folderManager = SessionManager.shared.folderManager

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -62,6 +62,8 @@ class AssetStore: Store {
             switch action {
             case .sortMode(let index):
                 selectSortMode(index: index)
+            case .applyOrder(let order):
+                applySortOrder(order: order)
             case .createAssetFor(let text):
                 createAssetFor(text: text)
             case .deleteAsset(let uuid):
@@ -200,6 +202,24 @@ extension AssetStore {
         }
     }
 
+    func applySortOrder(order: [UUID: Int]) {
+        print(order.values)
+        CoreDataManager.shared.performOnWriteContext { context in
+            for (key, value) in order {
+                let fetchRequest = StoryAsset.defaultFetchRequest()
+                fetchRequest.predicate = NSPredicate(format: "uuid = %@", key as CVarArg)
+
+                guard let asset = try? context.fetch(fetchRequest).first else {
+                    continue
+                }
+
+                asset.order = Int16(value)
+            }
+
+            CoreDataManager.shared.saveContext(context: context)
+        }
+
+    }
 }
 
 extension AssetStore {

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -10,11 +10,11 @@ class AssetStore: Store {
 
     /// Defines a SortOrganizer and its associated SortRules.
     lazy private(set) var sortOrganizer: SortOrganizer = {
-        var typeRules: [SortRule] = [
+        let typeRules: [SortRule] = [
             SortRule(field: "assetTypeValue", displayName: NSLocalizedString("Type", comment: "Noun. The type or category of something."), ascending: false),
             SortRule(field: "date", displayName: NSLocalizedString("Date", comment: "Noun. The date something was created."), ascending: true)
         ]
-        var typeSort = SortMode(defaultsKey: "AssetSortModeType",
+        let typeSort = SortMode(defaultsKey: "AssetSortModeType",
                                 title: NSLocalizedString("Type", comment: "Noun. The title of a list that is sorted by the types of objects in the list."),
                                 rules: typeRules,
                                 hasSections: true) { (title) -> String in
@@ -23,12 +23,12 @@ class AssetStore: Store {
                                     }
                                     return type.displayName()
                                 }
-        var orderRules: [SortRule] = [
+        let orderRules: [SortRule] = [
             SortRule(field: "sorted", displayName: NSLocalizedString("Sorted", comment: "Adjective. Refers whether items have been sorted or are unsorted."), ascending: false),
             SortRule(field: "order", displayName: NSLocalizedString("Order", comment: "Noun. Refers to the order or arrangement of items in a list."), ascending: true),
             SortRule(field: "date", displayName: NSLocalizedString("Date", comment: "Noun. The date something was created."), ascending: true)
         ]
-        var orderSort = SortMode(defaultsKey: "AssetSortModeOrder",
+        let orderSort = SortMode(defaultsKey: "AssetSortModeOrder",
                                  title: NSLocalizedString("Order", comment: "Noun. Refers to the order or arrangement of items in a list."),
                                  rules: orderRules,
                                  hasSections: true) { (title) -> String in
@@ -249,7 +249,6 @@ extension AssetStore {
     /// for the assets.
     ///
     func applySortOrder(order: [UUID: Int]) {
-        print(order.values)
         CoreDataManager.shared.performOnWriteContext { context in
             for (key, value) in order {
                 let fetchRequest = StoryAsset.defaultFetchRequest()
@@ -264,7 +263,6 @@ extension AssetStore {
 
             CoreDataManager.shared.saveContext(context: context)
         }
-
     }
 }
 

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -75,7 +75,7 @@ extension FolderStore {
 
         let fetchRequest = StoryFolder.defaultFetchRequest()
         fetchRequest.predicate = NSPredicate(format: "site.uuid = %@", siteID as CVarArg)
-        fetchRequest.sortDescriptors = sortRules.descriptors()
+        fetchRequest.sortDescriptors = sortRules.descriptors
         return NSFetchedResultsController(fetchRequest: fetchRequest,
                                           managedObjectContext: CoreDataManager.shared.mainContext,
                                           sectionNameKeyPath: nil,
@@ -251,7 +251,7 @@ extension FolderStore {
         let context = CoreDataManager.shared.mainContext
         let fetchRequest: NSFetchRequest<NSFetchRequestResult> = StoryFolder.fetchRequest()
         fetchRequest.predicate = NSPredicate(format: "site.uuid = %@ AND NOT (uuid IN %@)", siteID as CVarArg, uuidsToExclude)
-        fetchRequest.sortDescriptors = sortRules.descriptors()
+        fetchRequest.sortDescriptors = sortRules.descriptors
         fetchRequest.propertiesToFetch = ["uuid"]
         fetchRequest.resultType = .dictionaryResultType
 
@@ -352,7 +352,7 @@ extension FolderStore {
         let context = CoreDataManager.shared.mainContext
         let fetchRequest = StoryFolder.defaultFetchRequest()
         fetchRequest.predicate = NSPredicate(format: "site.uuid = %@", siteID as CVarArg)
-        fetchRequest.sortDescriptors = sortRules.descriptors()
+        fetchRequest.sortDescriptors = sortRules.descriptors
 
         if let results = try? context.fetch(fetchRequest) {
             return results

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -132,8 +132,8 @@
                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Ujc-SR-HJd">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
                                     <segments>
-                                        <segment title="Ordered"/>
                                         <segment title="Type"/>
+                                        <segment title="Ordered"/>
                                     </segments>
                                     <connections>
                                         <action selector="handleSortChangedWithSender:" destination="EtD-KI-a1B" eventType="valueChanged" id="Kog-eH-9Qt"/>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -142,17 +142,33 @@
                             </subviews>
                         </stackView>
                         <view key="tableFooterView" contentMode="scaleToFill" id="GFd-8g-uaH">
-                            <rect key="frame" x="0.0" y="143.5" width="375" height="44"/>
+                            <rect key="frame" x="0.0" y="155.5" width="375" height="44"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         </view>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AssetCell" id="a0I-9b-USj">
-                                <rect key="frame" x="0.0" y="72" width="375" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AssetCell" textLabel="X9L-A9-WjD" detailTextLabel="6PL-gr-v5j" style="IBUITableViewCellStyleSubtitle" id="a0I-9b-USj">
+                                <rect key="frame" x="0.0" y="72" width="375" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="a0I-9b-USj" id="G1c-S4-kfV">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="55.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="X9L-A9-WjD">
+                                            <rect key="frame" x="16" y="10" width="33.5" height="20.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6PL-gr-v5j">
+                                            <rect key="frame" x="16" y="31.5" width="44" height="14.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -125,14 +125,30 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <stackView key="tableHeaderView" opaque="NO" contentMode="scaleToFill" id="lrE-Pn-O5b">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <subviews>
+                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Ujc-SR-HJd">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
+                                    <segments>
+                                        <segment title="Ordered"/>
+                                        <segment title="Type"/>
+                                    </segments>
+                                    <connections>
+                                        <action selector="handleSortChangedWithSender:" destination="EtD-KI-a1B" eventType="valueChanged" id="Kog-eH-9Qt"/>
+                                    </connections>
+                                </segmentedControl>
+                            </subviews>
+                        </stackView>
                         <view key="tableFooterView" contentMode="scaleToFill" id="GFd-8g-uaH">
-                            <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                            <rect key="frame" x="0.0" y="143.5" width="375" height="44"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         </view>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AssetCell" id="a0I-9b-USj">
-                                <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
+                                <rect key="frame" x="0.0" y="72" width="375" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="a0I-9b-USj" id="G1c-S4-kfV">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -153,6 +169,9 @@
                         </barButtonItem>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <connections>
+                        <outlet property="sortControl" destination="Ujc-SR-HJd" id="vEb-oM-xai"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="V9p-Z4-7n1" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -178,11 +178,18 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="Assets" id="zmw-7F-Zw1">
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="YP3-Sh-l02">
-                            <connections>
-                                <action selector="handleAddTappedWithSender:" destination="EtD-KI-a1B" id="oCV-tr-wXm"/>
-                            </connections>
-                        </barButtonItem>
+                        <rightBarButtonItems>
+                            <barButtonItem systemItem="add" id="YP3-Sh-l02">
+                                <connections>
+                                    <action selector="handleAddTappedWithSender:" destination="EtD-KI-a1B" id="oCV-tr-wXm"/>
+                                </connections>
+                            </barButtonItem>
+                            <barButtonItem systemItem="edit" id="Q83-lh-HXm">
+                                <connections>
+                                    <action selector="handleToggleEditingWithSender:" destination="EtD-KI-a1B" id="XMg-Hr-Ag2"/>
+                                </connections>
+                            </barButtonItem>
+                        </rightBarButtonItems>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>

--- a/Newspack/Newspack/Utils/SortOrganizer.swift
+++ b/Newspack/Newspack/Utils/SortOrganizer.swift
@@ -1,0 +1,155 @@
+import Foundation
+import CoreData
+
+/// A struct that defines a single sort rule.
+///
+struct SortRule {
+    let field: String
+    let displayName: String
+    var ascending: Bool
+
+    init(dict: [String: Any]) {
+        guard
+            let field = dict["field"] as? String,
+            let displayName = dict["displayName"] as? String,
+            let ascending = dict["ascending"] as? Bool
+        else {
+            // We should never get here but...
+            fatalError()
+        }
+        self.field = field
+        self.displayName = displayName
+        self.ascending = ascending
+    }
+
+    mutating func setAscending(value: Bool) {
+        ascending = value
+    }
+
+    func dictionary() -> [String: Any] {
+        return [
+            "field": field,
+            "displayName": displayName,
+            "ascending": ascending
+        ]
+    }
+}
+
+/// Defines all the information necessary for a single sort mode.
+/// A sort mode is a collection of one or more sort rules.
+/// Includes the title of the sort mode, and sort descriptors.
+///
+class SortMode {
+
+    let title: String
+
+    let sectionNameKeyPath: String?
+
+    private let sectionNameResolver: ((_ name: String) -> String)?
+
+    private(set) var rules: [SortRule]
+
+    let defaultsKey: String
+
+    var descriptors: [NSSortDescriptor] {
+        var arr = [NSSortDescriptor]()
+        for rule in rules {
+            arr.append(NSSortDescriptor(key: rule.field, ascending: rule.ascending))
+        }
+        return arr
+    }
+
+    init(defaultsKey: String, title: String, sectionName: String, rules: [SortRule], resolver: @escaping ((_ name: String) -> String)) {
+        self.defaultsKey = defaultsKey
+        self.title = title
+        self.sectionNameKeyPath = sectionName
+        self.rules = rules
+        sectionNameResolver = resolver
+
+        if let savedRules = savedRules() {
+            self.rules = savedRules
+        }
+
+        save()
+    }
+
+    func title(for section: NSFetchedResultsSectionInfo) -> String {
+        guard let resolver = sectionNameResolver else {
+            return ""
+        }
+        return resolver(section.name)
+    }
+
+    func savedRules() -> [SortRule]? {
+        guard let arr = UserDefaults.shared.object(forKey: defaultsKey) as? [[String: Any]] else {
+            return nil
+        }
+        var rules = [SortRule]()
+        for item in arr {
+            rules.append(SortRule(dict: item))
+        }
+        return rules
+    }
+
+    func updateRule(for field: String, value: Bool) {
+        // Kind of annoying, but we need to recreate the whole array just to change one rule.
+        var arr = [SortRule]()
+
+        for rule in rules {
+            var rule = rule
+            if rule.field == field {
+                rule.setAscending(value: value)
+            }
+            arr.append(rule)
+        }
+        rules = arr
+
+        save()
+    }
+
+    private func save() {
+        var arr = [[String: Any]]()
+        for rule in rules {
+            arr.append(rule.dictionary())
+        }
+        UserDefaults.shared.set(arr, forKey: defaultsKey)
+    }
+}
+
+/// Manages a list of sort modes.
+///
+class SortOrganizer {
+
+    private(set) var modes: [SortMode]
+
+    private(set) var selectedIndex = 0
+
+    private let defaultsKey: String
+
+    var selectedMode: SortMode {
+        return modes[selectedIndex]
+    }
+
+    init(defaultsKey: String, modes: [SortMode]) {
+        self.defaultsKey = defaultsKey
+        self.modes = modes
+
+        selectedIndex = savedIndex()
+    }
+
+    func mode(at index: Int) -> SortMode {
+        return modes[index]
+    }
+
+    func select(index: Int) {
+        guard index < modes.count else {
+            return
+        }
+        selectedIndex = index
+        UserDefaults.shared.set(index, forKey: defaultsKey)
+    }
+
+    private func savedIndex() -> Int {
+        return UserDefaults.shared.integer(forKey: defaultsKey)
+    }
+}

--- a/Newspack/Newspack/Utils/SortOrganizer.swift
+++ b/Newspack/Newspack/Utils/SortOrganizer.swift
@@ -8,6 +8,12 @@ struct SortRule {
     let displayName: String
     var ascending: Bool
 
+    init(field: String, displayName: String, ascending: Bool) {
+        self.field = field
+        self.displayName = displayName
+        self.ascending = ascending
+    }
+
     init(dict: [String: Any]) {
         guard
             let field = dict["field"] as? String,
@@ -43,7 +49,7 @@ class SortMode {
 
     let title: String
 
-    let sectionNameKeyPath: String?
+    let hasSections: Bool
 
     private let sectionNameResolver: ((_ name: String) -> String)?
 
@@ -59,10 +65,17 @@ class SortMode {
         return arr
     }
 
-    init(defaultsKey: String, title: String, sectionName: String, rules: [SortRule], resolver: @escaping ((_ name: String) -> String)) {
+    var sectionNameKeyPath: String? {
+        guard hasSections else {
+            return nil
+        }
+        return rules.first?.field
+    }
+
+    init(defaultsKey: String, title: String, rules: [SortRule], hasSections: Bool, resolver: @escaping ((_ name: String) -> String)) {
         self.defaultsKey = defaultsKey
         self.title = title
-        self.sectionNameKeyPath = sectionName
+        self.hasSections = hasSections
         self.rules = rules
         sectionNameResolver = resolver
 

--- a/Newspack/NewspackTests/Utils/SortRulesBookTests.swift
+++ b/Newspack/NewspackTests/Utils/SortRulesBookTests.swift
@@ -25,10 +25,10 @@ class SortRulesBookTests: XCTestCase {
         }
 
         sortRules.setRules(rules: rules)
-        XCTAssertFalse(NSDictionary(dictionary: defaults).isEqual(to: sortRules.rules()))
+        XCTAssertFalse(NSDictionary(dictionary: defaults).isEqual(to: sortRules.rules))
 
         sortRules.reset()
-        XCTAssertTrue(NSDictionary(dictionary: defaults).isEqual(to: sortRules.rules()))
+        XCTAssertTrue(NSDictionary(dictionary: defaults).isEqual(to: sortRules.rules))
     }
 
     func testHasRule() {
@@ -58,7 +58,7 @@ class SortRulesBookTests: XCTestCase {
         }
         sortRules.setRules(rules: rules)
 
-        let setRules = sortRules.rules()
+        let setRules = sortRules.rules
         for (key, value) in setRules {
             XCTAssertTrue(fields.contains(key))
             XCTAssertTrue(value)
@@ -66,7 +66,7 @@ class SortRulesBookTests: XCTestCase {
     }
 
     func testDescriptors() {
-        let descriptors = sortRules.descriptors()
+        let descriptors = sortRules.descriptors
         for descriptor in descriptors {
             XCTAssertTrue(fields.contains(descriptor.key!))
             XCTAssertFalse(descriptor.ascending)


### PR DESCRIPTION
Closes #59 

This PR wraps up the sorting logic for StoryAssets. The list of story assets can be filtered between two sort modes: asset type, and a user defined sort mode.  Support is also added for dragging items from the unsorted section into the sorted section, and reordering items in the sorted section.   There is some temporary UI to facilitate testing the different sort modes and the editing behavior.  Please note that the new edit button in the nav bar only applies when viewing the sorted/unsorted list.

### To Test:

Prep: Create a Story Folder, enter the folder and add some text notes. Go the Photos app and copy some photos. Use the Files app to paste these into the story folder you created.

Scenario 1: Type Mode
- View the assets list for your story folder and confirm that you see text and image assets in two different sections.  
- Confirm the first section has text notes, and the second section has images.

Scenario 2: Switching Modes + Rememberance
- Switch to Ordered mode and back a few times.  Confirm that the list shows the correct sections every time.
- Confirm that the sort mode you are viewing is remembered by returning to the list of Story Folders, then back to the list of Assets.  You should always be returned to the list mode you were previously viewing.  
- Confirm that the segment control always shows the correct mode selected.

Scenario 3: Ordered Mode - Deletion
- While viewing ordered mode tap the + button to add a new text note.
- Delete the note. Confirm that the correct note was deleted.

Scenario 4: Ordered Mode - Editing
- If you do not have both an ordered and unordered sections, tap a few unordered rows to make them ordered.
- While viewing ordered mode, tap the Edit button.  Confirm that the drag accessory icons appear.
- Confirm that you can drag an item from the unsorted list into the sorted list.
- Confirm that you can not change the order of unsorted items.
- Confirm that you can not drag an item from the sorted list into the unsorted list.
- Confirm that you can change the order of items in the sorted list.
- Return to the list of Story Folders, then back to the list of assets.  Confirm that the order is remembered.

Scenario 5: Blank canvas.
- View the list of assets for a story folder with no assets.
- Confirm nothing goes 💥. 


Note: You can tap a sorted row to make it unsorted, or to give it a sort order of 1.  This is a hack to make testing easier and will be removed in the future. :) 

### Examples:
#### The Type list:
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-07-13 at 17 05 10](https://user-images.githubusercontent.com/1435271/87359491-855ebc80-c52d-11ea-83f3-e7cfd47127c4.png)

#### The Sorted list:
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-07-13 at 17 05 30](https://user-images.githubusercontent.com/1435271/87359497-8859ad00-c52d-11ea-8a73-156853645e9a.png)

Hola @jleandroperez!  Game for a review?