### PR TITLE
Issues/83 folders ui

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		E66CCA1C2303527D00F1CA59 /* Revision+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66CCA002303527C00F1CA59 /* Revision+CoreDataClass.swift */; };
 		E66CCA1D2303527D00F1CA59 /* AccountDetails+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66CCA012303527C00F1CA59 /* AccountDetails+CoreDataClass.swift */; };
 		E66CCA1E2303527D00F1CA59 /* Status+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66CCA022303527C00F1CA59 /* Status+CoreDataClass.swift */; };
+		E66E85A124CFA1010056E8AB /* StoryNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66E85A024CFA1010056E8AB /* StoryNavigationController.swift */; };
 		E66E8A05223596FE00E8DD88 /* CoreDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66E8A04223596FE00E8DD88 /* CoreDataManagerTests.swift */; };
 		E66E8A072235979500E8DD88 /* BaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66E8A062235979500E8DD88 /* BaseTest.swift */; };
 		E66E8A1D2235CAC000E8DD88 /* AuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66E8A1C2235CAC000E8DD88 /* AuthenticationManager.swift */; };
@@ -398,6 +399,7 @@
 		E66CCA002303527C00F1CA59 /* Revision+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Revision+CoreDataClass.swift"; sourceTree = "<group>"; };
 		E66CCA012303527C00F1CA59 /* AccountDetails+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AccountDetails+CoreDataClass.swift"; sourceTree = "<group>"; };
 		E66CCA022303527C00F1CA59 /* Status+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Status+CoreDataClass.swift"; sourceTree = "<group>"; };
+		E66E85A024CFA1010056E8AB /* StoryNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryNavigationController.swift; sourceTree = "<group>"; };
 		E66E8A04223596FE00E8DD88 /* CoreDataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManagerTests.swift; sourceTree = "<group>"; };
 		E66E8A062235979500E8DD88 /* BaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTest.swift; sourceTree = "<group>"; };
 		E66E8A0822359FE200E8DD88 /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = usr/lib/libxml2.tbd; sourceTree = SDKROOT; };
@@ -793,6 +795,7 @@
 				E604EE4D24C77BD10015D284 /* AboutViewController.swift */,
 				E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */,
 				E68689BF243C080400B7E363 /* FoldersViewController.swift */,
+				E66E85A024CFA1010056E8AB /* StoryNavigationController.swift */,
 				E6871F1A22C3FDE7008D3D46 /* PostListViewController.swift */,
 				E62982292303667E00E8CEC7 /* EditorViewController.swift */,
 				E68B2A0023048E050021283C /* EditorAttachmentImageProvider.swift */,
@@ -1458,6 +1461,7 @@
 				E63F3F3C236350BE00DB760E /* MediaTypeDiscerner.swift in Sources */,
 				E602E68F22C1637800795CBA /* PostApiActions.swift in Sources */,
 				E695A7E7244FD686007B29BB /* StoryAsset+CoreDataProperties.swift in Sources */,
+				E66E85A124CFA1010056E8AB /* StoryNavigationController.swift in Sources */,
 				E6B7728824BCD8DA00CA8AB8 /* SortOrganizer.swift in Sources */,
 				E641A66322A7584A008BBD85 /* AccountDetailsStore.swift in Sources */,
 				E636C262234FBE6800564B63 /* RemoteMedia.swift in Sources */,

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -2,9 +2,18 @@ import UIKit
 import CoreData
 import WordPressFlux
 
-class AssetsViewController: UITableViewController {
+class AssetsViewController: UIViewController, UITableViewDelegate {
 
     @IBOutlet var sortControl: UISegmentedControl!
+    @IBOutlet var folderLabel: UILabel!
+    @IBOutlet var syncButton: UIBarButtonItem!
+    @IBOutlet var editButton: UIBarButtonItem!
+    @IBOutlet var tableView: UITableView!
+
+    @IBOutlet var textNoteButton: UIBarButtonItem!
+    @IBOutlet var photoButton: UIBarButtonItem!
+    @IBOutlet var videoButton: UIBarButtonItem!
+    @IBOutlet var audioNoteButton: UIBarButtonItem!
 
     var dataSource: AssetDataSource!
 
@@ -13,13 +22,6 @@ class AssetsViewController: UITableViewController {
 
         configureDataSource()
         configureSortControl()
-
-        // Temporary measure. The UI will change so right now this doesn't need to be pretty.
-        let headerView = tableView.tableHeaderView!
-        var frame = headerView.frame
-        frame.size.height = 44.0
-        headerView.frame = frame
-        tableView.tableHeaderView = headerView
     }
 
 }
@@ -27,11 +29,6 @@ class AssetsViewController: UITableViewController {
 // MARK: - Actions
 
 extension AssetsViewController {
-
-    @IBAction func handleAddTapped(sender: Any) {
-        let action = AssetAction.createAssetFor(text: "New Text Note")
-        SessionManager.shared.sessionDispatcher.dispatch(action)
-    }
 
     @IBAction func handleSortChanged(sender: Any) {
         let action = AssetAction.sortMode(index: sortControl.selectedSegmentIndex)
@@ -52,10 +49,30 @@ extension AssetsViewController {
 
 }
 
+extension AssetsViewController {
+
+    @IBAction func handleTextNoteButton(sender: UIBarButtonItem) {
+        LogDebug(message: "tapped \(sender.description)")
+    }
+
+    @IBAction func handlePhotoButton(sender: UIBarButtonItem) {
+        LogDebug(message: "tapped \(sender.description)")
+    }
+
+    @IBAction func handleVideoButton(sender: UIBarButtonItem) {
+        LogDebug(message: "tapped \(sender.description)")
+    }
+
+    @IBAction func handleAudioNoteButton(sender: UIBarButtonItem) {
+        LogDebug(message: "tapped \(sender.description)")
+    }
+
+}
+
 // MARK: - TableViewDelegate methods
 extension AssetsViewController {
 
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectSelectedRowWithAnimation(true)
         guard let asset = dataSource.object(at: indexPath) else {
             return
@@ -66,15 +83,15 @@ extension AssetsViewController {
         CoreDataManager.shared.saveContext(context: asset.managedObjectContext!)
     }
 
-    override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+    func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
         return tableView.isEditing ? .none : .delete
     }
 
-    override func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
+    func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
         return tableView.isEditing ? false : true
     }
 
-    override func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
+    func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
         // No droppiing into the unsorted section, so just return the source indexpath.
         if proposedDestinationIndexPath.section == 1 {
             return sourceIndexPath

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -78,7 +78,7 @@ class AssetsViewController: UIViewController, UITableViewDelegate {
 
 extension AssetsViewController {
 
-    @IBAction func handleSortChanged(sender: Any) {
+    @IBAction func handleSortChanged(sender: UISegmentedControl) {
         let action = AssetAction.sortMode(index: sortControl.selectedSegmentIndex)
         SessionManager.shared.sessionDispatcher.dispatch(action)
 
@@ -87,7 +87,7 @@ extension AssetsViewController {
         dataSource.refresh()
     }
 
-    @IBAction func handleToggleEditing(sender: Any) {
+    @IBAction func handleToggleEditing(sender: UIBarButtonItem) {
         if tableView.isEditing {
             editButton.title = Constants.edit
             tableView.setEditing(false, animated: true)
@@ -95,6 +95,10 @@ extension AssetsViewController {
             editButton.title = Constants.done
             tableView.setEditing(true, animated: true)
         }
+    }
+
+    @IBAction func handleSyncTapped(sender: UIBarButtonItem) {
+        LogDebug(message: "tapped sync")
     }
 
 }

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -4,6 +4,11 @@ import WordPressFlux
 
 class AssetsViewController: UIViewController, UITableViewDelegate {
 
+    struct Constants {
+        static let edit = NSLocalizedString("Edit", comment: "Verb. Title of a control to enable editing.")
+        static let done = NSLocalizedString("Done", comment: "Verb (past participle). Title of a control to disable editing when finished.")
+    }
+
     @IBOutlet var sortControl: UISegmentedControl!
     @IBOutlet var syncButton: UIBarButtonItem!
     @IBOutlet var editButton: UIBarButtonItem!
@@ -51,6 +56,7 @@ class AssetsViewController: UIViewController, UITableViewDelegate {
         }
         navigationItem.title = currentStory.name
         syncButton.image = .gridicon(.sync)
+        editButton.title = Constants.edit
     }
 
     func configureToolbar() {
@@ -83,10 +89,10 @@ extension AssetsViewController {
 
     @IBAction func handleToggleEditing(sender: Any) {
         if tableView.isEditing {
-            editButton.title = NSLocalizedString("Edit", comment: "Verb. Title of a control to enable editing.")
+            editButton.title = Constants.edit
             tableView.setEditing(false, animated: true)
         } else if StoreContainer.shared.assetStore.canSortAssets {
-            editButton.title = NSLocalizedString("Done", comment: "Verb (past participle). Title of a control to disable editing when finished.")
+            editButton.title = Constants.done
             tableView.setEditing(true, animated: true)
         }
     }

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -5,7 +5,6 @@ import WordPressFlux
 class AssetsViewController: UIViewController, UITableViewDelegate {
 
     @IBOutlet var sortControl: UISegmentedControl!
-    @IBOutlet var folderLabel: UILabel!
     @IBOutlet var syncButton: UIBarButtonItem!
     @IBOutlet var editButton: UIBarButtonItem!
     @IBOutlet var tableView: UITableView!
@@ -22,6 +21,49 @@ class AssetsViewController: UIViewController, UITableViewDelegate {
 
         configureDataSource()
         configureSortControl()
+        configureNavbar()
+        configureToolbar()
+        configureStyle()
+        tableView.tableFooterView = UIView()
+    }
+
+    func configureDataSource() {
+        dataSource = AssetDataSource(tableView: tableView, cellProvider: { [weak self] (tableView, indexPath, storyAsset) -> UITableViewCell? in
+            return self?.cellFor(tableView: tableView, indexPath: indexPath, storyAsset: storyAsset)
+        })
+        dataSource.update()
+    }
+
+    func configureSortControl() {
+        let assetStore = StoreContainer.shared.assetStore
+
+        sortControl.removeAllSegments()
+        for (index, mode) in assetStore.sortOrganizer.modes.enumerated() {
+            sortControl.insertSegment(withTitle: mode.title, at: index, animated: false)
+        }
+
+        sortControl.selectedSegmentIndex = assetStore.sortOrganizer.selectedIndex
+    }
+
+    func configureNavbar() {
+        guard let currentStory = StoreContainer.shared.folderStore.currentStoryFolder else {
+            return
+        }
+        navigationItem.title = currentStory.name
+        syncButton.image = .gridicon(.sync)
+    }
+
+    func configureToolbar() {
+        textNoteButton.image = .gridicon(.posts)
+        photoButton.image = .gridicon(.imageMultiple)
+        videoButton.image = .gridicon(.video)
+        audioNoteButton.image = .gridicon(.microphone)
+
+        navigationController?.setToolbarHidden(false, animated: false)
+    }
+
+    func configureStyle() {
+        Appearance.style(view: view, tableView: tableView)
     }
 
 }
@@ -52,7 +94,9 @@ extension AssetsViewController {
 extension AssetsViewController {
 
     @IBAction func handleTextNoteButton(sender: UIBarButtonItem) {
-        LogDebug(message: "tapped \(sender.description)")
+        // Temporary action just for testing.
+        let action = AssetAction.createAssetFor(text: "New Text Note")
+        SessionManager.shared.sessionDispatcher.dispatch(action)
     }
 
     @IBAction func handlePhotoButton(sender: UIBarButtonItem) {
@@ -103,17 +147,6 @@ extension AssetsViewController {
 // MARK: - DataSource related methods
 extension AssetsViewController {
 
-    func configureSortControl() {
-        let assetStore = StoreContainer.shared.assetStore
-
-        sortControl.removeAllSegments()
-        for (index, mode) in assetStore.sortOrganizer.modes.enumerated() {
-            sortControl.insertSegment(withTitle: mode.title, at: index, animated: false)
-        }
-
-        sortControl.selectedSegmentIndex = assetStore.sortOrganizer.selectedIndex
-    }
-
     func cellFor(tableView: UITableView, indexPath: IndexPath, storyAsset: StoryAsset) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "AssetCell", for: indexPath)
         cell.textLabel?.text = storyAsset.name + " " + String(storyAsset.order)
@@ -121,13 +154,6 @@ extension AssetsViewController {
         cell.accessoryType = .disclosureIndicator
 
         return cell
-    }
-
-    func configureDataSource() {
-        dataSource = AssetDataSource(tableView: tableView, cellProvider: { [weak self] (tableView, indexPath, storyAsset) -> UITableViewCell? in
-            return self?.cellFor(tableView: tableView, indexPath: indexPath, storyAsset: storyAsset)
-        })
-        dataSource.update()
     }
 
 }

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -19,7 +19,7 @@ class AssetsViewController: UIViewController, UITableViewDelegate {
     @IBOutlet var videoButton: UIBarButtonItem!
     @IBOutlet var audioNoteButton: UIBarButtonItem!
 
-    var dataSource: AssetDataSource!
+    private var dataSource: AssetDataSource!
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -83,8 +83,10 @@ extension AssetsViewController {
 
     @IBAction func handleToggleEditing(sender: Any) {
         if tableView.isEditing {
+            editButton.title = NSLocalizedString("Edit", comment: "Verb. Title of a control to enable editing.")
             tableView.setEditing(false, animated: true)
         } else if StoreContainer.shared.assetStore.canSortAssets {
+            editButton.title = NSLocalizedString("Done", comment: "Verb (past participle). Title of a control to disable editing when finished.")
             tableView.setEditing(true, animated: true)
         }
     }

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -32,6 +32,12 @@ class AssetsViewController: UIViewController, UITableViewDelegate {
         tableView.tableFooterView = UIView()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        navigationController?.setToolbarHidden(false, animated: false)
+    }
+
     func configureDataSource() {
         dataSource = AssetDataSource(tableView: tableView, cellProvider: { [weak self] (tableView, indexPath, storyAsset) -> UITableViewCell? in
             return self?.cellFor(tableView: tableView, indexPath: indexPath, storyAsset: storyAsset)
@@ -64,8 +70,6 @@ class AssetsViewController: UIViewController, UITableViewDelegate {
         photoButton.image = .gridicon(.imageMultiple)
         videoButton.image = .gridicon(.video)
         audioNoteButton.image = .gridicon(.microphone)
-
-        navigationController?.setToolbarHidden(false, animated: false)
     }
 
     func configureStyle() {

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -164,6 +164,7 @@ extension FoldersViewController {
 
         cell.textLabel?.text = storyFolder.name
         cell.accessoryType = .disclosureIndicator
+        cell.selectedStory = storyFolder.uuid == StoreContainer.shared.folderStore.currentStoryFolderID
 
         return cell
     }
@@ -174,6 +175,17 @@ extension FoldersViewController {
 
 class FolderCell: UITableViewCell {
 
+    var selectedStory: Bool = false {
+        didSet {
+            backgroundColor = selectedStory ? .cellBackgroundSelected : .cellBackground
+        }
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        selectedStory = false
+    }
 }
 
 // MARK: - FolderDataSource

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -174,7 +174,7 @@ class FolderCell: UITableViewCell {
 
     var selectedStory: Bool = false {
         didSet {
-            backgroundColor = selectedStory ? .cellBackgroundSelected : .cellBackground
+            textLabel?.textColor = selectedStory ? .textLink : .text
         }
     }
 

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -58,6 +58,7 @@ class FoldersViewController: UIViewController, UITableViewDelegate {
     }
 
     func configureNavbar() {
+        navigationItem.title = NSLocalizedString("Stories", comment: "Noun. The title of the list of stories the reporter is working on.")
         navigationItem.leftBarButtonItem?.image = .gridicon(.menu)
         navigationItem.rightBarButtonItem?.image = .gridicon(.plus)
     }
@@ -157,7 +158,7 @@ extension FoldersViewController {
 extension FoldersViewController {
 
     func cellFor(tableView: UITableView, indexPath: IndexPath, storyFolder: StoryFolder) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "FolderCell", for: indexPath) as? FolderCell else {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: FolderCell.reuseIdentifier, for: indexPath) as? FolderCell else {
             fatalError("Cannot create new cell")
         }
         Appearance.style(cell: cell)

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -3,20 +3,6 @@ import CoreData
 import Gridicons
 import WordPressFlux
 
-extension FoldersViewController: UIViewControllerRestoration {
-    static func viewController(withRestorationIdentifierPath identifierComponents: [String], coder: NSCoder) -> UIViewController? {
-        guard
-            let mainNav = AppDelegate.shared.window?.rootViewController as? MainNavController,
-            let sideBar = mainNav.viewControllers.first as? SidebarContainerViewController,
-            let storyNav = sideBar.mainViewController as? StoryNavigationController,
-            let folderController = storyNav.viewControllers.first as? AssetsViewController
-        else {
-            return nil
-        }
-        return folderController
-    }
-}
-
 class FoldersViewController: UIViewController, UITableViewDelegate {
 
     @IBOutlet var sortControl: UISegmentedControl!

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -27,6 +27,12 @@ class FoldersViewController: UIViewController, UITableViewDelegate {
         tableView.tableFooterView = UIView()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        navigationController?.setToolbarHidden(false, animated: false)
+    }
+
     func configureDataSource() {
         dataSource = FolderDataSource(tableView: tableView, cellProvider: { [weak self] (tableView, indexPath, storyFolder) -> UITableViewCell? in
             return self?.cellFor(tableView: tableView, indexPath: indexPath, storyFolder: storyFolder)
@@ -64,8 +70,6 @@ class FoldersViewController: UIViewController, UITableViewDelegate {
         photoButton.image = .gridicon(.imageMultiple)
         videoButton.image = .gridicon(.video)
         audioNoteButton.image = .gridicon(.microphone)
-
-        navigationController?.setToolbarHidden(false, animated: false)
     }
 
     func configureStyle() {

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -2,10 +2,16 @@ import UIKit
 import CoreData
 import WordPressFlux
 
-class FoldersViewController: UITableViewController {
+class FoldersViewController: UIViewController, UITableViewDelegate {
 
-    @IBOutlet var sortField: UISegmentedControl!
-    @IBOutlet var sortDirection: UISegmentedControl!
+    @IBOutlet var sortControl: UISegmentedControl!
+    @IBOutlet var directionButton: UIButton!
+    @IBOutlet var tableView: UITableView!
+
+    @IBOutlet var textNoteButton: UIBarButtonItem!
+    @IBOutlet var photoButton: UIBarButtonItem!
+    @IBOutlet var videoButton: UIBarButtonItem!
+    @IBOutlet var audioNoteButton: UIBarButtonItem!
 
     var dataSource: FolderDataSource!
 
@@ -18,17 +24,11 @@ class FoldersViewController: UITableViewController {
 
         configureDataSource()
         configureSortControl()
-
-        // Temporary measure. The UI will change so right now this doesn't need to be pretty.
-        let headerView = tableView.tableHeaderView!
-        var frame = headerView.frame
-        frame.size.height = 44.0
-        headerView.frame = frame
-        tableView.tableHeaderView = headerView
     }
 }
 
 // MARK: - Actions and Handlers
+
 extension FoldersViewController {
 
     @IBAction func handleMenuButtonTapped(sender: Any) {
@@ -36,10 +36,10 @@ extension FoldersViewController {
     }
 
     @IBAction func handleSortChanged(sender: Any) {
-        let field = sortField.titleForSegment(at: sortField.selectedSegmentIndex)!.lowercased()
-        let direction = sortDirection.selectedSegmentIndex == 0
+//        let field = sortField.titleForSegment(at: sortField.selectedSegmentIndex)!.lowercased()
+//        let direction = sortDirection.selectedSegmentIndex == 0
 
-        dataSource.sortBy(field: field, ascending: direction)
+//        dataSource.sortBy(field: field, ascending: direction)
     }
 
     @IBAction func handleAddTapped(sender: Any) {
@@ -59,10 +59,31 @@ extension FoldersViewController {
 
 }
 
-// MARK: - TableViewDelegate methods
 extension FoldersViewController {
 
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    @IBAction func handleTextNoteButton(sender: UIBarButtonItem) {
+        LogDebug(message: "tapped \(sender.description)")
+    }
+
+    @IBAction func handlePhotoButton(sender: UIBarButtonItem) {
+        LogDebug(message: "tapped \(sender.description)")
+    }
+
+    @IBAction func handleVideoButton(sender: UIBarButtonItem) {
+        LogDebug(message: "tapped \(sender.description)")
+    }
+
+    @IBAction func handleAudioNoteButton(sender: UIBarButtonItem) {
+        LogDebug(message: "tapped \(sender.description)")
+    }
+
+}
+
+// MARK: - TableViewDelegate methods
+
+extension FoldersViewController {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let storyFolder = dataSource.resultsController.fetchedObjects?[indexPath.row] else {
             return
         }
@@ -83,17 +104,17 @@ extension FoldersViewController {
             fatalError("Cannot create new cell")
         }
 
-        cell.textField.text = storyFolder.name
-        cell.textChangedHandler = { text, aCell in
-            // NOTE: Get the index path from the passed cell to ensure we're not
-            // capturing the value of cellFor's passed IndexPath. This can lead to
-            // referencing an incoreect index path leading to the wrong folder being renamed
-            // or an out of bounds error.
-            guard let indexPath = tableView.indexPath(for: aCell) else {
-                return
-            }
-            self.handleFolderNameChanged(indexPath: indexPath, newName: text)
-        }
+//        cell.textField.text = storyFolder.name
+//        cell.textChangedHandler = { text, aCell in
+//            // NOTE: Get the index path from the passed cell to ensure we're not
+//            // capturing the value of cellFor's passed IndexPath. This can lead to
+//            // referencing an incoreect index path leading to the wrong folder being renamed
+//            // or an out of bounds error.
+//            guard let indexPath = tableView.indexPath(for: aCell) else {
+//                return
+//            }
+//            self.handleFolderNameChanged(indexPath: indexPath, newName: text)
+//        }
         cell.accessoryType = storyFolder.uuid == StoreContainer.shared.folderStore.currentStoryFolderID ? .detailDisclosureButton : .disclosureIndicator
 
         return cell
@@ -110,32 +131,32 @@ extension FoldersViewController {
         guard let rule = StoreContainer.shared.folderStore.sortMode.rules.first else {
             return
         }
-        sortDirection.selectedSegmentIndex = rule.ascending ? 0 : 1
-        let name = sortField.titleForSegment(at: 0)!.lowercased()
-        sortField.selectedSegmentIndex = rule.field == name ? 0 : 1
+//        sortDirection.selectedSegmentIndex = rule.ascending ? 0 : 1
+//        let name = sortField.titleForSegment(at: 0)!.lowercased()
+//        sortField.selectedSegmentIndex = rule.field == name ? 0 : 1
     }
 }
 
 // MARK: - Folder Cell
 class FolderCell: UITableViewCell {
 
-    @IBOutlet var textField: UITextField!
-    var textChangedHandler: ((String?, UITableViewCell) -> Void)?
+//    @IBOutlet var textField: UITextField!
+//    var textChangedHandler: ((String?, UITableViewCell) -> Void)?
 
 }
 
-extension FolderCell: UITextFieldDelegate {
-
-    func textFieldDidEndEditing(_ textField: UITextField) {
-        textChangedHandler?(textField.text, self)
-    }
-
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        textField.resignFirstResponder()
-        return false
-    }
-
-}
+//extension FolderCell: UITextFieldDelegate {
+//
+//    func textFieldDidEndEditing(_ textField: UITextField) {
+//        textChangedHandler?(textField.text, self)
+//    }
+//
+//    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+//        textField.resignFirstResponder()
+//        return false
+//    }
+//
+//}
 
 // MARK: - FolderDataSource
 class FolderDataSource: UITableViewDiffableDataSource<FolderDataSource.Section, StoryFolder> {

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -3,6 +3,20 @@ import CoreData
 import Gridicons
 import WordPressFlux
 
+extension FoldersViewController: UIViewControllerRestoration {
+    static func viewController(withRestorationIdentifierPath identifierComponents: [String], coder: NSCoder) -> UIViewController? {
+        guard
+            let mainNav = AppDelegate.shared.window?.rootViewController as? MainNavController,
+            let sideBar = mainNav.viewControllers.first as? SidebarContainerViewController,
+            let storyNav = sideBar.mainViewController as? StoryNavigationController,
+            let folderController = storyNav.viewControllers.first as? AssetsViewController
+        else {
+            return nil
+        }
+        return folderController
+    }
+}
+
 class FoldersViewController: UIViewController, UITableViewDelegate {
 
     @IBOutlet var sortControl: UISegmentedControl!
@@ -15,10 +29,6 @@ class FoldersViewController: UIViewController, UITableViewDelegate {
     @IBOutlet var audioNoteButton: UIBarButtonItem!
 
     var dataSource: FolderDataSource!
-
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -14,7 +14,7 @@ class FoldersViewController: UIViewController, UITableViewDelegate {
     @IBOutlet var videoButton: UIBarButtonItem!
     @IBOutlet var audioNoteButton: UIBarButtonItem!
 
-    var dataSource: FolderDataSource!
+    private var dataSource: FolderDataSource!
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Newspack/Newspack/Controllers/MainNavController.swift
+++ b/Newspack/Newspack/Controllers/MainNavController.swift
@@ -71,9 +71,9 @@ final class MainNavController: UINavigationController {
 // MARK: - State Restoration
 
 extension MainNavController: UIViewControllerRestoration {
-    static let sidebarControllerIdentifier = String(describing: type(of: SidebarContainerViewController.self))
-    static let storyNavIdentifier = String(describing: type(of: StoryNavigationController.self))
-    static let menuControllerIdentifier = String(describing: type(of: MenuViewController.self))
+    static let sidebarControllerIdentifier = SidebarContainerViewController.classnameWithoutNamespaces
+    static let storyNavIdentifier = StoryNavigationController.classnameWithoutNamespaces
+    static let menuControllerIdentifier = MenuViewController.classnameWithoutNamespaces
 
     static func viewController(withRestorationIdentifierPath identifierComponents: [String], coder: NSCoder) -> UIViewController? {
         guard

--- a/Newspack/Newspack/Controllers/MainNavController.swift
+++ b/Newspack/Newspack/Controllers/MainNavController.swift
@@ -6,9 +6,39 @@ final class MainNavController: UINavigationController {
     var sessionReceipt: Any?
     var authenticationManager: AuthenticationManager?
 
+    private lazy var menuController: MenuViewController = {
+        let controller = MainStoryboard.instantiateViewController(withIdentifier: .menu) as! MenuViewController
+        controller.restorationClass = MainNavController.self
+        controller.restorationIdentifier = MainNavController.menuControllerIdentifier
+        return controller
+    }()
+
+    private lazy var storyNavigationController: StoryNavigationController = {
+        let controller = MainStoryboard.instantiateViewController(withIdentifier: .storyNav) as! StoryNavigationController
+        controller.restorationClass = MainNavController.self
+        controller.restorationIdentifier = MainNavController.storyNavIdentifier
+        return controller
+    }()
+
+    private lazy var sidebarContainerController: SidebarContainerViewController = {
+        let controller = SidebarContainerViewController(mainViewController: storyNavigationController, sidebarViewController: menuController)
+        controller.delegate = self
+        controller.view.backgroundColor = .basicBackground
+        controller.modalTransitionStyle = .crossDissolve
+
+        controller.restorationClass = MainNavController.self
+        controller.restorationIdentifier = MainNavController.sidebarControllerIdentifier
+
+        return controller
+    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        // Call handleSessionChange initially to create the starting view hierarchy.
+        // Important as the intial session is configured before the app has
+        // finished launching.
+        handleSessionChange()
         listenForSessionChanges()
         delegate = self
     }
@@ -31,23 +61,46 @@ final class MainNavController: UINavigationController {
             return
         }
 
-        let menuController = MainStoryboard.instantiateViewController(withIdentifier: .menu)
-        let folderController = MainStoryboard.instantiateViewController(withIdentifier: .folderList)
-        let navController = UINavigationController(rootViewController: folderController)
-
-        let controller = SidebarContainerViewController(mainViewController: navController, sidebarViewController: menuController)
-        controller.delegate = self
-        controller.view.backgroundColor = .basicBackground
-        controller.modalTransitionStyle = .crossDissolve
-        setViewControllers([controller], animated: true)
+        setViewControllers([sidebarContainerController], animated: true)
 
         presentedViewController?.dismiss(animated: true, completion: nil)
     }
+
 }
 
+// MARK: - State Restoration
 
-// Session related
-//
+extension MainNavController: UIViewControllerRestoration {
+    static let sidebarControllerIdentifier = String(describing: type(of: SidebarContainerViewController.self))
+    static let storyNavIdentifier = String(describing: type(of: StoryNavigationController.self))
+    static let menuControllerIdentifier = String(describing: type(of: MenuViewController.self))
+
+    static func viewController(withRestorationIdentifierPath identifierComponents: [String], coder: NSCoder) -> UIViewController? {
+        guard
+            let controller = AppDelegate.shared.window?.rootViewController as? MainNavController,
+            let component = identifierComponents.last
+        else {
+            return nil
+        }
+
+        if component == menuControllerIdentifier {
+            return controller.menuController
+        }
+
+        if component == storyNavIdentifier {
+            return controller.storyNavigationController
+        }
+
+        if component == sidebarControllerIdentifier {
+            return controller.sidebarContainerController
+        }
+
+        return controller
+    }
+}
+
+// MARK: - Session related
+
 extension MainNavController {
 
     func listenForSessionChanges() {
@@ -85,7 +138,7 @@ extension MainNavController {
 
 
 // MARK: - Nav Delegate Related
-//
+
 extension MainNavController: UINavigationControllerDelegate {
 
     func navigationController(_ navigationController: UINavigationController,

--- a/Newspack/Newspack/Controllers/SidebarContainerViewController.swift
+++ b/Newspack/Newspack/Controllers/SidebarContainerViewController.swift
@@ -29,6 +29,8 @@ class SidebarContainerViewController: UIViewController {
         static let sidebarAnimationCompletionMax = CGFloat(0.999)
         static let sidebarAnimationCompletionFactorFull = CGFloat(1.0)
         static let sidebarAnimationCompletionFactorZero = CGFloat(0.0)
+        static let mainControllerEncodeKey = "mainControllerEncodeKey"
+        static let sideControllerEncodeKey = "sideControllerEncodeKey"
     }
 
     private(set) var sidebarViewController: UIViewController
@@ -144,6 +146,9 @@ class SidebarContainerViewController: UIViewController {
         attachCaptureView()
         attachSidebarView()
 
+        mainViewController.didMove(toParent: self)
+        sidebarViewController.didMove(toParent: self)
+
         NotificationCenter.default.addObserver(self, selector: #selector(handleToggleSidebarNotification(notification:)), name: SidebarContainerViewController.toggleSidebarNotification, object: nil)
     }
 
@@ -192,6 +197,12 @@ class SidebarContainerViewController: UIViewController {
     @objc
     func handleToggleSidebarNotification(notification: Notification) {
         toggleSidebar()
+    }
+
+    override func encodeRestorableState(with coder: NSCoder) {
+        super.encodeRestorableState(with: coder)
+        coder.encode(mainViewController, forKey: Constants.mainControllerEncodeKey)
+        coder.encode(sidebarViewController, forKey: Constants.sideControllerEncodeKey)
     }
 }
 

--- a/Newspack/Newspack/Controllers/StoryNavigationController.swift
+++ b/Newspack/Newspack/Controllers/StoryNavigationController.swift
@@ -1,0 +1,8 @@
+import Foundation
+import UIKit
+
+/// Simple subclass to facilitate navigation and state restoration.
+///
+class StoryNavigationController: UINavigationController {
+
+}

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -15,12 +15,18 @@ class FolderStore: Store {
     /// before it is used.
     private(set) var currentStoryFolderID = UUID()
 
-    lazy private(set) var sortMode: SortMode = {
-        let field = "date"
-        let rules: [SortRule] = [
-            SortRule(field: field, displayName: displayNameForField(field: field), ascending: false)
+    lazy var sortRules: [SortRule] = {
+        let dateField = "date"
+        let nameField = "name"
+        return [
+            SortRule(field: dateField, displayName: displayNameForField(field: dateField), ascending: true),
+            SortRule(field: nameField, displayName: displayNameForField(field: nameField), ascending: true)
         ]
-        return SortMode(defaultsKey: "FolderStoreSortMode", title: "", rules: rules, hasSections: false, resolver: nil)
+    }()
+
+    lazy private(set) var sortMode: SortMode = {
+        let rule = sortRules.first!
+        return SortMode(defaultsKey: "FolderStoreSortMode", title: "", rules: [rule], hasSections: false, resolver: nil)
     }()
 
     /// A convenience getter to get the current story folder.

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -155,7 +155,7 @@
             </objects>
             <point key="canvasLocation" x="292" y="-1169.865067466267"/>
         </scene>
-        <!--Folders-->
+        <!--Stories-->
         <scene sceneID="NTU-fz-MXb">
             <objects>
                 <viewController storyboardIdentifier="FoldersViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="HoW-Ma-W9C" customClass="FoldersViewController" customModule="Newspack" customModuleProvider="target" sceneMemberID="viewController">
@@ -266,7 +266,7 @@
                             </connections>
                         </barButtonItem>
                     </toolbarItems>
-                    <navigationItem key="navigationItem" title="Folders" id="kt5-gi-Yct">
+                    <navigationItem key="navigationItem" title="Stories" id="kt5-gi-Yct">
                         <barButtonItem key="leftBarButtonItem" title="Item" image="menu" id="Rg0-or-Kc9">
                             <connections>
                                 <action selector="handleMenuButtonTappedWithSender:" destination="HoW-Ma-W9C" id="xkh-cd-C86"/>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -303,31 +303,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4KS-uW-XyS">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="88"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6HK-ka-tl4">
-                                        <rect key="frame" x="8" y="0.0" width="359" height="44"/>
-                                        <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="folder" translatesAutoresizingMaskIntoConstraints="NO" id="NO1-Pw-MSM">
-                                                <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="44" id="1dq-hB-aZR"/>
-                                                    <constraint firstAttribute="width" constant="44" id="KSk-Z0-GCV"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Folder Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l39-sX-qNj">
-                                                <rect key="frame" x="52" y="0.0" width="307" height="44"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="ayk-Oe-ndL"/>
-                                        </constraints>
-                                    </stackView>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="iLK-I6-MuO">
-                                        <rect key="frame" x="107.5" y="47" width="160" height="32"/>
+                                        <rect key="frame" x="107.5" y="6.5" width="160" height="32"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="160" id="W64-GM-wse"/>
                                         </constraints>
@@ -340,7 +319,7 @@
                                         </connections>
                                     </segmentedControl>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AMB-nt-ccw">
-                                        <rect key="frame" x="0.0" y="87" width="375" height="1"/>
+                                        <rect key="frame" x="0.0" y="43" width="375" height="1"/>
                                         <color key="backgroundColor" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="JOe-Ls-r3H"/>
@@ -349,19 +328,16 @@
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
-                                    <constraint firstItem="6HK-ka-tl4" firstAttribute="top" secondItem="4KS-uW-XyS" secondAttribute="top" id="24a-ax-XMT"/>
+                                    <constraint firstItem="iLK-I6-MuO" firstAttribute="centerY" secondItem="4KS-uW-XyS" secondAttribute="centerY" id="LOl-qD-G6k"/>
                                     <constraint firstAttribute="bottom" secondItem="AMB-nt-ccw" secondAttribute="bottom" id="MX9-eX-bou"/>
-                                    <constraint firstAttribute="trailing" secondItem="6HK-ka-tl4" secondAttribute="trailing" constant="8" id="WXF-m7-Wsa"/>
-                                    <constraint firstItem="6HK-ka-tl4" firstAttribute="leading" secondItem="4KS-uW-XyS" secondAttribute="leading" constant="8" id="Yt5-Q6-oFJ"/>
                                     <constraint firstAttribute="trailing" secondItem="AMB-nt-ccw" secondAttribute="trailing" id="ZFs-b2-u4Z"/>
                                     <constraint firstItem="iLK-I6-MuO" firstAttribute="centerX" secondItem="4KS-uW-XyS" secondAttribute="centerX" id="bus-Nq-SZy"/>
-                                    <constraint firstAttribute="bottom" secondItem="iLK-I6-MuO" secondAttribute="bottom" constant="10" id="hVM-Vu-5Y4"/>
-                                    <constraint firstAttribute="height" constant="88" id="pyr-ic-t2l"/>
+                                    <constraint firstAttribute="height" constant="44" id="pyr-ic-t2l"/>
                                     <constraint firstItem="AMB-nt-ccw" firstAttribute="leading" secondItem="4KS-uW-XyS" secondAttribute="leading" id="ymL-Fz-Nj1"/>
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="IC9-M0-AO4">
-                                <rect key="frame" x="0.0" y="89" width="375" height="485"/>
+                                <rect key="frame" x="0.0" y="45" width="375" height="529"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AssetCell" textLabel="fhP-Mh-0fy" detailTextLabel="3cd-FK-kOv" style="IBUITableViewCellStyleSubtitle" id="8GI-SA-Ocq">
@@ -447,7 +423,6 @@
                     <connections>
                         <outlet property="audioNoteButton" destination="GnL-gZ-eCi" id="RlS-n1-NlY"/>
                         <outlet property="editButton" destination="7ng-Vi-nSB" id="Kcj-ya-LdH"/>
-                        <outlet property="folderLabel" destination="l39-sX-qNj" id="zz3-9D-HWy"/>
                         <outlet property="photoButton" destination="fcy-JG-eKM" id="Ctf-YY-KUS"/>
                         <outlet property="sortControl" destination="iLK-I6-MuO" id="aAT-mL-p5F"/>
                         <outlet property="syncButton" destination="YoR-aT-oGj" id="IqL-DZ-n6V"/>
@@ -680,7 +655,6 @@
         <image name="chevron-right" width="24" height="24"/>
         <image name="create folder" width="128" height="128"/>
         <image name="cross" width="24" height="24"/>
-        <image name="folder" width="24" height="24"/>
         <image name="image-multiple" width="24" height="24"/>
         <image name="menu" width="24" height="24"/>
         <image name="microphone" width="24" height="24"/>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -410,7 +410,11 @@
                     </toolbarItems>
                     <navigationItem key="navigationItem" title="Assets" id="YtF-a8-687">
                         <rightBarButtonItems>
-                            <barButtonItem title="Item" image="sync" largeContentSizeImage="sync" id="YoR-aT-oGj"/>
+                            <barButtonItem title="Item" image="sync" largeContentSizeImage="sync" id="YoR-aT-oGj">
+                                <connections>
+                                    <action selector="handleSyncTappedWithSender:" destination="NWk-Co-Z8t" id="gLL-2i-pfm"/>
+                                </connections>
+                            </barButtonItem>
                             <barButtonItem title="Edit" id="7ng-Vi-nSB">
                                 <connections>
                                     <action selector="handleToggleEditingWithSender:" destination="NWk-Co-Z8t" id="DLi-Up-EqJ"/>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -158,7 +158,7 @@
         <!--Folders-->
         <scene sceneID="NTU-fz-MXb">
             <objects>
-                <viewController id="HoW-Ma-W9C" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="FoldersViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="HoW-Ma-W9C" customClass="FoldersViewController" customModule="Newspack" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ou8-ZM-ej4">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -175,6 +175,9 @@
                                             <segment title="Date"/>
                                             <segment title="Name"/>
                                         </segments>
+                                        <connections>
+                                            <action selector="handleSortChangedWithSender:" destination="HoW-Ma-W9C" eventType="valueChanged" id="azd-go-huG"/>
+                                        </connections>
                                     </segmentedControl>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PfQ-Pm-Ra2">
                                         <rect key="frame" x="280.5" y="10" width="24" height="24"/>
@@ -183,6 +186,9 @@
                                             <constraint firstAttribute="width" constant="24" id="qui-Sy-6SV"/>
                                         </constraints>
                                         <state key="normal" title="Button" image="chevron-down"/>
+                                        <connections>
+                                            <action selector="handleSortChangedWithSender:" destination="HoW-Ma-W9C" eventType="touchUpInside" id="z1C-fk-XYX"/>
+                                        </connections>
                                     </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hkv-nq-i3Y">
                                         <rect key="frame" x="0.0" y="43" width="375" height="1"/>
@@ -208,7 +214,7 @@
                                 <rect key="frame" x="0.0" y="45" width="375" height="529"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="8Pc-C0-8g3">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="FolderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FolderCell" id="8Pc-C0-8g3" customClass="FolderCell" customModule="Newspack" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8Pc-C0-8g3" id="L3s-pR-PR2">
@@ -232,24 +238,57 @@
                         <viewLayoutGuide key="safeArea" id="Ppq-kB-bNS"/>
                     </view>
                     <toolbarItems>
-                        <barButtonItem title="Item" image="doc.text" catalog="system" id="YXs-K9-y6Z"/>
+                        <barButtonItem title="Item" image="doc.text" catalog="system" id="YXs-K9-y6Z">
+                            <connections>
+                                <action selector="handleTextNoteButtonWithSender:" destination="HoW-Ma-W9C" id="uo1-Bf-hDU"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem style="plain" systemItem="flexibleSpace" id="yz5-cB-IPh"/>
-                        <barButtonItem title="Item" image="image-multiple" id="CDY-v8-QbT"/>
+                        <barButtonItem title="Item" image="image-multiple" id="CDY-v8-QbT">
+                            <connections>
+                                <action selector="handlePhotoButtonWithSender:" destination="HoW-Ma-W9C" id="T9T-cL-Jd7"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem style="plain" systemItem="flexibleSpace" id="uZF-dx-aBe"/>
-                        <barButtonItem title="Item" image="video" id="PMa-Ad-aM0"/>
+                        <barButtonItem title="Item" image="video" id="PMa-Ad-aM0">
+                            <connections>
+                                <action selector="handleVideoButtonWithSender:" destination="HoW-Ma-W9C" id="0JT-na-hBx"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem style="plain" systemItem="flexibleSpace" id="fGN-o6-DsB"/>
-                        <barButtonItem title="Item" image="microphone" id="EVv-Df-1uE"/>
+                        <barButtonItem title="Item" image="microphone" id="EVv-Df-1uE">
+                            <connections>
+                                <action selector="handleAudioNoteButtonWithSender:" destination="HoW-Ma-W9C" id="ycQ-az-umX"/>
+                            </connections>
+                        </barButtonItem>
                     </toolbarItems>
                     <navigationItem key="navigationItem" title="Folders" id="kt5-gi-Yct">
-                        <barButtonItem key="leftBarButtonItem" title="Item" image="menu" id="Rg0-or-Kc9"/>
-                        <barButtonItem key="rightBarButtonItem" image="plus" largeContentSizeImage="create folder" id="1nj-Jr-xHF"/>
+                        <barButtonItem key="leftBarButtonItem" title="Item" image="menu" id="Rg0-or-Kc9">
+                            <connections>
+                                <action selector="handleMenuButtonTappedWithSender:" destination="HoW-Ma-W9C" id="xkh-cd-C86"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" image="plus" largeContentSizeImage="create folder" id="1nj-Jr-xHF">
+                            <connections>
+                                <action selector="handleAddTappedWithSender:" destination="HoW-Ma-W9C" id="WXY-yC-hTy"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="audioNoteButton" destination="EVv-Df-1uE" id="IWr-Ow-uGO"/>
+                        <outlet property="directionButton" destination="PfQ-Pm-Ra2" id="9Pi-ob-YAD"/>
+                        <outlet property="photoButton" destination="CDY-v8-QbT" id="KbD-Bv-oUP"/>
+                        <outlet property="sortControl" destination="M20-Ij-iSu" id="RXf-Yn-Hbq"/>
+                        <outlet property="tableView" destination="DE7-1p-iKS" id="rma-Rg-3tp"/>
+                        <outlet property="textNoteButton" destination="YXs-K9-y6Z" id="aAz-p7-Ftk"/>
+                        <outlet property="videoButton" destination="PMa-Ad-aM0" id="AI9-g5-1RI"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="GUw-mL-IDK" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="980" y="-1169.865067466267"/>
+            <point key="canvasLocation" x="292" y="-504"/>
         </scene>
         <!--Assets-->
         <scene sceneID="Ca1-RU-Vfb">
@@ -358,7 +397,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rPD-5z-GAP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1624.8" y="-1171.6641679160421"/>
+            <point key="canvasLocation" x="964" y="-1164"/>
         </scene>
         <!--Menu View Controller-->
         <scene sceneID="tOF-tp-XBd">
@@ -417,106 +456,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aVd-sy-YNL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-354" y="-504"/>
-        </scene>
-        <!--Folders-->
-        <scene sceneID="8gr-DY-Qxl">
-            <objects>
-                <tableViewController storyboardIdentifier="FoldersViewController" title="Folders" useStoryboardIdentifierAsRestorationIdentifier="YES" id="o5i-8K-DIP" customClass="FoldersViewController" customModule="Newspack" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="w0w-el-gTo">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <stackView key="tableHeaderView" opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" id="QLX-ao-DFN">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="110"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <subviews>
-                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="EkV-Vg-qa5">
-                                    <rect key="frame" x="0.0" y="0.0" width="194.5" height="111"/>
-                                    <segments>
-                                        <segment title="Date"/>
-                                        <segment title="Name"/>
-                                    </segments>
-                                    <connections>
-                                        <action selector="handleSortChangedWithSender:" destination="o5i-8K-DIP" eventType="valueChanged" id="6Ig-Ng-b50"/>
-                                    </connections>
-                                </segmentedControl>
-                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="KoB-kO-fC0">
-                                    <rect key="frame" x="194.5" y="0.0" width="180.5" height="111"/>
-                                    <segments>
-                                        <segment title="Asc"/>
-                                        <segment title="Desc"/>
-                                    </segments>
-                                    <connections>
-                                        <action selector="handleSortChangedWithSender:" destination="o5i-8K-DIP" eventType="valueChanged" id="J5x-VT-H4L"/>
-                                    </connections>
-                                </segmentedControl>
-                            </subviews>
-                        </stackView>
-                        <view key="tableFooterView" contentMode="scaleToFill" id="T7a-7n-C8K">
-                            <rect key="frame" x="0.0" y="208.5" width="375" height="44"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        </view>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="FolderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FolderCell" id="O2R-uA-A0M" customClass="FolderCell" customModule="Newspack" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="138" width="375" height="42.5"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="O2R-uA-A0M" id="W0e-Zt-FK0">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="42.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="KCq-fL-Dbc">
-                                            <rect key="frame" x="16" y="10" width="351" height="22.5"/>
-                                            <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Placeholder" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Ga5-YF-VJ1">
-                                                    <rect key="frame" x="0.0" y="0.0" width="351" height="22.5"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <textInputTraits key="textInputTraits" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
-                                                    <connections>
-                                                        <outlet property="delegate" destination="O2R-uA-A0M" id="N7w-xy-EBg"/>
-                                                    </connections>
-                                                </textField>
-                                            </subviews>
-                                        </stackView>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstItem="KCq-fL-Dbc" firstAttribute="leading" secondItem="Ec6-1T-jHG" secondAttribute="leading" constant="16" id="Tro-Fm-MIL"/>
-                                        <constraint firstItem="Ec6-1T-jHG" firstAttribute="bottom" secondItem="KCq-fL-Dbc" secondAttribute="bottom" constant="10" id="d4m-mh-1Xi"/>
-                                        <constraint firstItem="KCq-fL-Dbc" firstAttribute="top" secondItem="Ec6-1T-jHG" secondAttribute="top" constant="10" id="d5f-3M-nz7"/>
-                                        <constraint firstItem="Ec6-1T-jHG" firstAttribute="trailing" secondItem="KCq-fL-Dbc" secondAttribute="trailing" constant="8" id="k4x-LJ-wmS"/>
-                                    </constraints>
-                                    <viewLayoutGuide key="safeArea" id="Ec6-1T-jHG"/>
-                                </tableViewCellContentView>
-                                <connections>
-                                    <outlet property="textField" destination="Ga5-YF-VJ1" id="yfq-1p-9Di"/>
-                                </connections>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="delegate" destination="o5i-8K-DIP" id="arm-xD-IwK"/>
-                        </connections>
-                    </tableView>
-                    <navigationItem key="navigationItem" title="Folders" id="uV3-oP-jOr">
-                        <barButtonItem key="leftBarButtonItem" title="Menu" id="lgK-5A-NeH">
-                            <connections>
-                                <action selector="handleMenuButtonTappedWithSender:" destination="o5i-8K-DIP" id="wH7-Xc-HFT"/>
-                            </connections>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="H42-WT-r23">
-                            <connections>
-                                <action selector="handleAddTappedWithSender:" destination="o5i-8K-DIP" id="SsC-s9-7NN"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
-                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                    <connections>
-                        <outlet property="sortDirection" destination="KoB-kO-fC0" id="E3B-uI-NFv"/>
-                        <outlet property="sortField" destination="EkV-Vg-qa5" id="VVV-E8-jE3"/>
-                    </connections>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="DK2-Ey-tPA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="292" y="-504.19790104947532"/>
         </scene>
         <!--Assets-->
         <scene sceneID="crf-0X-lV6">

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -155,6 +155,211 @@
             </objects>
             <point key="canvasLocation" x="292" y="-1169.865067466267"/>
         </scene>
+        <!--Folders-->
+        <scene sceneID="NTU-fz-MXb">
+            <objects>
+                <viewController id="HoW-Ma-W9C" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ou8-ZM-ej4">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E9o-Tv-ax7">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                <subviews>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="M20-Ij-iSu">
+                                        <rect key="frame" x="107.5" y="6.5" width="160" height="32"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="160" id="Myb-qO-QpU"/>
+                                        </constraints>
+                                        <segments>
+                                            <segment title="Date"/>
+                                            <segment title="Name"/>
+                                        </segments>
+                                    </segmentedControl>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PfQ-Pm-Ra2">
+                                        <rect key="frame" x="280.5" y="10" width="24" height="24"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="24" id="oQv-cx-faK"/>
+                                            <constraint firstAttribute="width" constant="24" id="qui-Sy-6SV"/>
+                                        </constraints>
+                                        <state key="normal" title="Button" image="chevron-down"/>
+                                    </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hkv-nq-i3Y">
+                                        <rect key="frame" x="0.0" y="43" width="375" height="1"/>
+                                        <color key="backgroundColor" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="WTw-1b-dA7"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="2i9-yy-L96"/>
+                                    <constraint firstItem="hkv-nq-i3Y" firstAttribute="leading" secondItem="E9o-Tv-ax7" secondAttribute="leading" id="2rk-mA-JCA"/>
+                                    <constraint firstAttribute="trailing" secondItem="hkv-nq-i3Y" secondAttribute="trailing" id="MXz-vy-pAm"/>
+                                    <constraint firstItem="M20-Ij-iSu" firstAttribute="centerY" secondItem="E9o-Tv-ax7" secondAttribute="centerY" id="QzG-dU-ohK"/>
+                                    <constraint firstItem="PfQ-Pm-Ra2" firstAttribute="leading" secondItem="M20-Ij-iSu" secondAttribute="trailing" constant="13" id="nRe-sq-Az3"/>
+                                    <constraint firstAttribute="bottom" secondItem="hkv-nq-i3Y" secondAttribute="bottom" id="sIx-wq-u5D"/>
+                                    <constraint firstItem="M20-Ij-iSu" firstAttribute="centerX" secondItem="E9o-Tv-ax7" secondAttribute="centerX" id="umO-EA-KNj"/>
+                                    <constraint firstItem="PfQ-Pm-Ra2" firstAttribute="centerY" secondItem="E9o-Tv-ax7" secondAttribute="centerY" id="zeq-NR-Zf8"/>
+                                </constraints>
+                            </view>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="DE7-1p-iKS">
+                                <rect key="frame" x="0.0" y="45" width="375" height="529"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="8Pc-C0-8g3">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8Pc-C0-8g3" id="L3s-pR-PR2">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="E9o-Tv-ax7" firstAttribute="leading" secondItem="Ppq-kB-bNS" secondAttribute="leading" id="2vG-TU-TXW"/>
+                            <constraint firstItem="E9o-Tv-ax7" firstAttribute="top" secondItem="Ppq-kB-bNS" secondAttribute="top" id="CeD-VT-6Fh"/>
+                            <constraint firstItem="Ppq-kB-bNS" firstAttribute="trailing" secondItem="DE7-1p-iKS" secondAttribute="trailing" id="EkS-Yj-X2r"/>
+                            <constraint firstItem="Ppq-kB-bNS" firstAttribute="trailing" secondItem="E9o-Tv-ax7" secondAttribute="trailing" id="dV0-ub-uiu"/>
+                            <constraint firstItem="Ppq-kB-bNS" firstAttribute="bottom" secondItem="DE7-1p-iKS" secondAttribute="bottom" id="gJw-j9-7gE"/>
+                            <constraint firstItem="DE7-1p-iKS" firstAttribute="leading" secondItem="Ppq-kB-bNS" secondAttribute="leading" id="iaF-fJ-U75"/>
+                            <constraint firstItem="DE7-1p-iKS" firstAttribute="top" secondItem="E9o-Tv-ax7" secondAttribute="bottom" constant="1" id="pwF-pl-scy"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="Ppq-kB-bNS"/>
+                    </view>
+                    <toolbarItems>
+                        <barButtonItem title="Item" image="doc.text" catalog="system" id="YXs-K9-y6Z"/>
+                        <barButtonItem style="plain" systemItem="flexibleSpace" id="yz5-cB-IPh"/>
+                        <barButtonItem title="Item" image="image-multiple" id="CDY-v8-QbT"/>
+                        <barButtonItem style="plain" systemItem="flexibleSpace" id="uZF-dx-aBe"/>
+                        <barButtonItem title="Item" image="video" id="PMa-Ad-aM0"/>
+                        <barButtonItem style="plain" systemItem="flexibleSpace" id="fGN-o6-DsB"/>
+                        <barButtonItem title="Item" image="microphone" id="EVv-Df-1uE"/>
+                    </toolbarItems>
+                    <navigationItem key="navigationItem" title="Folders" id="kt5-gi-Yct">
+                        <barButtonItem key="leftBarButtonItem" title="Item" image="menu" id="Rg0-or-Kc9"/>
+                        <barButtonItem key="rightBarButtonItem" image="plus" largeContentSizeImage="create folder" id="1nj-Jr-xHF"/>
+                    </navigationItem>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="GUw-mL-IDK" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="980" y="-1169.865067466267"/>
+        </scene>
+        <!--Assets-->
+        <scene sceneID="Ca1-RU-Vfb">
+            <objects>
+                <viewController id="NWk-Co-Z8t" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="T4B-9L-L3M">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4KS-uW-XyS">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="88"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6HK-ka-tl4">
+                                        <rect key="frame" x="8" y="0.0" width="359" height="44"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="folder" translatesAutoresizingMaskIntoConstraints="NO" id="NO1-Pw-MSM">
+                                                <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="44" id="1dq-hB-aZR"/>
+                                                    <constraint firstAttribute="width" constant="44" id="KSk-Z0-GCV"/>
+                                                </constraints>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Folder Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l39-sX-qNj">
+                                                <rect key="frame" x="52" y="0.0" width="307" height="44"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="ayk-Oe-ndL"/>
+                                        </constraints>
+                                    </stackView>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="iLK-I6-MuO">
+                                        <rect key="frame" x="107.5" y="47" width="160" height="32"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="160" id="W64-GM-wse"/>
+                                        </constraints>
+                                        <segments>
+                                            <segment title="Type"/>
+                                            <segment title="Order"/>
+                                        </segments>
+                                    </segmentedControl>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AMB-nt-ccw">
+                                        <rect key="frame" x="0.0" y="87" width="375" height="1"/>
+                                        <color key="backgroundColor" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="JOe-Ls-r3H"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstItem="6HK-ka-tl4" firstAttribute="top" secondItem="4KS-uW-XyS" secondAttribute="top" id="24a-ax-XMT"/>
+                                    <constraint firstAttribute="bottom" secondItem="AMB-nt-ccw" secondAttribute="bottom" id="MX9-eX-bou"/>
+                                    <constraint firstAttribute="trailing" secondItem="6HK-ka-tl4" secondAttribute="trailing" constant="8" id="WXF-m7-Wsa"/>
+                                    <constraint firstItem="6HK-ka-tl4" firstAttribute="leading" secondItem="4KS-uW-XyS" secondAttribute="leading" constant="8" id="Yt5-Q6-oFJ"/>
+                                    <constraint firstAttribute="trailing" secondItem="AMB-nt-ccw" secondAttribute="trailing" id="ZFs-b2-u4Z"/>
+                                    <constraint firstItem="iLK-I6-MuO" firstAttribute="centerX" secondItem="4KS-uW-XyS" secondAttribute="centerX" id="bus-Nq-SZy"/>
+                                    <constraint firstAttribute="bottom" secondItem="iLK-I6-MuO" secondAttribute="bottom" constant="10" id="hVM-Vu-5Y4"/>
+                                    <constraint firstAttribute="height" constant="88" id="pyr-ic-t2l"/>
+                                    <constraint firstItem="AMB-nt-ccw" firstAttribute="leading" secondItem="4KS-uW-XyS" secondAttribute="leading" id="ymL-Fz-Nj1"/>
+                                </constraints>
+                            </view>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="IC9-M0-AO4">
+                                <rect key="frame" x="0.0" y="89" width="375" height="485"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="8GI-SA-Ocq">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8GI-SA-Ocq" id="9kO-Br-4Fb">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="IC9-M0-AO4" firstAttribute="leading" secondItem="WK3-Qr-Vcx" secondAttribute="leading" id="5D3-7f-y7O"/>
+                            <constraint firstItem="IC9-M0-AO4" firstAttribute="top" secondItem="4KS-uW-XyS" secondAttribute="bottom" constant="1" id="JW1-6n-Dmb"/>
+                            <constraint firstItem="WK3-Qr-Vcx" firstAttribute="trailing" secondItem="4KS-uW-XyS" secondAttribute="trailing" id="MUc-FC-49I"/>
+                            <constraint firstItem="WK3-Qr-Vcx" firstAttribute="bottom" secondItem="IC9-M0-AO4" secondAttribute="bottom" id="ZMA-U8-XVO"/>
+                            <constraint firstItem="4KS-uW-XyS" firstAttribute="top" secondItem="WK3-Qr-Vcx" secondAttribute="top" id="n49-CS-QD9"/>
+                            <constraint firstItem="4KS-uW-XyS" firstAttribute="leading" secondItem="WK3-Qr-Vcx" secondAttribute="leading" id="o2F-1d-mzg"/>
+                            <constraint firstItem="WK3-Qr-Vcx" firstAttribute="trailing" secondItem="IC9-M0-AO4" secondAttribute="trailing" id="wBl-Hf-HfR"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="WK3-Qr-Vcx"/>
+                    </view>
+                    <toolbarItems>
+                        <barButtonItem title="Item" image="doc.text" catalog="system" id="I7i-cV-h16"/>
+                        <barButtonItem style="plain" systemItem="flexibleSpace" id="ooB-Tp-2HQ"/>
+                        <barButtonItem title="Item" image="image-multiple" id="fcy-JG-eKM"/>
+                        <barButtonItem style="plain" systemItem="flexibleSpace" id="gCW-ke-f2d"/>
+                        <barButtonItem title="Item" image="video" id="QOd-iL-h26"/>
+                        <barButtonItem style="plain" systemItem="flexibleSpace" id="5ql-PT-64F"/>
+                        <barButtonItem title="Item" image="microphone" id="GnL-gZ-eCi"/>
+                    </toolbarItems>
+                    <navigationItem key="navigationItem" title="Assets" id="YtF-a8-687">
+                        <barButtonItem key="rightBarButtonItem" title="Item" image="sync" largeContentSizeImage="sync" id="YoR-aT-oGj"/>
+                    </navigationItem>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="rPD-5z-GAP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1624.8" y="-1171.6641679160421"/>
+        </scene>
         <!--Menu View Controller-->
         <scene sceneID="tOF-tp-XBd">
             <objects>
@@ -553,12 +758,22 @@
     <color key="tintColor" name="NewspackBlue"/>
     <resources>
         <image name="Icon" width="32" height="32"/>
+        <image name="chevron-down" width="24" height="24"/>
         <image name="chevron-left" width="24" height="24"/>
         <image name="chevron-right" width="24" height="24"/>
+        <image name="create folder" width="128" height="128"/>
         <image name="cross" width="24" height="24"/>
+        <image name="doc.text" catalog="system" width="115" height="128"/>
+        <image name="folder" width="24" height="24"/>
+        <image name="image-multiple" width="24" height="24"/>
+        <image name="menu" width="24" height="24"/>
+        <image name="microphone" width="24" height="24"/>
+        <image name="plus" width="24" height="24"/>
         <image name="refresh" width="24" height="24"/>
         <image name="safari" catalog="system" width="128" height="121"/>
         <image name="share-ios" width="24" height="24"/>
+        <image name="sync" width="24" height="24"/>
+        <image name="video" width="24" height="24"/>
         <namedColor name="NewspackBlue">
             <color red="0.20000000000000001" green="0.40000000000000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -187,7 +187,7 @@
                                         </constraints>
                                         <state key="normal" image="chevron-down"/>
                                         <connections>
-                                            <action selector="handleSortChangedWithSender:" destination="HoW-Ma-W9C" eventType="touchUpInside" id="z1C-fk-XYX"/>
+                                            <action selector="handleDirectionButtonTappedWithSender:" destination="HoW-Ma-W9C" eventType="touchUpInside" id="ojq-bL-h5c"/>
                                         </connections>
                                     </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hkv-nq-i3Y">
@@ -213,12 +213,6 @@
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="DE7-1p-iKS">
                                 <rect key="frame" x="0.0" y="45" width="375" height="529"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <view key="tableFooterView" contentMode="scaleToFill" id="jW9-Kf-8UD">
-                                    <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="FolderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FolderCell" id="8Pc-C0-8g3" customClass="FolderCell" customModule="Newspack" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
@@ -248,7 +242,7 @@
                         <viewLayoutGuide key="safeArea" id="Ppq-kB-bNS"/>
                     </view>
                     <toolbarItems>
-                        <barButtonItem title="Item" image="doc.text" catalog="system" id="YXs-K9-y6Z">
+                        <barButtonItem title="Item" image="posts" id="YXs-K9-y6Z">
                             <connections>
                                 <action selector="handleTextNoteButtonWithSender:" destination="HoW-Ma-W9C" id="uo1-Bf-hDU"/>
                             </connections>
@@ -369,11 +363,6 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="IC9-M0-AO4">
                                 <rect key="frame" x="0.0" y="89" width="375" height="485"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <view key="tableFooterView" contentMode="scaleToFill" id="TUY-ZN-kgh">
-                                    <rect key="frame" x="0.0" y="129" width="375" height="44"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AssetCell" textLabel="fhP-Mh-0fy" detailTextLabel="3cd-FK-kOv" style="IBUITableViewCellStyleSubtitle" id="8GI-SA-Ocq">
                                         <rect key="frame" x="0.0" y="55.5" width="375" height="55.5"/>
@@ -419,7 +408,7 @@
                         <viewLayoutGuide key="safeArea" id="WK3-Qr-Vcx"/>
                     </view>
                     <toolbarItems>
-                        <barButtonItem title="Item" image="doc.text" catalog="system" id="I7i-cV-h16">
+                        <barButtonItem title="Item" image="posts" id="I7i-cV-h16">
                             <connections>
                                 <action selector="handleTextNoteButtonWithSender:" destination="NWk-Co-Z8t" id="Nek-rD-dKx"/>
                             </connections>
@@ -691,12 +680,12 @@
         <image name="chevron-right" width="24" height="24"/>
         <image name="create folder" width="128" height="128"/>
         <image name="cross" width="24" height="24"/>
-        <image name="doc.text" catalog="system" width="115" height="128"/>
         <image name="folder" width="24" height="24"/>
         <image name="image-multiple" width="24" height="24"/>
         <image name="menu" width="24" height="24"/>
         <image name="microphone" width="24" height="24"/>
         <image name="plus" width="24" height="24"/>
+        <image name="posts" width="24" height="24"/>
         <image name="refresh" width="24" height="24"/>
         <image name="safari" catalog="system" width="128" height="121"/>
         <image name="share-ios" width="24" height="24"/>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -411,7 +411,7 @@
                     <navigationItem key="navigationItem" title="Assets" id="YtF-a8-687">
                         <rightBarButtonItems>
                             <barButtonItem title="Item" image="sync" largeContentSizeImage="sync" id="YoR-aT-oGj"/>
-                            <barButtonItem systemItem="edit" id="7ng-Vi-nSB">
+                            <barButtonItem title="Edit" id="7ng-Vi-nSB">
                                 <connections>
                                     <action selector="handleToggleEditingWithSender:" destination="NWk-Co-Z8t" id="DLi-Up-EqJ"/>
                                 </connections>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -74,7 +74,23 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ZDB-VV-olZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-354" y="-1169"/>
+            <point key="canvasLocation" x="289" y="-1170"/>
+        </scene>
+        <!--Story Navigation Controller-->
+        <scene sceneID="48Y-eH-lUf">
+            <objects>
+                <navigationController storyboardIdentifier="StoryNavigationController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="OXw-Qc-qBP" customClass="StoryNavigationController" customModule="Newspack" customModuleProvider="target" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="wWy-kG-HmN">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="HoW-Ma-W9C" kind="relationship" relationship="rootViewController" id="NGX-fA-0pg"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Hdq-ng-1SU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-354" y="-504"/>
         </scene>
         <!--Web View Controller-->
         <scene sceneID="zwj-ZW-uPp">
@@ -153,7 +169,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aMw-h8-Exn" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="292" y="-1169.865067466267"/>
+            <point key="canvasLocation" x="964" y="-1170"/>
         </scene>
         <!--Stories-->
         <scene sceneID="NTU-fz-MXb">
@@ -495,7 +511,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aVd-sy-YNL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-354" y="-504"/>
+            <point key="canvasLocation" x="-354" y="-1171"/>
         </scene>
         <!--Initial View Controller-->
         <scene sceneID="tne-QT-ifu">

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -185,7 +185,7 @@
                                             <constraint firstAttribute="height" constant="24" id="oQv-cx-faK"/>
                                             <constraint firstAttribute="width" constant="24" id="qui-Sy-6SV"/>
                                         </constraints>
-                                        <state key="normal" title="Button" image="chevron-down"/>
+                                        <state key="normal" image="chevron-down"/>
                                         <connections>
                                             <action selector="handleSortChangedWithSender:" destination="HoW-Ma-W9C" eventType="touchUpInside" id="z1C-fk-XYX"/>
                                         </connections>
@@ -204,6 +204,7 @@
                                     <constraint firstItem="hkv-nq-i3Y" firstAttribute="leading" secondItem="E9o-Tv-ax7" secondAttribute="leading" id="2rk-mA-JCA"/>
                                     <constraint firstAttribute="trailing" secondItem="hkv-nq-i3Y" secondAttribute="trailing" id="MXz-vy-pAm"/>
                                     <constraint firstItem="M20-Ij-iSu" firstAttribute="centerY" secondItem="E9o-Tv-ax7" secondAttribute="centerY" id="QzG-dU-ohK"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="PfQ-Pm-Ra2" secondAttribute="trailing" constant="8" id="hur-ZT-SL5"/>
                                     <constraint firstItem="PfQ-Pm-Ra2" firstAttribute="leading" secondItem="M20-Ij-iSu" secondAttribute="trailing" constant="13" id="nRe-sq-Az3"/>
                                     <constraint firstAttribute="bottom" secondItem="hkv-nq-i3Y" secondAttribute="bottom" id="sIx-wq-u5D"/>
                                     <constraint firstItem="M20-Ij-iSu" firstAttribute="centerX" secondItem="E9o-Tv-ax7" secondAttribute="centerX" id="umO-EA-KNj"/>
@@ -213,6 +214,11 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="DE7-1p-iKS">
                                 <rect key="frame" x="0.0" y="45" width="375" height="529"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <view key="tableFooterView" contentMode="scaleToFill" id="jW9-Kf-8UD">
+                                    <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="FolderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FolderCell" id="8Pc-C0-8g3" customClass="FolderCell" customModule="Newspack" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
@@ -223,6 +229,10 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="HoW-Ma-W9C" id="8Ng-Wc-nDy"/>
+                                    <outlet property="delegate" destination="HoW-Ma-W9C" id="6yv-IN-AI1"/>
+                                </connections>
                             </tableView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
@@ -293,7 +303,7 @@
         <!--Assets-->
         <scene sceneID="Ca1-RU-Vfb">
             <objects>
-                <viewController id="NWk-Co-Z8t" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="AssetsViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="NWk-Co-Z8t" customClass="AssetsViewController" customModule="Newspack" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="T4B-9L-L3M">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -331,6 +341,9 @@
                                             <segment title="Type"/>
                                             <segment title="Order"/>
                                         </segments>
+                                        <connections>
+                                            <action selector="handleSortChangedWithSender:" destination="NWk-Co-Z8t" eventType="valueChanged" id="rav-mh-nq8"/>
+                                        </connections>
                                     </segmentedControl>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AMB-nt-ccw">
                                         <rect key="frame" x="0.0" y="87" width="375" height="1"/>
@@ -353,19 +366,44 @@
                                     <constraint firstItem="AMB-nt-ccw" firstAttribute="leading" secondItem="4KS-uW-XyS" secondAttribute="leading" id="ymL-Fz-Nj1"/>
                                 </constraints>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="IC9-M0-AO4">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="IC9-M0-AO4">
                                 <rect key="frame" x="0.0" y="89" width="375" height="485"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <view key="tableFooterView" contentMode="scaleToFill" id="TUY-ZN-kgh">
+                                    <rect key="frame" x="0.0" y="129" width="375" height="44"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                </view>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="8GI-SA-Ocq">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AssetCell" textLabel="fhP-Mh-0fy" detailTextLabel="3cd-FK-kOv" style="IBUITableViewCellStyleSubtitle" id="8GI-SA-Ocq">
+                                        <rect key="frame" x="0.0" y="55.5" width="375" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8GI-SA-Ocq" id="9kO-Br-4Fb">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="55.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="fhP-Mh-0fy">
+                                                    <rect key="frame" x="15" y="10" width="33.5" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3cd-FK-kOv">
+                                                    <rect key="frame" x="15" y="31.5" width="44" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="NWk-Co-Z8t" id="3qC-Ir-9GJ"/>
+                                    <outlet property="delegate" destination="NWk-Co-Z8t" id="tlA-mA-9ww"/>
+                                </connections>
                             </tableView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
@@ -381,23 +419,57 @@
                         <viewLayoutGuide key="safeArea" id="WK3-Qr-Vcx"/>
                     </view>
                     <toolbarItems>
-                        <barButtonItem title="Item" image="doc.text" catalog="system" id="I7i-cV-h16"/>
+                        <barButtonItem title="Item" image="doc.text" catalog="system" id="I7i-cV-h16">
+                            <connections>
+                                <action selector="handleTextNoteButtonWithSender:" destination="NWk-Co-Z8t" id="Nek-rD-dKx"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem style="plain" systemItem="flexibleSpace" id="ooB-Tp-2HQ"/>
-                        <barButtonItem title="Item" image="image-multiple" id="fcy-JG-eKM"/>
+                        <barButtonItem title="Item" image="image-multiple" id="fcy-JG-eKM">
+                            <connections>
+                                <action selector="handlePhotoButtonWithSender:" destination="NWk-Co-Z8t" id="1YQ-KO-iJG"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem style="plain" systemItem="flexibleSpace" id="gCW-ke-f2d"/>
-                        <barButtonItem title="Item" image="video" id="QOd-iL-h26"/>
+                        <barButtonItem title="Item" image="video" id="QOd-iL-h26">
+                            <connections>
+                                <action selector="handleVideoButtonWithSender:" destination="NWk-Co-Z8t" id="Pe0-eK-IU9"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem style="plain" systemItem="flexibleSpace" id="5ql-PT-64F"/>
-                        <barButtonItem title="Item" image="microphone" id="GnL-gZ-eCi"/>
+                        <barButtonItem title="Item" image="microphone" id="GnL-gZ-eCi">
+                            <connections>
+                                <action selector="handleAudioNoteButtonWithSender:" destination="NWk-Co-Z8t" id="qPU-EK-zxk"/>
+                            </connections>
+                        </barButtonItem>
                     </toolbarItems>
                     <navigationItem key="navigationItem" title="Assets" id="YtF-a8-687">
-                        <barButtonItem key="rightBarButtonItem" title="Item" image="sync" largeContentSizeImage="sync" id="YoR-aT-oGj"/>
+                        <rightBarButtonItems>
+                            <barButtonItem title="Item" image="sync" largeContentSizeImage="sync" id="YoR-aT-oGj"/>
+                            <barButtonItem systemItem="edit" id="7ng-Vi-nSB">
+                                <connections>
+                                    <action selector="handleToggleEditingWithSender:" destination="NWk-Co-Z8t" id="DLi-Up-EqJ"/>
+                                </connections>
+                            </barButtonItem>
+                        </rightBarButtonItems>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="audioNoteButton" destination="GnL-gZ-eCi" id="RlS-n1-NlY"/>
+                        <outlet property="editButton" destination="7ng-Vi-nSB" id="Kcj-ya-LdH"/>
+                        <outlet property="folderLabel" destination="l39-sX-qNj" id="zz3-9D-HWy"/>
+                        <outlet property="photoButton" destination="fcy-JG-eKM" id="Ctf-YY-KUS"/>
+                        <outlet property="sortControl" destination="iLK-I6-MuO" id="aAT-mL-p5F"/>
+                        <outlet property="syncButton" destination="YoR-aT-oGj" id="IqL-DZ-n6V"/>
+                        <outlet property="tableView" destination="IC9-M0-AO4" id="7tv-iN-yXH"/>
+                        <outlet property="textNoteButton" destination="I7i-cV-h16" id="Izx-j7-0Rf"/>
+                        <outlet property="videoButton" destination="QOd-iL-h26" id="sLn-BN-7DO"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rPD-5z-GAP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="964" y="-1164"/>
+            <point key="canvasLocation" x="964" y="-504"/>
         </scene>
         <!--Menu View Controller-->
         <scene sceneID="tOF-tp-XBd">
@@ -456,89 +528,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aVd-sy-YNL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-354" y="-504"/>
-        </scene>
-        <!--Assets-->
-        <scene sceneID="crf-0X-lV6">
-            <objects>
-                <tableViewController storyboardIdentifier="AssetsViewController" title="Assets" useStoryboardIdentifierAsRestorationIdentifier="YES" id="EtD-KI-a1B" customClass="AssetsViewController" customModule="Newspack" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Gj8-TX-CtG">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <stackView key="tableHeaderView" opaque="NO" contentMode="scaleToFill" id="lrE-Pn-O5b">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <subviews>
-                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Ujc-SR-HJd">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
-                                    <segments>
-                                        <segment title="Type"/>
-                                        <segment title="Ordered"/>
-                                    </segments>
-                                    <connections>
-                                        <action selector="handleSortChangedWithSender:" destination="EtD-KI-a1B" eventType="valueChanged" id="Kog-eH-9Qt"/>
-                                    </connections>
-                                </segmentedControl>
-                            </subviews>
-                        </stackView>
-                        <view key="tableFooterView" contentMode="scaleToFill" id="GFd-8g-uaH">
-                            <rect key="frame" x="0.0" y="155.5" width="375" height="44"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        </view>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AssetCell" textLabel="X9L-A9-WjD" detailTextLabel="6PL-gr-v5j" style="IBUITableViewCellStyleSubtitle" id="a0I-9b-USj">
-                                <rect key="frame" x="0.0" y="72" width="375" height="55.5"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="a0I-9b-USj" id="G1c-S4-kfV">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="55.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="X9L-A9-WjD">
-                                            <rect key="frame" x="16" y="10" width="33.5" height="20.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6PL-gr-v5j">
-                                            <rect key="frame" x="16" y="31.5" width="44" height="14.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="EtD-KI-a1B" id="1Yf-zF-eCU"/>
-                            <outlet property="delegate" destination="EtD-KI-a1B" id="vcw-dE-pg9"/>
-                        </connections>
-                    </tableView>
-                    <navigationItem key="navigationItem" title="Assets" id="zmw-7F-Zw1">
-                        <rightBarButtonItems>
-                            <barButtonItem systemItem="add" id="YP3-Sh-l02">
-                                <connections>
-                                    <action selector="handleAddTappedWithSender:" destination="EtD-KI-a1B" id="oCV-tr-wXm"/>
-                                </connections>
-                            </barButtonItem>
-                            <barButtonItem systemItem="edit" id="Q83-lh-HXm">
-                                <connections>
-                                    <action selector="handleToggleEditingWithSender:" destination="EtD-KI-a1B" id="XMg-Hr-Ag2"/>
-                                </connections>
-                            </barButtonItem>
-                        </rightBarButtonItems>
-                    </navigationItem>
-                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                    <connections>
-                        <outlet property="sortControl" destination="Ujc-SR-HJd" id="vEb-oM-xai"/>
-                    </connections>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="V9p-Z4-7n1" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="964" y="-504"/>
         </scene>
         <!--Initial View Controller-->
         <scene sceneID="tne-QT-ifu">

--- a/Newspack/Newspack/Storyboards/MainStoryboard.swift
+++ b/Newspack/Newspack/Storyboards/MainStoryboard.swift
@@ -10,6 +10,7 @@ class MainStoryboard {
         case postList = "PostListViewController"
         case editor = "EditorViewController"
         case mediaDetail = "MediaDetailViewController"
+        case storyNav = "StoryNavigationController"
         case folderList = "FoldersViewController"
         case assetsList = "AssetsViewController"
         case menu = "MenuViewController"

--- a/Newspack/Newspack/Styles/Appearance.swift
+++ b/Newspack/Newspack/Styles/Appearance.swift
@@ -6,8 +6,7 @@ class Appearance {
     /// Configure global UI appearance settings via the appearane API.
     ///
     static func configureGlobalAppearance() {
-        let view = UIView()
-        view.backgroundColor = .cellBackgroundSelected
+        let view = CellBackgroundView()
         UITableViewCell.appearance().selectedBackgroundView = view
     }
 
@@ -61,6 +60,27 @@ extension UIFont {
 
     static var tableViewSubtitle: UIFont {
         .preferredFont(forTextStyle: .callout)
+    }
+
+}
+
+// MARK: - Custom Views
+
+// Apparently views used for a cell's background do not have their traits updated
+// correctly. So we'll use this class to inspect the parent's traits to see if
+// we're in light or dark mode.
+class CellBackgroundView: UIView {
+
+    override func willMove(toSuperview newSuperview: UIView?) {
+        super.willMove(toSuperview: newSuperview)
+        guard let superView = newSuperview else {
+            return
+        }
+        if superView.traitCollection.userInterfaceStyle == .dark {
+            backgroundColor = .withColorStudio(.newspackBlue, shade: .shade80)
+        } else {
+            backgroundColor = .withColorStudio(.newspackBlue, shade: .shade20)
+        }
     }
 
 }

--- a/Newspack/Newspack/Styles/Appearance.swift
+++ b/Newspack/Newspack/Styles/Appearance.swift
@@ -3,6 +3,14 @@ import UIKit
 
 class Appearance {
 
+    /// Configure global UI appearance settings via the appearane API.
+    ///
+    static func configureGlobalAppearance() {
+        let view = UIView()
+        view.backgroundColor = .cellBackgroundSelected
+        UITableViewCell.appearance().selectedBackgroundView = view
+    }
+
     // MARK: - UserView styles
 
     static func style(userView label: UILabel, imageView: UIImageView) {
@@ -23,7 +31,7 @@ class Appearance {
     }
 
     static func style(cell: UITableViewCell) {
-        cell.backgroundColor = .basicBackground
+        cell.backgroundColor = .cellBackground // semantic pass-thru to basicBackground.
 
         cell.textLabel?.font = .tableViewText
         cell.textLabel?.sizeToFit()

--- a/Newspack/Newspack/Styles/ColorStudio.swift
+++ b/Newspack/Newspack/Styles/ColorStudio.swift
@@ -64,7 +64,7 @@ struct ColorStudio {
     // MARK: - Semantic colors
     static let newspackBlue = ColorStudio(name: .newspackBlue)
     static let brand = ColorStudio(name: .newspackBlue)
-    static let accent = ColorStudio(name: .pink)
+    static let accent = ColorStudio(name: .newspackBlue)
     static let divider = ColorStudio(name: .gray, shade: .shade10)
     static let error = ColorStudio(name: .red)
     static let gray = ColorStudio(name: .gray)

--- a/Newspack/Newspack/Styles/UIColor+SemanticColors.swift
+++ b/Newspack/Newspack/Styles/UIColor+SemanticColors.swift
@@ -166,6 +166,25 @@ extension UIColor {
         return .white
     }
 
+    /// Selection color.
+    ///
+    static var selection: UIColor {
+        return UIColor(light: .newspackBlue(.shade20),
+                       dark: .newspackBlue(.shade80))
+    }
+
+    /// Cell default background color
+    ///
+    static var cellBackground: UIColor {
+        return basicBackground
+    }
+
+    /// Cell selected background color
+    ///
+    static var cellBackgroundSelected: UIColor {
+        return selection
+    }
+
     /// App Navigation Bar. brand (< iOS 13 and Light Mode) and `UIColor.systemThickMaterial` (Dark Mode)
     ///
     static var appBar: UIColor {

--- a/Newspack/Newspack/System/AppDelegate.swift
+++ b/Newspack/Newspack/System/AppDelegate.swift
@@ -17,17 +17,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         // Need to configure the user agent as early as possible.
         UserAgent.configure()
+        configureEventMonitor()
+        configureLogger()
+
+        // Configure the window which should call makeKeyAndVisible.
+        // Necessary in order to present the authentication flow.
+        configureWindow()
+        // Configure the session prior to state restoration running.
+        configureSession()
+
         return true
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        configureEventMonitor()
-        configureLogger()
         Appearance.configureGlobalAppearance()
-        // Configure the window which should call makeKeyAndVisible.
-        // Necessary in order to present the authentication flow.
-        configureWindow()
-        configureSession()
+
 
         LogInfo(message: "Application did finish launching.")
 
@@ -56,6 +60,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+    func application(_ application: UIApplication, shouldSaveApplicationState coder: NSCoder) -> Bool {
+        return SessionManager.shared.state == .initialized
+    }
+
+    func application(_ application: UIApplication, shouldRestoreApplicationState coder: NSCoder) -> Bool {
+        return true
     }
 
 }

--- a/Newspack/Newspack/System/AppDelegate.swift
+++ b/Newspack/Newspack/System/AppDelegate.swift
@@ -23,6 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         configureEventMonitor()
         configureLogger()
+        Appearance.configureGlobalAppearance()
         // Configure the window which should call makeKeyAndVisible.
         // Necessary in order to present the authentication flow.
         configureWindow()


### PR DESCRIPTION
Refs #83 

This PR updates the UI of the Story Folder and Story Assets screens as well as enables state restoration when resuming the app.  Note that the ability to rename a story was removed with this PR. There will be a couple of follow up PRs ~to adjust some cell styling~ and to introduce a create/edit screen when making a new folder.  (Edit: Actually the cell styling change was very small so I went ahead and included it.)

To test: 

- [x] Review the Story Folder list.  Confirm that it looks good, no missing icons, etc. 
- [x] Test the sort control. Try sorting by name ascending and descending.
- [x] Confirm that the last selected story is remembered between app launches.
- [x] Confirm that the last selected story is shown in blue text (but not other stories).
- [x] Review the Story Asset list.  Confirm that it looks good, no missing icons, etc. 
- [x] Confirm sorting still works.  Note that the test behavior of tapping rows to move between sorted and unsorted lists is still in place.  New text notes may be added by tapping the text note button on the Assets screen. 
- [x] Confirm the title of the assets screen is the name of the story you chose.
- [x] While viewing the assets screen, background the app to trigger state restoration (remember to wait a second or two). Stop debugging, the relaunch the app.  Confirm you are returned to the assets screen for the story you had selected.
- [x] Confirm darkmode looks good on both screens. 

@jleandroperez how about another? 

### Examples:
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-07-28 at 13 46 46](https://user-images.githubusercontent.com/1435271/88708599-853bf080-d0d9-11ea-936d-f600342d8a09.png)
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-07-28 at 12 38 53](https://user-images.githubusercontent.com/1435271/88708601-866d1d80-d0d9-11ea-89f1-ad9e44cdf095.png)
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-07-28 at 13 46 54](https://user-images.githubusercontent.com/1435271/88708604-879e4a80-d0d9-11ea-9ee9-b3dcd4f0b91f.png)


