### PR TITLE
Photos: Create assets for newly imported photos.

### DIFF
--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -284,7 +284,27 @@ extension AssetStore {
         }
 
         let importer = try? MediaImporter(destination: url)
-        importer?.importAssets(assets: assets)
+        importer?.importAssets(assets: assets, onComplete: { [weak self] (imported, errors) in
+            self?.createAssetsForImports(imports: imported, errors: errors)
+        })
+    }
+
+    /// Create assets for imported media.
+    ///
+    /// - Parameters:
+    ///   - imports: A dictionary of imported assets. PHAsset IDs are keys.
+    ///   - errors: A dictionary of errors. PHAsset IDs are keys.
+    ///
+    func createAssetsForImports(imports: [String: URL], errors: [String: Error]) {
+        guard let storyFolder = StoreContainer.shared.folderStore.currentStoryFolder else {
+            return
+        }
+        if imports.count > 0 {
+            createAssetsForURLs(urls: Array(imports.values), storyFolder: storyFolder)
+        }
+        if errors.count > 0 {
+            //TODO: Handle errors
+        }
     }
 
 }


### PR DESCRIPTION
Refs #91 

This PR updates the photo import process to create Asset records after the import.  Errors during the import are logged and recorded in a dictionary so a single error won't halt the import of the rest of the assets.  I've left communicating the error to the user as a future TODO and will be addressed once UI for displaying a prompt is added.

To test:
- Use the photo icon to select one or more photos to the currently selected story.
- View the asset screen for the current story and confirm the photos assets are there.

Game for a short PR @jleandroperez ? 
