### PR TITLE
Issues/83 create edit story

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		E67B9D60236775FC00860A6C /* MediaCache+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67B9D5E236775FB00860A6C /* MediaCache+CoreDataClass.swift */; };
 		E67B9D61236775FC00860A6C /* MediaCache+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67B9D5F236775FC00860A6C /* MediaCache+CoreDataProperties.swift */; };
 		E67F56D52230914800BFD38B /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67F56D42230914800BFD38B /* CoreDataManager.swift */; };
+		E68408A024D0D0ED00C36AB9 /* FolderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E684089F24D0D0ED00C36AB9 /* FolderViewController.swift */; };
 		E684D05324C8980700C0B777 /* Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = E684D05224C8980700C0B777 /* Appearance.swift */; };
 		E68689C0243C080400B7E363 /* FoldersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68689BF243C080400B7E363 /* FoldersViewController.swift */; };
 		E6871F1922C3FD8A008D3D46 /* SiteMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6871F1822C3FD8A008D3D46 /* SiteMenuViewController.swift */; };
@@ -414,6 +415,7 @@
 		E67B9D5E236775FB00860A6C /* MediaCache+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MediaCache+CoreDataClass.swift"; sourceTree = "<group>"; };
 		E67B9D5F236775FC00860A6C /* MediaCache+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MediaCache+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		E67F56D42230914800BFD38B /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CoreDataManager.swift; path = Newspack/System/CoreDataManager.swift; sourceTree = SOURCE_ROOT; };
+		E684089F24D0D0ED00C36AB9 /* FolderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderViewController.swift; sourceTree = "<group>"; };
 		E684D05224C8980700C0B777 /* Appearance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Appearance.swift; sourceTree = "<group>"; };
 		E68689BF243C080400B7E363 /* FoldersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldersViewController.swift; sourceTree = "<group>"; };
 		E6871F1822C3FD8A008D3D46 /* SiteMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMenuViewController.swift; sourceTree = "<group>"; };
@@ -795,6 +797,7 @@
 				E604EE4D24C77BD10015D284 /* AboutViewController.swift */,
 				E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */,
 				E68689BF243C080400B7E363 /* FoldersViewController.swift */,
+				E684089F24D0D0ED00C36AB9 /* FolderViewController.swift */,
 				E66E85A024CFA1010056E8AB /* StoryNavigationController.swift */,
 				E6871F1A22C3FDE7008D3D46 /* PostListViewController.swift */,
 				E62982292303667E00E8CEC7 /* EditorViewController.swift */,
@@ -1368,6 +1371,7 @@
 				E67339A6232EFEA3007C5E45 /* Logging.swift in Sources */,
 				E6034B1422529414007DB6DD /* UserAgent.swift in Sources */,
 				E6500F9D2368F36500CB8C6C /* MediaDetailViewController.swift in Sources */,
+				E68408A024D0D0ED00C36AB9 /* FolderViewController.swift in Sources */,
 				E67B9D60236775FC00860A6C /* MediaCache+CoreDataClass.swift in Sources */,
 				E68B29FF23048C6C0021283C /* EditCoordinator.swift in Sources */,
 				E66CCA162303527D00F1CA59 /* Post+CoreDataProperties.swift in Sources */,

--- a/Newspack/Newspack/Controllers/FolderViewController.swift
+++ b/Newspack/Newspack/Controllers/FolderViewController.swift
@@ -1,0 +1,139 @@
+import UIKit
+
+class FolderViewController: UITableViewController {
+
+    @IBOutlet var saveButton: UIBarButtonItem!
+    @IBOutlet var cancelButton: UIBarButtonItem!
+
+    var textField: UITextField?
+    var storyUUID: UUID?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureStyle()
+        configureTitle()
+    }
+
+    private func configureStyle() {
+        Appearance.style(view: view, tableView: tableView)
+    }
+
+    private func configureTitle() {
+        if let _ = storyUUID {
+            navigationItem.title = NSLocalizedString("Edit Story", comment: "Noun. Title of a screen for editing a story.")
+        } else {
+            navigationItem.title = NSLocalizedString("New Story", comment: "Noun. Title of a screen for creating a new story.")
+        }
+    }
+
+}
+
+// MARK: - Actions
+
+extension FolderViewController {
+
+    @IBAction func handleSaveTapped(sender: UIBarButtonItem) {
+        saveStoryTitle()
+        dismiss(animated: true, completion: nil)
+    }
+
+    @IBAction func handleCancelTapped(sender: UIBarButtonItem) {
+        dismiss(animated: true, completion: nil)
+    }
+
+    func saveStoryTitle() {
+        guard let title = textField?.text else {
+            return
+        }
+
+        if let uuid = storyUUID {
+            // Edit story action
+            let action = FolderAction.renameStoryFolder(folderID: uuid, name: title)
+            SessionManager.shared.sessionDispatcher.dispatch(action)
+        } else {
+            // New story action
+            let action = FolderAction.createStoryFolderNamed(path: title, addSuffix: true)
+            SessionManager.shared.sessionDispatcher.dispatch(action)
+        }
+    }
+
+}
+
+// MARK: - Table view data source
+
+extension FolderViewController {
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: TextFieldCell.reuseIdentifier, for: indexPath) as! TextFieldCell
+        Appearance.style(cell: cell)
+        cell.delegate = self
+
+        // We only have one cell, so this works okay.
+        textField = cell.textField
+
+        let placeholder = NSLocalizedString("New Story", comment: "Noun. This is the default title of a new story before the author provides a title.")
+        textField?.placeholder = placeholder
+
+        if let uuid = storyUUID, let story = StoreContainer.shared.folderStore.getStoryFolderByID(uuid: uuid) {
+            textField?.text = story.name
+        } else {
+            textField?.text = placeholder
+        }
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        textField?.becomeFirstResponder()
+    }
+
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        if let _ = storyUUID {
+            return NSLocalizedString("Change the story's title.", comment: "A short prompt providing instruction to the user.")
+        } else {
+            return NSLocalizedString("Give the story a title.", comment: "A short prompt providing instruction to the user.")
+        }
+    }
+
+}
+
+// MARK: - Text Field Delegate
+
+extension FolderViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        saveStoryTitle()
+        dismiss(animated: true, completion: nil)
+        return true
+    }
+}
+
+class TextFieldCell: UITableViewCell {
+
+    @IBOutlet var textField: UITextField!
+
+    var delegate: UITextFieldDelegate? {
+        get {
+            return textField.delegate
+        }
+        set {
+            textField.delegate = newValue
+        }
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        textField.font = .tableViewText
+        textField.textColor = .text
+    }
+
+}

--- a/Newspack/Newspack/Controllers/FolderViewController.swift
+++ b/Newspack/Newspack/Controllers/FolderViewController.swift
@@ -43,7 +43,7 @@ extension FolderViewController {
     }
 
     func saveStoryTitle() {
-        guard let title = textField?.text else {
+        guard let title = textField?.text, title.count > 0 else {
             return
         }
 
@@ -79,6 +79,9 @@ extension FolderViewController {
 
         // We only have one cell, so this works okay.
         textField = cell.textField
+        textField?.on(.editingChanged, call: { [weak self] textField in
+            self?.saveButton.isEnabled = (textField.text?.characterCount ?? 0) > 0
+        })
 
         let placeholder = NSLocalizedString("New Story", comment: "Noun. This is the default title of a new story before the author provides a title.")
         textField?.placeholder = placeholder

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -107,8 +107,27 @@ extension FoldersViewController {
     }
 
     @IBAction func handleAddTapped(sender: UIBarButtonItem) {
-        let action = FolderAction.createStoryFolder
+        presentFolderScreen(for: nil)
+    }
+
+    func editActionHandler(indexPath: IndexPath) {
+        let storyFolder = dataSource.resultsController.object(at: indexPath)
+        presentFolderScreen(for: storyFolder.uuid)
+    }
+
+    func deleteActionHandler(indexPath: IndexPath) {
+        let storyFolder = dataSource.resultsController.object(at: indexPath)
+        let action = FolderAction.deleteStoryFolder(folderID: storyFolder.uuid)
         SessionManager.shared.sessionDispatcher.dispatch(action)
+    }
+
+    func presentFolderScreen(for storyUUID: UUID?) {
+        let controller = MainStoryboard.instantiateViewController(withIdentifier: .folder) as! FolderViewController
+        controller.storyUUID = storyUUID
+
+        let navController = UINavigationController(rootViewController: controller)
+        navController.modalPresentationStyle = .formSheet
+        self.present(navController, animated: true, completion: nil)
     }
 
 }
@@ -148,9 +167,30 @@ extension FoldersViewController {
         let controller = MainStoryboard.instantiateViewController(withIdentifier: .assetsList)
         navigationController?.pushViewController(controller, animated: true)
     }
+
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+
+        let editAction = UIContextualAction(style: .normal,
+                                            title: NSLocalizedString("Edit", comment: "Verb. Name of a control to edit an object."),
+                                            handler: { (action, view, completion) in
+                                                self.editActionHandler(indexPath: indexPath)
+                                                completion(true)
+        })
+
+        let deleteAction = UIContextualAction(style: .destructive,
+                                            title: NSLocalizedString("Delete", comment: "Verb. Name of a control to delete an object."),
+                                            handler: { (action, view, completion) in
+                                                self.deleteActionHandler(indexPath: indexPath)
+                                                completion(true)
+        })
+
+        return UISwipeActionsConfiguration(actions: [deleteAction, editAction])
+    }
+
 }
 
 // MARK: - DataSource related methods
+
 extension FoldersViewController {
 
     func cellFor(tableView: UITableView, indexPath: IndexPath, storyFolder: StoryFolder) -> UITableViewCell {
@@ -183,6 +223,7 @@ class FolderCell: UITableViewCell {
 
         selectedStory = false
     }
+
 }
 
 // MARK: - FolderDataSource
@@ -207,6 +248,8 @@ class FolderDataSource: UITableViewDiffableDataSource<FolderDataSource.Section, 
     // animate changes.
     weak var tableView: UITableView?
 
+    private var sorting = false
+
     override init(tableView: UITableView, cellProvider: @escaping UITableViewDiffableDataSource<FolderDataSource.Section, StoryFolder>.CellProvider) {
         self.tableView = tableView
         super.init(tableView: tableView, cellProvider: cellProvider)
@@ -227,7 +270,9 @@ class FolderDataSource: UITableViewDiffableDataSource<FolderDataSource.Section, 
         resultsController.fetchRequest.sortDescriptors = StoreContainer.shared.folderStore.sortMode.descriptors
         try? resultsController.performFetch()
 
+        sorting = true
         update()
+        sorting = false
     }
 
     /// Updates the current datasource snapshot. Changes are animated only if
@@ -241,23 +286,12 @@ class FolderDataSource: UITableViewDiffableDataSource<FolderDataSource.Section, 
         snapshot.appendSections([.main])
         snapshot.appendItems(items)
 
-        let shouldAnimate = tableView?.window != nil
-        apply(snapshot, animatingDifferences: shouldAnimate, completion: nil)
+        apply(snapshot, animatingDifferences: sorting, completion: nil)
     }
 
     // MARK: - Overrides for cell deletion behaviors
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         return true
-    }
-
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        guard let storyFolder = resultsController.fetchedObjects?[indexPath.row] else {
-            return
-        }
-        if editingStyle == .delete {
-            let action = FolderAction.deleteStoryFolder(folderID: storyFolder.uuid)
-            SessionManager.shared.sessionDispatcher.dispatch(action)
-        }
     }
 
 }

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -455,7 +455,7 @@
             </objects>
             <point key="canvasLocation" x="964" y="-504"/>
         </scene>
-        <!--Title-->
+        <!--New Story-->
         <scene sceneID="B6C-np-jWC">
             <objects>
                 <tableViewController storyboardIdentifier="FolderViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="RTl-op-Js6" customClass="FolderViewController" customModule="Newspack" customModuleProvider="target" sceneMemberID="viewController">
@@ -477,7 +477,7 @@
                                                 <constraint firstAttribute="height" constant="36" id="PCL-yf-oLw"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                                            <textInputTraits key="textInputTraits"/>
+                                            <textInputTraits key="textInputTraits" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
                                         </textField>
                                     </subviews>
                                     <constraints>
@@ -497,7 +497,7 @@
                             <outlet property="delegate" destination="RTl-op-Js6" id="E9K-aG-Qqz"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Title" id="k39-8d-rnO">
+                    <navigationItem key="navigationItem" title="New Story" id="k39-8d-rnO">
                         <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="PgT-9V-gG7">
                             <connections>
                                 <action selector="handleCancelTappedWithSender:" destination="RTl-op-Js6" id="ylA-w7-iWg"/>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -455,6 +455,70 @@
             </objects>
             <point key="canvasLocation" x="964" y="-504"/>
         </scene>
+        <!--Title-->
+        <scene sceneID="B6C-np-jWC">
+            <objects>
+                <tableViewController storyboardIdentifier="FolderViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="RTl-op-Js6" customClass="FolderViewController" customModule="Newspack" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="AdN-H2-Gbd">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="TextFieldCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="TextFieldCell" id="Ico-hJ-m17" customClass="TextFieldCell" customModule="Newspack" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="55.5" width="375" height="46"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ico-hJ-m17" id="4Jz-Uz-hka">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="46"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Placeholder" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="1Pa-zE-YIR">
+                                            <rect key="frame" x="16" y="4" width="343" height="36.5"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="36" id="PCL-yf-oLw"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="1Pa-zE-YIR" secondAttribute="bottom" constant="5.5" id="Tyd-M3-b0p"/>
+                                        <constraint firstItem="1Pa-zE-YIR" firstAttribute="leading" secondItem="4Jz-Uz-hka" secondAttribute="leading" constant="16" id="YOK-A6-oxe"/>
+                                        <constraint firstItem="1Pa-zE-YIR" firstAttribute="top" secondItem="4Jz-Uz-hka" secondAttribute="top" constant="4" id="nkk-SJ-9Tn"/>
+                                        <constraint firstAttribute="trailing" secondItem="1Pa-zE-YIR" secondAttribute="trailing" constant="16" id="u0c-pf-sbM"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="textField" destination="1Pa-zE-YIR" id="uQe-Cq-r5i"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="RTl-op-Js6" id="EaH-2r-eJ7"/>
+                            <outlet property="delegate" destination="RTl-op-Js6" id="E9K-aG-Qqz"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Title" id="k39-8d-rnO">
+                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="PgT-9V-gG7">
+                            <connections>
+                                <action selector="handleCancelTappedWithSender:" destination="RTl-op-Js6" id="ylA-w7-iWg"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" systemItem="save" id="4B7-83-Ujy">
+                            <connections>
+                                <action selector="handleSaveTappedWithSender:" destination="RTl-op-Js6" id="wVz-ye-ZK9"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <connections>
+                        <outlet property="cancelButton" destination="PgT-9V-gG7" id="R8B-lF-zJN"/>
+                        <outlet property="saveButton" destination="4B7-83-Ujy" id="mDs-GC-N7O"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ms9-Hc-I7E" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1640.8" y="-504.19790104947532"/>
+        </scene>
         <!--Menu View Controller-->
         <scene sceneID="tOF-tp-XBd">
             <objects>

--- a/Newspack/Newspack/Storyboards/MainStoryboard.swift
+++ b/Newspack/Newspack/Storyboards/MainStoryboard.swift
@@ -16,6 +16,7 @@ class MainStoryboard {
         case menu = "MenuViewController"
         case about = "AboutViewController"
         case web = "WebViewController"
+        case folder = "FolderViewController"
     }
 
     static func instantiateViewController(withIdentifier identifier: Identifier) -> UIViewController {

--- a/Newspack/Newspack/Styles/Appearance.swift
+++ b/Newspack/Newspack/Styles/Appearance.swift
@@ -33,6 +33,7 @@ class Appearance {
     static func style(cell: UITableViewCell) {
         cell.backgroundColor = .cellBackground // semantic pass-thru to basicBackground.
 
+        cell.textLabel?.textColor = .text
         cell.textLabel?.font = .tableViewText
         cell.textLabel?.sizeToFit()
 


### PR DESCRIPTION
Closes: #83 

In this PR we restore the ability to change the name of an existing story folder, and introduce a way to provide a name when the folder is created. 

### Details
On the Story Folder list, tapping the + button will present a new form where a user can provide a title and create a new story. A default name is already provided.  If the story is created with an existing name a numeric suffix is appended.

Swiping on a story folder cell will now show an Edit option.  Tapping edit will present the same form where a user can modify the name of the existing story.  (Note that this does not change the name of the corresponding directory in the filesystem.)

### Testing

To test:
- [x] Tap the + button on the story folder list.  Confirm the presented controller is titled New Story.
- [x] Confirm there is a default title.
- [x] Confirm you can create a story with the default title and a numeric suffix is added if necessary.
- [x] Confirm you can add your own title and a new story is created with that title. 
- [x] Confirm that the save button (and done button on the keyboard) is disabled when there is no text in the text field and enabled when there is.
- [x] Swipe to edit an existing story and confirm the presented controller is titled Edit Story.
- [x] Confirm you can save a new name and the correct item is updated in the story folder list.
- [x] Tap to sort the list. Confirm sorting remains animated. 

### Examples:

![new story](https://user-images.githubusercontent.com/1435271/88843804-50966a80-d1a7-11ea-8af0-ef12fa024e7f.png)
![edit cell](https://user-images.githubusercontent.com/1435271/88843826-58560f00-d1a7-11ea-82b1-d75ea5650d7f.png)
![edit story](https://user-images.githubusercontent.com/1435271/88843836-5a1fd280-d1a7-11ea-90f4-fae8cc5b770c.png)
![edit story no text](https://user-images.githubusercontent.com/1435271/88843841-5b50ff80-d1a7-11ea-8d7d-192c9edde79c.png)

@jleandroperez This should be the last UI PR for a while :)