### PR TITLE
Housekeeping/rename field

### DIFF
--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -181,12 +181,12 @@ class AssetDataSource: UITableViewDiffableDataSource<Int, StoryAsset> {
             snapshot.appendItems(items, toSection: i)
         }
 
-        // Note: When animating cells, for some reason individual cells are not redrawn
-        // (i.e. cellForRow is not being called). Needs further exploration to figure out why.
+        // Note: When animating cells, for some reason individual cells are not
+        // redrawn, nor are section titles. (i.e. cellForRow is not being called).
+        // Needs further exploration to figure out why.
         // Also, when animating it makes reording look a little weird.
-        // For these reasons we'll disable animating when sorting or not in a window.
-        let shouldAnimate = tableView?.window != nil && tableView?.isEditing == false
-        apply(snapshot, animatingDifferences: shouldAnimate, completion: nil)
+        // For these reasons we'll disable animating.
+        apply(snapshot, animatingDifferences: false, completion: nil)
     }
 
     // MARK: - Overrides for cell deletion behaviors

--- a/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
+++ b/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
@@ -251,7 +251,6 @@
         <relationship name="site" maxCount="1" deletionRule="Nullify" destinationEntity="Site" inverseName="statuses" inverseEntity="Site"/>
     </entity>
     <entity name="StoryAsset" representedClassName="StoryAsset" syncable="YES">
-        <attribute name="assetTypeValue" attributeType="String"/>
         <attribute name="bookmark" optional="YES" attributeType="Binary"/>
         <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lastSync" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -260,6 +259,7 @@
         <attribute name="order" attributeType="Integer 16" defaultValueString="-1" usesScalarValueType="YES"/>
         <attribute name="sorted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="type" attributeType="String"/>
         <attribute name="uuid" attributeType="UUID" usesScalarValueType="NO"/>
         <relationship name="folder" maxCount="1" deletionRule="Nullify" destinationEntity="StoryFolder" inverseName="assets" inverseEntity="StoryFolder"/>
     </entity>

--- a/Newspack/Newspack/Models/StoryAsset+CoreDataProperties.swift
+++ b/Newspack/Newspack/Models/StoryAsset+CoreDataProperties.swift
@@ -10,14 +10,14 @@ extension StoryAsset {
 
     var assetType: StoryAssetType {
         get {
-            return StoryAssetType(rawValue: assetTypeValue)!
+            return StoryAssetType(rawValue: type)!
         }
         set {
-            assetTypeValue = newValue.rawValue
+            type = newValue.rawValue
         }
     }
 
-    @NSManaged private var assetTypeValue: String!
+    @NSManaged private var type: String!
     @NSManaged public var bookmark: Data? // Text notes do not have local files. RemoteMedia may not have local files.
     @NSManaged public var name: String!
     @NSManaged public var uuid: UUID!

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -11,7 +11,7 @@ class AssetStore: Store {
     /// Defines a SortOrganizer and its associated SortRules.
     lazy private(set) var sortOrganizer: SortOrganizer = {
         let typeRules: [SortRule] = [
-            SortRule(field: "assetTypeValue", displayName: NSLocalizedString("Type", comment: "Noun. The type or category of something."), ascending: false),
+            SortRule(field: "type", displayName: NSLocalizedString("Type", comment: "Noun. The type or category of something."), ascending: false),
             SortRule(field: "date", displayName: NSLocalizedString("Date", comment: "Noun. The date something was created."), ascending: true)
         ]
         let typeSort = SortMode(defaultsKey: "AssetSortModeType",


### PR DESCRIPTION
In this PR we're doing a little housekeeping. We're renaming the StoryAsset model's `assetTypeValue` property to just `type` to be a little neater. The asset controller also disables its update animation behavior completely as section titles weren't updating as they should. :(  

This change edits the existing model revision so a clean install is necessary.

To test: 
- Perform a clean install. 
- Confirm unit tests pass. 
- View the Assets and do a quick smoke test to confirm sorting still works.

@jleandroperez can I trouble you with a quick peek at this one? 