### PR TITLE
Issues/event wrangling

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		E68B2A0323048E510021283C /* EditorAttachmentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68B2A0223048E510021283C /* EditorAttachmentDelegate.swift */; };
 		E68BA80C2347BAA300AB60F9 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68BA80B2347BAA300AB60F9 /* Environment.swift */; };
 		E690D57223722BB700676B1D /* PhotoLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E690D57123722BB700676B1D /* PhotoLibraryViewController.swift */; };
+		E692CA9F24CA2E6D008FB96B /* EventMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E692CA9E24CA2E6D008FB96B /* EventMonitor.swift */; };
 		E695A7E6244FD686007B29BB /* StoryFolder+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = E695A7E2244FD686007B29BB /* StoryFolder+CoreDataProperties.swift */; };
 		E695A7E7244FD686007B29BB /* StoryAsset+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = E695A7E3244FD686007B29BB /* StoryAsset+CoreDataProperties.swift */; };
 		E695A7E8244FD686007B29BB /* StoryFolder+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = E695A7E4244FD686007B29BB /* StoryFolder+CoreDataClass.swift */; };
@@ -422,6 +423,7 @@
 		E68B2A0223048E510021283C /* EditorAttachmentDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorAttachmentDelegate.swift; sourceTree = "<group>"; };
 		E68BA80B2347BAA300AB60F9 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		E690D57123722BB700676B1D /* PhotoLibraryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibraryViewController.swift; sourceTree = "<group>"; };
+		E692CA9E24CA2E6D008FB96B /* EventMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMonitor.swift; sourceTree = "<group>"; };
 		E695A7E2244FD686007B29BB /* StoryFolder+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StoryFolder+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		E695A7E3244FD686007B29BB /* StoryAsset+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StoryAsset+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		E695A7E4244FD686007B29BB /* StoryFolder+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StoryFolder+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -667,6 +669,7 @@
 			children = (
 				E6138FD12211FE86004E5B91 /* AppDelegate.swift */,
 				E67F56D42230914800BFD38B /* CoreDataManager.swift */,
+				E692CA9E24CA2E6D008FB96B /* EventMonitor.swift */,
 				E6241B95224EC8CD00B578F5 /* SessionManager.swift */,
 				E61BBD6722FA0470008A6D4C /* StartupHelper.swift */,
 				E6034B1322529414007DB6DD /* UserAgent.swift */,
@@ -1461,6 +1464,7 @@
 				E6DF5575242E7139007DDC47 /* FolderManager.swift in Sources */,
 				E6D44DF1234BDBA000B51438 /* MediaApiService.swift in Sources */,
 				E66CCA0C2303527C00F1CA59 /* Media+CoreDataClass.swift in Sources */,
+				E692CA9F24CA2E6D008FB96B /* EventMonitor.swift in Sources */,
 				E677AAED24B4EED9000FAA3D /* AssetAction.swift in Sources */,
 				E604EE4724C76FAD0015D284 /* CircularImageView.swift in Sources */,
 				E62A6BA424C6198300013092 /* MenuViewController.swift in Sources */,

--- a/Newspack/Newspack/Controllers/AboutViewController.swift
+++ b/Newspack/Newspack/Controllers/AboutViewController.swift
@@ -153,23 +153,28 @@ extension AboutViewController {
 
     func showNewspack() {
         displayWebPage(url: URL(string: "https://newspack.pub/"))
+        Notification.send(.newspackSiteTapped)
     }
 
     func showPrivacy() {
         displayWebPage(url: URL(string: "https://automattic.com/privacy/"))
+        Notification.send(.privacyTapped)
     }
 
     func showTerms() {
         displayWebPage(url: URL(string: "https://wordpress.com/tos/"))
+        Notification.send(.termsTapped)
     }
 
     func showSource() {
         displayWebPage(url: URL(string: "https://github.com/Automattic/newspack-ios"))
+        Notification.send(.sourceTapped)
     }
 
     func showAcknowledgements() {
         let url = Bundle.main.url(forResource: "acknowledgements", withExtension: "htm")
         displayWebPage(url: url)
+        Notification.send(.acknowledgementsTapped)
     }
 
     func displayWebPage(url: URL?) {
@@ -193,4 +198,12 @@ struct AboutSection {
 struct AboutRow {
     let title: String
     let callback: (() -> Void)?
+}
+
+extension Notification.Name {
+    static let newspackSiteTapped = Notification.Name(rawValue: "newspack_site_tapped")
+    static let privacyTapped = Notification.Name(rawValue: "privacy_tapped")
+    static let termsTapped = Notification.Name(rawValue: "terms_tapped")
+    static let sourceTapped = Notification.Name(rawValue: "source_tapped")
+    static let acknowledgementsTapped = Notification.Name(rawValue: "acknowledgements_tapped")
 }

--- a/Newspack/Newspack/Controllers/MainNavController.swift
+++ b/Newspack/Newspack/Controllers/MainNavController.swift
@@ -36,6 +36,7 @@ final class MainNavController: UINavigationController {
         let navController = UINavigationController(rootViewController: folderController)
 
         let controller = SidebarContainerViewController(mainViewController: navController, sidebarViewController: menuController)
+        controller.delegate = self
         controller.view.backgroundColor = .basicBackground
         controller.modalTransitionStyle = .crossDissolve
         setViewControllers([controller], animated: true)
@@ -113,4 +114,35 @@ extension MainNavController: UINavigationControllerDelegate {
         return FadeTransitionController(hideNavigationBar: toVC is InitialViewController)
     }
 
+}
+
+// MARK: - SidebarContainer Delegate
+
+extension MainNavController: SidebarContainerDelegate {
+
+    func containerShouldShowSidebar(container: SidebarContainerViewController) -> Bool {
+        return true
+    }
+
+    func containerWillShowSidebar(container: SidebarContainerViewController) {
+        // No op
+    }
+
+    func containerDidShowSidebar(container: SidebarContainerViewController) {
+        Notification.send(.sidebarOpened)
+    }
+
+    func containerWillHideSidebar(container: SidebarContainerViewController) {
+        // No op
+    }
+
+    func containerDidHideSidebar(container: SidebarContainerViewController) {
+        Notification.send(.sidebarClosed)
+    }
+
+}
+
+extension Notification.Name {
+    static let sidebarOpened = Notification.Name(rawValue: "sidebar_opened")
+    static let sidebarClosed = Notification.Name(rawValue: "sidebar_closed")
 }

--- a/Newspack/Newspack/Controllers/MenuViewController.swift
+++ b/Newspack/Newspack/Controllers/MenuViewController.swift
@@ -175,16 +175,23 @@ extension MenuDataSource {
         }
         let action = AccountAction.removeAccount(uuid: account.uuid)
         SessionManager.shared.sessionDispatcher.dispatch(action)
+        Notification.send(.logoutTapped)
     }
 
     func showAbout() {
         let controller = MainStoryboard.instantiateViewController(withIdentifier: .about)
         let navController = UINavigationController(rootViewController: controller)
         presenter?.present(navController, animated: true, completion: nil)
+        Notification.send(.aboutTapped)
     }
 
     func selectSite(uuid: UUID) {
         // For now, we only support a single site, so just toggle closed the menu.
         NotificationCenter.default.post(name: SidebarContainerViewController.toggleSidebarNotification, object: nil)
     }
+}
+
+extension Notification.Name {
+    static let logoutTapped = Notification.Name(rawValue: "logout_tapped")
+    static let aboutTapped = Notification.Name(rawValue: "about_tapped")
 }

--- a/Newspack/Newspack/System/AppDelegate.swift
+++ b/Newspack/Newspack/System/AppDelegate.swift
@@ -3,6 +3,11 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    /// Convenience to make it a little easier to reference the AppDelegate.
+    static var shared: AppDelegate {
+        UIApplication.shared.delegate as! AppDelegate
+    }
+
     // We want a single instance of the Reconciler for the lifecycle of the app.
     // We'll instantiate it here for convenience.
     private let reconciler = Reconciler()
@@ -16,6 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        configureEventMonitor()
         configureLogger()
         // Configure the window which should call makeKeyAndVisible.
         // Necessary in order to present the authentication flow.
@@ -81,6 +87,10 @@ extension AppDelegate {
 
     private func configureLogger() {
         Log.setup()
+    }
+
+    private func configureEventMonitor() {
+        EventMonitor.shared.registerObject(object: self)
     }
 
 }

--- a/Newspack/Newspack/System/EventMonitor.swift
+++ b/Newspack/Newspack/System/EventMonitor.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// EventMonitor provides a proxy mechanism for analytics tracking.
+/// Significant events may be dispatched via NSNotifications vs some custom type
+/// and will be picked up by the EventMonitor. A lightweight extenion to Notification
+/// provides a convenience method for dispatching notifications that the monitor
+/// will detect.
+///
+class EventMonitor: NSObject {
+
+    static let shared = EventMonitor()
+
+    fileprivate var object: AnyObject? {
+        didSet {
+            if let _ = oldValue {
+                NotificationCenter.default.removeObserver(self)
+            }
+            if let _ = object {
+                NotificationCenter.default.addObserver(self, selector: #selector(handle(notification:)), name: nil, object: object)
+            }
+        }
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    override init() {
+        super.init()
+        NotificationCenter.default.addObserver(self, selector: #selector(handle(notification:)), name: nil, object: self)
+    }
+
+    /// Register an object in order to subscribe to its notifiations. This must
+    /// be called to begin listening.  Passing nil will stop observing notifications.
+    ///
+    /// - Parameter object: The object to observe.
+    ///
+    func registerObject(object: AnyObject?) {
+        self.object = object
+    }
+
+    /// Handles notifications referencing the subscribed object.
+    ///
+    /// - Parameter notification: The notification.
+    ///
+    @objc private func handle(notification: Notification) {
+        // For now just log the notification name. When we're ready to wire up
+        // analytics we'll revisit.
+        LogInfo(message: notification.name.rawValue)
+    }
+
+}
+
+/// A lightweight extension providing a convenience method to dispatch notifications
+/// that the EventMonitor will handle.
+///
+extension Notification {
+
+    /// Dispatch a notification for the specific type, and optional userInfo
+    /// dictionary that will be detected by the EventMonitor.
+    ///
+    /// - Parameters:
+    ///   - name: The Notification.Name to dispatch.
+    ///   - info: An optional userInfo dictionary.
+    ///
+    static func send(_ name: Notification.Name, info: [AnyHashable: Any]? = nil) {
+        NotificationCenter.default.post(name: name, object: EventMonitor.shared.object, userInfo: info)
+    }
+
+}


### PR DESCRIPTION
This PR introduces the foundation for future analytics support.

Rather than tightly couple an instance of a tracker to various controllers (and other things), this leverages `Notification`s and a centralized `EventMonitor` to watch for interesting events.  An object is registered with the `EventMonitor`, and then any `Notification` referencing this object is detected by the `EventMonitor`.  An extension on `Notification` provides a convenience method for posting a `Notification` using the registered object.  Individual controllers (or other objects) are responsible for defining their own Notification.Name extensions rather than maintaining an centralized enumeration of supported events.  It is expected that the appropriate event naming convention will be followed for new `Notification.Name`s, i.e. [source]_[context]_[optional subcontext]_[action]_[optional qualifier].

This arrangement provides a single touch point for integrating an analytics tracker, and the `Notification` extension could easily be updated to just be a convenience pass through to `NotificationCenter.default.post` should we ever decide to remove the `EventMonitor`.

A (far) future PR will integrate a tracker.  At that time EventMonitor will be updated to do more than just log event names.

To test: 
- Launch the app.
- Open the side bar.
- View the About screen.
- View some of the items on the About screen. 
- Confirm you see events logged to the console.

@jleandroperez Would you mind a quick peek at this one? 
