### PR TITLE
Assets: Adds an AttachmentInfo entity that some StoryAssets can have.

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -122,6 +122,8 @@
 		E65875A823A811F100185C75 /* MediaItemStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65875A723A811F100185C75 /* MediaItemStoreTests.swift */; };
 		E65875AA23A8139500185C75 /* StagedMediaImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65875A923A8139500185C75 /* StagedMediaImporterTests.swift */; };
 		E65875AC23A813EA00185C75 /* StagedMediaStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65875AB23A813EA00185C75 /* StagedMediaStoreTests.swift */; };
+		E65F1A2924E5D63000C9D04E /* AttachmentInfo+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A2724E5D63000C9D04E /* AttachmentInfo+CoreDataClass.swift */; };
+		E65F1A2A24E5D63000C9D04E /* AttachmentInfo+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A2824E5D63000C9D04E /* AttachmentInfo+CoreDataProperties.swift */; };
 		E66B7D4522162754004355D3 /* ApiCredentials.tpl in Resources */ = {isa = PBXBuildFile; fileRef = E66B7D3F22162754004355D3 /* ApiCredentials.tpl */; };
 		E66B7D4622162754004355D3 /* InfoPlist.tpl in Resources */ = {isa = PBXBuildFile; fileRef = E66B7D4022162754004355D3 /* InfoPlist.tpl */; };
 		E66B7D4822162754004355D3 /* replace_secrets.rb in Resources */ = {isa = PBXBuildFile; fileRef = E66B7D4422162754004355D3 /* replace_secrets.rb */; };
@@ -378,6 +380,8 @@
 		E65875A723A811F100185C75 /* MediaItemStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaItemStoreTests.swift; sourceTree = "<group>"; };
 		E65875A923A8139500185C75 /* StagedMediaImporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedMediaImporterTests.swift; sourceTree = "<group>"; };
 		E65875AB23A813EA00185C75 /* StagedMediaStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedMediaStoreTests.swift; sourceTree = "<group>"; };
+		E65F1A2724E5D63000C9D04E /* AttachmentInfo+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AttachmentInfo+CoreDataClass.swift"; sourceTree = "<group>"; };
+		E65F1A2824E5D63000C9D04E /* AttachmentInfo+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AttachmentInfo+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		E66B7D3F22162754004355D3 /* ApiCredentials.tpl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ApiCredentials.tpl; sourceTree = "<group>"; };
 		E66B7D4022162754004355D3 /* InfoPlist.tpl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = InfoPlist.tpl; sourceTree = "<group>"; };
 		E66B7D4422162754004355D3 /* replace_secrets.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = replace_secrets.rb; sourceTree = "<group>"; };
@@ -728,6 +732,8 @@
 				E66CC9F92303527A00F1CA59 /* AccountCapabilities+CoreDataProperties.swift */,
 				E66CCA012303527C00F1CA59 /* AccountDetails+CoreDataClass.swift */,
 				E66CC9F82303527900F1CA59 /* AccountDetails+CoreDataProperties.swift */,
+				E65F1A2724E5D63000C9D04E /* AttachmentInfo+CoreDataClass.swift */,
+				E65F1A2824E5D63000C9D04E /* AttachmentInfo+CoreDataProperties.swift */,
 				E66CC9F02303527800F1CA59 /* Media+CoreDataClass.swift */,
 				E66CC9FD2303527C00F1CA59 /* Media+CoreDataProperties.swift */,
 				E67B9D5E236775FB00860A6C /* MediaCache+CoreDataClass.swift */,
@@ -1372,6 +1378,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E606E71924D8AED9000DD9C5 /* ToolbarViewController.swift in Sources */,
+				E65F1A2924E5D63000C9D04E /* AttachmentInfo+CoreDataClass.swift in Sources */,
 				E6710A1722CE9F040036156E /* FadeTransitionController.swift in Sources */,
 				E66E8A1D2235CAC000E8DD88 /* AuthenticationManager.swift in Sources */,
 				E66CCA1D2303527D00F1CA59 /* AccountDetails+CoreDataClass.swift in Sources */,
@@ -1468,6 +1475,7 @@
 				E602E68D22C1634900795CBA /* SiteApiActions.swift in Sources */,
 				E63EECD7234289DD00669FFC /* PostApiService.swift in Sources */,
 				E623C6F62220516600F9865C /* ApiCredentials.swift in Sources */,
+				E65F1A2A24E5D63000C9D04E /* AttachmentInfo+CoreDataProperties.swift in Sources */,
 				E66CCA1A2303527D00F1CA59 /* Post+CoreDataClass.swift in Sources */,
 				E61AE63C2237373E00E6A489 /* StoreContainer.swift in Sources */,
 				E63FF0EC24AA864C0002A32F /* URL+FileReference.swift in Sources */,

--- a/Newspack/Newspack/Models/AttachmentInfo+CoreDataClass.swift
+++ b/Newspack/Newspack/Models/AttachmentInfo+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(AttachmentInfo)
+public class AttachmentInfo: NSManagedObject {
+
+}

--- a/Newspack/Newspack/Models/AttachmentInfo+CoreDataProperties.swift
+++ b/Newspack/Newspack/Models/AttachmentInfo+CoreDataProperties.swift
@@ -1,0 +1,18 @@
+import Foundation
+import CoreData
+
+
+extension AttachmentInfo {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<AttachmentInfo> {
+        return NSFetchRequest<AttachmentInfo>(entityName: "AttachmentInfo")
+    }
+
+    @NSManaged public var attachmentID: Int64
+    @NSManaged public var caption: String!
+    @NSManaged public var altText: String!
+    @NSManaged public var pageURL: URL!
+    @NSManaged public var srcURL: URL!
+    @NSManaged public var asset: StoryAsset!
+
+}

--- a/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
+++ b/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
@@ -28,7 +28,7 @@
         <attribute name="username" attributeType="String"/>
         <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="details" inverseEntity="Account"/>
     </entity>
-    <entity name="AttachmentInfo" representedClassName="AttachmentInfo" syncable="YES" codeGenerationType="class">
+    <entity name="AttachmentInfo" representedClassName="AttachmentInfo" syncable="YES">
         <attribute name="altText" attributeType="String" defaultValueString=""/>
         <attribute name="attachmentID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="caption" attributeType="String" defaultValueString=""/>

--- a/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
+++ b/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
@@ -28,6 +28,14 @@
         <attribute name="username" attributeType="String"/>
         <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="details" inverseEntity="Account"/>
     </entity>
+    <entity name="AttachmentInfo" representedClassName="AttachmentInfo" syncable="YES" codeGenerationType="class">
+        <attribute name="altText" attributeType="String" defaultValueString=""/>
+        <attribute name="attachmentID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="caption" attributeType="String" defaultValueString=""/>
+        <attribute name="pageURL" attributeType="URI"/>
+        <attribute name="srcURL" attributeType="URI"/>
+        <relationship name="asset" maxCount="1" deletionRule="Nullify" destinationEntity="StoryAsset" inverseName="attachmentInfo" inverseEntity="StoryAsset"/>
+    </entity>
     <entity name="Media" representedClassName="Media" syncable="YES">
         <attribute name="altText" attributeType="String"/>
         <attribute name="authorID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -261,6 +269,7 @@
         <attribute name="text" optional="YES" attributeType="String"/>
         <attribute name="type" attributeType="String"/>
         <attribute name="uuid" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="attachmentInfo" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="AttachmentInfo" inverseName="asset" inverseEntity="AttachmentInfo"/>
         <relationship name="folder" maxCount="1" deletionRule="Nullify" destinationEntity="StoryFolder" inverseName="assets" inverseEntity="StoryFolder"/>
     </entity>
     <entity name="StoryFolder" representedClassName="StoryFolder" syncable="YES">
@@ -300,8 +309,9 @@
         <element name="StagedEdits" positionX="-868.6484375" positionY="-275.66015625" width="128" height="118"/>
         <element name="StagedMedia" positionX="-2097.73828125" positionY="129.59765625" width="128" height="208"/>
         <element name="Status" positionX="-1600.76953125" positionY="-2.2265625" width="128" height="165"/>
-        <element name="StoryAsset" positionX="-1702.796875" positionY="382.8671875" width="128" height="208"/>
+        <element name="StoryAsset" positionX="-1702.796875" positionY="382.8671875" width="128" height="223"/>
         <element name="StoryFolder" positionX="-1515.86328125" positionY="210.171875" width="128" height="163"/>
         <element name="User" positionX="-976.9921875" positionY="-127.2734375" width="128" height="163"/>
+        <element name="AttachmentInfo" positionX="-1944" positionY="-828" width="128" height="133"/>
     </elements>
 </model>

--- a/Newspack/Newspack/Models/StoryAsset+CoreDataProperties.swift
+++ b/Newspack/Newspack/Models/StoryAsset+CoreDataProperties.swift
@@ -28,5 +28,5 @@ extension StoryAsset {
     @NSManaged public var text: String?
     @NSManaged public var sorted: Bool
     @NSManaged public var folder: StoryFolder!
-
+    @NSManaged public var attachmentInfo: AttachmentInfo?
 }


### PR DESCRIPTION
Refs #91 

This is a quick PR introducing a new core data entity called AttachmentInfo.  It will store discrete bits of info about certain uploaded assets (images, video, audio, maybe documents).  Functionality and usage around this entity will be introduced in a future PR dealing with syncing. 

Of note:
AttachmentInfo properties are all required (none are optional) and strings will default to empty strings. The relationship between StoryAsset is one to one, required for the AttachmentInfo but optional for the StoryAsset. Deletion cascades from the StoryAsset but nullifies from the AttachmentInfo. 

Quick peek @jleandroperez?  It's mostly boilerplate changes.