### PR TITLE
UI: Add a sufix to a renamed folder if the name is already taken.

### DIFF
--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -240,10 +240,7 @@ class FolderManager {
             return false
         }
 
-        var destination = destination.deletingLastPathComponent().appendingPathComponent(name, isDirectory: true)
-        if folderExists(url: destination) {
-            destination = urlForFolderAtPath(path: destination.path, ifExistsAppendSuffix: true)
-        }
+        let destination = destination.deletingLastPathComponent().appendingPathComponent(name, isDirectory: true)
 
         guard folderExists(url: source) && !folderExists(url: destination) else {
             return false
@@ -268,7 +265,13 @@ class FolderManager {
     /// renamed.
     ///
     func renameFolder(at source: URL, to name: String) -> URL? {
-        let newURL = source.deletingLastPathComponent().appendingPathComponent(name, isDirectory: true)
+        let sanitizedName = sanitizedFolderName(name: name)
+        var newURL = source.deletingLastPathComponent().appendingPathComponent(sanitizedName, isDirectory: true)
+
+        if folderExists(url: newURL) {
+            newURL = urlForFolderAtPath(path: name, ifExistsAppendSuffix: true)
+        }
+
         if moveFolder(at: source, to: newURL) {
             return newURL
         }

--- a/Newspack/Newspack/Folders/FolderManager.swift
+++ b/Newspack/Newspack/Folders/FolderManager.swift
@@ -240,7 +240,11 @@ class FolderManager {
             return false
         }
 
-        let destination = destination.deletingLastPathComponent().appendingPathComponent(name, isDirectory: true)
+        var destination = destination.deletingLastPathComponent().appendingPathComponent(name, isDirectory: true)
+        if folderExists(url: destination) {
+            destination = urlForFolderAtPath(path: destination.path, ifExistsAppendSuffix: true)
+        }
+
         guard folderExists(url: source) && !folderExists(url: destination) else {
             return false
         }

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -254,7 +254,7 @@ extension FolderStore {
     func renameStoryFolder(uuid: UUID, to name: String) {
         // Get the folder.
         guard let storyFolder = getStoryFolderByID(uuid: uuid) else {
-            LogError(message: "Unable to rename story folder")
+            LogError(message: "Unable to find the story folder to rename.")
             return
         }
 
@@ -267,7 +267,7 @@ extension FolderStore {
             return
         }
 
-        LogDebug(message: "Success: \(newUrl)")
+        LogInfo(message: "Success: \(newUrl)")
 
         // Save the name in core data.
         let objID = storyFolder.objectID

--- a/Newspack/Newspack/System/AppDelegate.swift
+++ b/Newspack/Newspack/System/AppDelegate.swift
@@ -67,7 +67,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, shouldRestoreApplicationState coder: NSCoder) -> Bool {
-        return true
+        return !Environment.isTesting()
     }
 
 }


### PR DESCRIPTION
Fixes #77 

When renaming a story, and the new folder name matches an existing folder name, rather than failing silently just append a suffix behind the scenes. This parallels the ability to change the title of a blog post, giving it the title of another post, but its slug will have an numeric index appended.

To test: 
- [x] Swipe to rename a story and give it the name of another story.  Confirm you have two stories with the same name.
- [x] Switch to the Files app and confirm that the renamed folder has a numeric suffix.

@jleandroperez Game for a quick bug fix patch?