### PR TITLE
Issues/91 new cells

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		E65F1A4424E5DD5700C9D04E /* TextNoteTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65F1A4224E5DD5700C9D04E /* TextNoteTableViewCell.xib */; };
 		E65F1A4724E5DD7600C9D04E /* AudioTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A4524E5DD7600C9D04E /* AudioTableViewCell.swift */; };
 		E65F1A4824E5DD7600C9D04E /* AudioTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65F1A4624E5DD7600C9D04E /* AudioTableViewCell.xib */; };
+		E6663E4A24E70E09006553B3 /* CellBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6663E4924E70E09006553B3 /* CellBackgroundView.swift */; };
 		E66B7D4522162754004355D3 /* ApiCredentials.tpl in Resources */ = {isa = PBXBuildFile; fileRef = E66B7D3F22162754004355D3 /* ApiCredentials.tpl */; };
 		E66B7D4622162754004355D3 /* InfoPlist.tpl in Resources */ = {isa = PBXBuildFile; fileRef = E66B7D4022162754004355D3 /* InfoPlist.tpl */; };
 		E66B7D4822162754004355D3 /* replace_secrets.rb in Resources */ = {isa = PBXBuildFile; fileRef = E66B7D4422162754004355D3 /* replace_secrets.rb */; };
@@ -398,6 +399,7 @@
 		E65F1A4224E5DD5700C9D04E /* TextNoteTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextNoteTableViewCell.xib; sourceTree = "<group>"; };
 		E65F1A4524E5DD7600C9D04E /* AudioTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioTableViewCell.swift; sourceTree = "<group>"; };
 		E65F1A4624E5DD7600C9D04E /* AudioTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AudioTableViewCell.xib; sourceTree = "<group>"; };
+		E6663E4924E70E09006553B3 /* CellBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellBackgroundView.swift; sourceTree = "<group>"; };
 		E66B7D3F22162754004355D3 /* ApiCredentials.tpl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ApiCredentials.tpl; sourceTree = "<group>"; };
 		E66B7D4022162754004355D3 /* InfoPlist.tpl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = InfoPlist.tpl; sourceTree = "<group>"; };
 		E66B7D4422162754004355D3 /* replace_secrets.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = replace_secrets.rb; sourceTree = "<group>"; };
@@ -820,6 +822,7 @@
 				E65F1A4224E5DD5700C9D04E /* TextNoteTableViewCell.xib */,
 				E65F1A4524E5DD7600C9D04E /* AudioTableViewCell.swift */,
 				E65F1A4624E5DD7600C9D04E /* AudioTableViewCell.xib */,
+				E6663E4924E70E09006553B3 /* CellBackgroundView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1504,6 +1507,7 @@
 				E6051DE323071A3A005AAF0B /* RemoteRevision.swift in Sources */,
 				E695A7E9244FD686007B29BB /* StoryAsset+CoreDataClass.swift in Sources */,
 				E66CCA0F2303527C00F1CA59 /* Revision+CoreDataProperties.swift in Sources */,
+				E6663E4A24E70E09006553B3 /* CellBackgroundView.swift in Sources */,
 				E641A66522A75866008BBD85 /* AccountCapabilitiesStore.swift in Sources */,
 				E602E68D22C1634900795CBA /* SiteApiActions.swift in Sources */,
 				E63EECD7234289DD00669FFC /* PostApiService.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -122,11 +122,16 @@
 		E65875A823A811F100185C75 /* MediaItemStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65875A723A811F100185C75 /* MediaItemStoreTests.swift */; };
 		E65875AA23A8139500185C75 /* StagedMediaImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65875A923A8139500185C75 /* StagedMediaImporterTests.swift */; };
 		E65875AC23A813EA00185C75 /* StagedMediaStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65875AB23A813EA00185C75 /* StagedMediaStoreTests.swift */; };
-		E65F1A2C24E5DBED00C9D04E /* StoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A2B24E5DBED00C9D04E /* StoryTableViewCell.swift */; };
-		E65F1A2E24E5DC0000C9D04E /* PhotoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A2D24E5DC0000C9D04E /* PhotoTableViewCell.swift */; };
-		E65F1A3024E5DC0C00C9D04E /* VideoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A2F24E5DC0C00C9D04E /* VideoTableViewCell.swift */; };
-		E65F1A3224E5DC1A00C9D04E /* TextNoteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A3124E5DC1A00C9D04E /* TextNoteTableViewCell.swift */; };
-		E65F1A3424E5DC2800C9D04E /* AudioTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A3324E5DC2800C9D04E /* AudioTableViewCell.swift */; };
+		E65F1A3724E5DCFA00C9D04E /* StoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A3524E5DCFA00C9D04E /* StoryTableViewCell.swift */; };
+		E65F1A3824E5DCFA00C9D04E /* StoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65F1A3624E5DCFA00C9D04E /* StoryTableViewCell.xib */; };
+		E65F1A3B24E5DD2900C9D04E /* PhotoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A3924E5DD2900C9D04E /* PhotoTableViewCell.swift */; };
+		E65F1A3C24E5DD2900C9D04E /* PhotoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65F1A3A24E5DD2900C9D04E /* PhotoTableViewCell.xib */; };
+		E65F1A3F24E5DD4300C9D04E /* VideoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A3D24E5DD4300C9D04E /* VideoTableViewCell.swift */; };
+		E65F1A4024E5DD4300C9D04E /* VideoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65F1A3E24E5DD4300C9D04E /* VideoTableViewCell.xib */; };
+		E65F1A4324E5DD5700C9D04E /* TextNoteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A4124E5DD5700C9D04E /* TextNoteTableViewCell.swift */; };
+		E65F1A4424E5DD5700C9D04E /* TextNoteTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65F1A4224E5DD5700C9D04E /* TextNoteTableViewCell.xib */; };
+		E65F1A4724E5DD7600C9D04E /* AudioTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A4524E5DD7600C9D04E /* AudioTableViewCell.swift */; };
+		E65F1A4824E5DD7600C9D04E /* AudioTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65F1A4624E5DD7600C9D04E /* AudioTableViewCell.xib */; };
 		E66B7D4522162754004355D3 /* ApiCredentials.tpl in Resources */ = {isa = PBXBuildFile; fileRef = E66B7D3F22162754004355D3 /* ApiCredentials.tpl */; };
 		E66B7D4622162754004355D3 /* InfoPlist.tpl in Resources */ = {isa = PBXBuildFile; fileRef = E66B7D4022162754004355D3 /* InfoPlist.tpl */; };
 		E66B7D4822162754004355D3 /* replace_secrets.rb in Resources */ = {isa = PBXBuildFile; fileRef = E66B7D4422162754004355D3 /* replace_secrets.rb */; };
@@ -383,11 +388,16 @@
 		E65875A723A811F100185C75 /* MediaItemStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaItemStoreTests.swift; sourceTree = "<group>"; };
 		E65875A923A8139500185C75 /* StagedMediaImporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedMediaImporterTests.swift; sourceTree = "<group>"; };
 		E65875AB23A813EA00185C75 /* StagedMediaStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedMediaStoreTests.swift; sourceTree = "<group>"; };
-		E65F1A2B24E5DBED00C9D04E /* StoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryTableViewCell.swift; sourceTree = "<group>"; };
-		E65F1A2D24E5DC0000C9D04E /* PhotoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoTableViewCell.swift; sourceTree = "<group>"; };
-		E65F1A2F24E5DC0C00C9D04E /* VideoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTableViewCell.swift; sourceTree = "<group>"; };
-		E65F1A3124E5DC1A00C9D04E /* TextNoteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextNoteTableViewCell.swift; sourceTree = "<group>"; };
-		E65F1A3324E5DC2800C9D04E /* AudioTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioTableViewCell.swift; sourceTree = "<group>"; };
+		E65F1A3524E5DCFA00C9D04E /* StoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryTableViewCell.swift; sourceTree = "<group>"; };
+		E65F1A3624E5DCFA00C9D04E /* StoryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StoryTableViewCell.xib; sourceTree = "<group>"; };
+		E65F1A3924E5DD2900C9D04E /* PhotoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoTableViewCell.swift; sourceTree = "<group>"; };
+		E65F1A3A24E5DD2900C9D04E /* PhotoTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PhotoTableViewCell.xib; sourceTree = "<group>"; };
+		E65F1A3D24E5DD4300C9D04E /* VideoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTableViewCell.swift; sourceTree = "<group>"; };
+		E65F1A3E24E5DD4300C9D04E /* VideoTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = VideoTableViewCell.xib; sourceTree = "<group>"; };
+		E65F1A4124E5DD5700C9D04E /* TextNoteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextNoteTableViewCell.swift; sourceTree = "<group>"; };
+		E65F1A4224E5DD5700C9D04E /* TextNoteTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextNoteTableViewCell.xib; sourceTree = "<group>"; };
+		E65F1A4524E5DD7600C9D04E /* AudioTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioTableViewCell.swift; sourceTree = "<group>"; };
+		E65F1A4624E5DD7600C9D04E /* AudioTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AudioTableViewCell.xib; sourceTree = "<group>"; };
 		E66B7D3F22162754004355D3 /* ApiCredentials.tpl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ApiCredentials.tpl; sourceTree = "<group>"; };
 		E66B7D4022162754004355D3 /* InfoPlist.tpl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = InfoPlist.tpl; sourceTree = "<group>"; };
 		E66B7D4422162754004355D3 /* replace_secrets.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = replace_secrets.rb; sourceTree = "<group>"; };
@@ -800,11 +810,16 @@
 				E604EE4624C76FAD0015D284 /* CircularImageView.swift */,
 				E604EE4A24C774FB0015D284 /* SimpleTableViewCell.swift */,
 				E604EE4824C774A80015D284 /* UserView.swift */,
-				E65F1A2B24E5DBED00C9D04E /* StoryTableViewCell.swift */,
-				E65F1A2D24E5DC0000C9D04E /* PhotoTableViewCell.swift */,
-				E65F1A2F24E5DC0C00C9D04E /* VideoTableViewCell.swift */,
-				E65F1A3124E5DC1A00C9D04E /* TextNoteTableViewCell.swift */,
-				E65F1A3324E5DC2800C9D04E /* AudioTableViewCell.swift */,
+				E65F1A3524E5DCFA00C9D04E /* StoryTableViewCell.swift */,
+				E65F1A3624E5DCFA00C9D04E /* StoryTableViewCell.xib */,
+				E65F1A3924E5DD2900C9D04E /* PhotoTableViewCell.swift */,
+				E65F1A3A24E5DD2900C9D04E /* PhotoTableViewCell.xib */,
+				E65F1A3D24E5DD4300C9D04E /* VideoTableViewCell.swift */,
+				E65F1A3E24E5DD4300C9D04E /* VideoTableViewCell.xib */,
+				E65F1A4124E5DD5700C9D04E /* TextNoteTableViewCell.swift */,
+				E65F1A4224E5DD5700C9D04E /* TextNoteTableViewCell.xib */,
+				E65F1A4524E5DD7600C9D04E /* AudioTableViewCell.swift */,
+				E65F1A4624E5DD7600C9D04E /* AudioTableViewCell.xib */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1204,11 +1219,16 @@
 			files = (
 				E66B7D4822162754004355D3 /* replace_secrets.rb in Resources */,
 				E65469F724C78C420083FAA5 /* acknowledgements.htm in Resources */,
+				E65F1A3C24E5DD2900C9D04E /* PhotoTableViewCell.xib in Resources */,
 				E6138FDF2211FE88004E5B91 /* LaunchScreen.storyboard in Resources */,
 				E66B7D4622162754004355D3 /* InfoPlist.tpl in Resources */,
 				E6138FDC2211FE88004E5B91 /* Assets.xcassets in Resources */,
 				E6138FD72211FE86004E5B91 /* Main.storyboard in Resources */,
+				E65F1A4024E5DD4300C9D04E /* VideoTableViewCell.xib in Resources */,
+				E65F1A4424E5DD5700C9D04E /* TextNoteTableViewCell.xib in Resources */,
 				E6190C4724BF834B0060D00A /* ColorStudio.xcassets in Resources */,
+				E65F1A3824E5DCFA00C9D04E /* StoryTableViewCell.xib in Resources */,
+				E65F1A4824E5DD7600C9D04E /* AudioTableViewCell.xib in Resources */,
 				E66B7D4522162754004355D3 /* ApiCredentials.tpl in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1398,7 +1418,6 @@
 				E61D8F6F2378C95B005FECED /* StagedMedia+CoreDataProperties.swift in Sources */,
 				E61D8F702378C95B005FECED /* StagedMedia+CoreDataClass.swift in Sources */,
 				E602E69822C1670800795CBA /* PostAction.swift in Sources */,
-				E65F1A3224E5DC1A00C9D04E /* TextNoteTableViewCell.swift in Sources */,
 				E6138FD42211FE86004E5B91 /* InitialViewController.swift in Sources */,
 				E66CCA072303527C00F1CA59 /* Account+CoreDataClass.swift in Sources */,
 				E69E59F922540D0900899DE2 /* SiteServiceRemote.swift in Sources */,
@@ -1406,8 +1425,10 @@
 				E6A4D742230A08A700929376 /* StagedEdits+CoreDataProperties.swift in Sources */,
 				E636C26B234FEAD800564B63 /* MediaQuery+CoreDataClass.swift in Sources */,
 				E67339A6232EFEA3007C5E45 /* Logging.swift in Sources */,
+				E65F1A3724E5DCFA00C9D04E /* StoryTableViewCell.swift in Sources */,
 				E6034B1422529414007DB6DD /* UserAgent.swift in Sources */,
 				E6500F9D2368F36500CB8C6C /* MediaDetailViewController.swift in Sources */,
+				E65F1A3F24E5DD4300C9D04E /* VideoTableViewCell.swift in Sources */,
 				E68408A024D0D0ED00C36AB9 /* FolderViewController.swift in Sources */,
 				E67B9D60236775FC00860A6C /* MediaCache+CoreDataClass.swift in Sources */,
 				E68B29FF23048C6C0021283C /* EditCoordinator.swift in Sources */,
@@ -1419,8 +1440,8 @@
 				E67B9D61236775FC00860A6C /* MediaCache+CoreDataProperties.swift in Sources */,
 				E6138FDA2211FE86004E5B91 /* Newspack.xcdatamodeld in Sources */,
 				E66CCA192303527D00F1CA59 /* Media+CoreDataProperties.swift in Sources */,
-				E65F1A2E24E5DC0000C9D04E /* PhotoTableViewCell.swift in Sources */,
 				E66CCA1E2303527D00F1CA59 /* Status+CoreDataClass.swift in Sources */,
+				E65F1A3B24E5DD2900C9D04E /* PhotoTableViewCell.swift in Sources */,
 				E6051DEC23075A3A005AAF0B /* Dictionary+Merge.swift in Sources */,
 				E677AAEB24B3C954000FAA3D /* AssetStore.swift in Sources */,
 				E6343ADF23A077C80033D369 /* SiteMediaSelectViewController.swift in Sources */,
@@ -1436,7 +1457,6 @@
 				E64594A122B448C2003BF6C0 /* PostServiceRemote.swift in Sources */,
 				E68BA80C2347BAA300AB60F9 /* Environment.swift in Sources */,
 				E636C269234FEAD800564B63 /* MediaItem+CoreDataClass.swift in Sources */,
-				E65F1A3024E5DC0C00C9D04E /* VideoTableViewCell.swift in Sources */,
 				E66CCA1C2303527D00F1CA59 /* Revision+CoreDataClass.swift in Sources */,
 				E66CCA062303527C00F1CA59 /* Site+CoreDataClass.swift in Sources */,
 				E69E59FD22541ABD00899DE2 /* WordPressCoreRestApi.swift in Sources */,
@@ -1467,6 +1487,7 @@
 				E636C264234FD16F00564B63 /* MediaApiActions.swift in Sources */,
 				E690D57223722BB700676B1D /* PhotoLibraryViewController.swift in Sources */,
 				E602E68522C15ECC00795CBA /* RemoteSiteSettings.swift in Sources */,
+				E65F1A4324E5DD5700C9D04E /* TextNoteTableViewCell.swift in Sources */,
 				E68B2A0323048E510021283C /* EditorAttachmentDelegate.swift in Sources */,
 				E68A965E246098C700BE664B /* NSObject+Helpers.swift in Sources */,
 				E6A7C06D2257A42400CC2191 /* UserServiceRemote.swift in Sources */,
@@ -1477,8 +1498,8 @@
 				E67F56D52230914800BFD38B /* CoreDataManager.swift in Sources */,
 				E602E69F22C1747D00795CBA /* Dictionary+Unwrappers.swift in Sources */,
 				E6A800F324380A5300A14E6C /* FolderStore.swift in Sources */,
+				E65F1A4724E5DD7600C9D04E /* AudioTableViewCell.swift in Sources */,
 				E629822A2303667E00E8CEC7 /* EditorViewController.swift in Sources */,
-				E65F1A3424E5DC2800C9D04E /* AudioTableViewCell.swift in Sources */,
 				E66CCA1B2303527D00F1CA59 /* User+CoreDataClass.swift in Sources */,
 				E6051DE323071A3A005AAF0B /* RemoteRevision.swift in Sources */,
 				E695A7E9244FD686007B29BB /* StoryAsset+CoreDataClass.swift in Sources */,
@@ -1503,7 +1524,6 @@
 				E61D8F6C2375EC3E005FECED /* StagedMediaStore.swift in Sources */,
 				E66CCA0D2303527C00F1CA59 /* Site+CoreDataProperties.swift in Sources */,
 				E604EE4924C774A80015D284 /* UserView.swift in Sources */,
-				E65F1A2C24E5DBED00C9D04E /* StoryTableViewCell.swift in Sources */,
 				E66CCA0B2303527C00F1CA59 /* Account+CoreDataProperties.swift in Sources */,
 				E63F3F3C236350BE00DB760E /* MediaTypeDiscerner.swift in Sources */,
 				E602E68F22C1637800795CBA /* PostApiActions.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -213,6 +213,8 @@
 		E6B4034D22D8E12500A0DDCA /* remote-posts-ids-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */; };
 		E6B4034E22D8E12500A0DDCA /* remote-posts-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */; };
 		E6B7728824BCD8DA00CA8AB8 /* SortOrganizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B7728724BCD8DA00CA8AB8 /* SortOrganizer.swift */; };
+		E6B779E824EB2F9D007EA033 /* ImageResizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B779E724EB2F9D007EA033 /* ImageResizer.swift */; };
+		E6B779EA24EB2FC5007EA033 /* CGSize+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B779E924EB2FC5007EA033 /* CGSize+Helpers.swift */; };
 		E6B8CFDB24AB91430068C6BE /* URLFileReferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDA24AB91430068C6BE /* URLFileReferenceTests.swift */; };
 		E6B8CFDD24ABC48C0068C6BE /* FolderStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDC24ABC48C0068C6BE /* FolderStoreTests.swift */; };
 		E6B8CFE024ABD6EB0068C6BE /* ReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */; };
@@ -485,6 +487,8 @@
 		E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-ids-edit.json"; sourceTree = "<group>"; };
 		E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-edit.json"; sourceTree = "<group>"; };
 		E6B7728724BCD8DA00CA8AB8 /* SortOrganizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortOrganizer.swift; sourceTree = "<group>"; };
+		E6B779E724EB2F9D007EA033 /* ImageResizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageResizer.swift; sourceTree = "<group>"; };
+		E6B779E924EB2FC5007EA033 /* CGSize+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Helpers.swift"; sourceTree = "<group>"; };
 		E6B8CFDA24AB91430068C6BE /* URLFileReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLFileReferenceTests.swift; sourceTree = "<group>"; };
 		E6B8CFDC24ABC48C0068C6BE /* FolderStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderStoreTests.swift; sourceTree = "<group>"; };
 		E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcilerTests.swift; sourceTree = "<group>"; };
@@ -1032,6 +1036,7 @@
 			isa = PBXGroup;
 			children = (
 				E6B7728724BCD8DA00CA8AB8 /* SortOrganizer.swift */,
+				E6B779E724EB2F9D007EA033 /* ImageResizer.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1088,6 +1093,7 @@
 		E6FB51FE22B9677A0010FDF8 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				E6B779E924EB2FC5007EA033 /* CGSize+Helpers.swift */,
 				E6FB51FF22B967910010FDF8 /* Dictionary+KeyPath.swift */,
 				E602E69E22C1747D00795CBA /* Dictionary+Unwrappers.swift */,
 				E6051DEB23075A3A005AAF0B /* Dictionary+Merge.swift */,
@@ -1505,6 +1511,7 @@
 				E66CCA102303527C00F1CA59 /* User+CoreDataProperties.swift in Sources */,
 				E6E2ACF722E10F3400A8E85D /* MainStoryboard.swift in Sources */,
 				E6AB672A24E88182003D5D2A /* StoryTableViewCell.swift in Sources */,
+				E6B779E824EB2F9D007EA033 /* ImageResizer.swift in Sources */,
 				E6A800F524380A6600A14E6C /* FolderAction.swift in Sources */,
 				E67F56D52230914800BFD38B /* CoreDataManager.swift in Sources */,
 				E602E69F22C1747D00795CBA /* Dictionary+Unwrappers.swift in Sources */,
@@ -1536,6 +1543,7 @@
 				E66CCA0D2303527C00F1CA59 /* Site+CoreDataProperties.swift in Sources */,
 				E604EE4924C774A80015D284 /* UserView.swift in Sources */,
 				E66CCA0B2303527C00F1CA59 /* Account+CoreDataProperties.swift in Sources */,
+				E6B779EA24EB2FC5007EA033 /* CGSize+Helpers.swift in Sources */,
 				E63F3F3C236350BE00DB760E /* MediaTypeDiscerner.swift in Sources */,
 				E602E68F22C1637800795CBA /* PostApiActions.swift in Sources */,
 				E695A7E7244FD686007B29BB /* StoryAsset+CoreDataProperties.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -198,6 +198,17 @@
 		E6A7C06D2257A42400CC2191 /* UserServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A7C06C2257A42400CC2191 /* UserServiceRemote.swift */; };
 		E6A800F324380A5300A14E6C /* FolderStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A800F224380A5300A14E6C /* FolderStore.swift */; };
 		E6A800F524380A6600A14E6C /* FolderAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A800F424380A6600A14E6C /* FolderAction.swift */; };
+		E6AB672024E88182003D5D2A /* AudioTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AB671524E88182003D5D2A /* AudioTableViewCell.swift */; };
+		E6AB672124E88182003D5D2A /* TextNoteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AB671624E88182003D5D2A /* TextNoteTableViewCell.swift */; };
+		E6AB672224E88182003D5D2A /* CellBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AB671724E88182003D5D2A /* CellBackgroundView.swift */; };
+		E6AB672324E88182003D5D2A /* StoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E6AB671824E88182003D5D2A /* StoryTableViewCell.xib */; };
+		E6AB672424E88182003D5D2A /* AudioTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E6AB671924E88182003D5D2A /* AudioTableViewCell.xib */; };
+		E6AB672524E88182003D5D2A /* TextNoteTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E6AB671A24E88182003D5D2A /* TextNoteTableViewCell.xib */; };
+		E6AB672624E88182003D5D2A /* PhotoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E6AB671B24E88182003D5D2A /* PhotoTableViewCell.xib */; };
+		E6AB672724E88182003D5D2A /* PhotoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AB671C24E88182003D5D2A /* PhotoTableViewCell.swift */; };
+		E6AB672824E88182003D5D2A /* VideoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AB671D24E88182003D5D2A /* VideoTableViewCell.swift */; };
+		E6AB672924E88182003D5D2A /* VideoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E6AB671E24E88182003D5D2A /* VideoTableViewCell.xib */; };
+		E6AB672A24E88182003D5D2A /* StoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AB671F24E88182003D5D2A /* StoryTableViewCell.swift */; };
 		E6AC98B823CCD5DE00E95381 /* MainNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AC98B723CCD5DE00E95381 /* MainNavController.swift */; };
 		E6B4034D22D8E12500A0DDCA /* remote-posts-ids-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */; };
 		E6B4034E22D8E12500A0DDCA /* remote-posts-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */; };
@@ -459,6 +470,17 @@
 		E6A7C06C2257A42400CC2191 /* UserServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserServiceRemote.swift; sourceTree = "<group>"; };
 		E6A800F224380A5300A14E6C /* FolderStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderStore.swift; sourceTree = "<group>"; };
 		E6A800F424380A6600A14E6C /* FolderAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderAction.swift; sourceTree = "<group>"; };
+		E6AB671524E88182003D5D2A /* AudioTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioTableViewCell.swift; sourceTree = "<group>"; };
+		E6AB671624E88182003D5D2A /* TextNoteTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextNoteTableViewCell.swift; sourceTree = "<group>"; };
+		E6AB671724E88182003D5D2A /* CellBackgroundView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CellBackgroundView.swift; sourceTree = "<group>"; };
+		E6AB671824E88182003D5D2A /* StoryTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StoryTableViewCell.xib; sourceTree = "<group>"; };
+		E6AB671924E88182003D5D2A /* AudioTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AudioTableViewCell.xib; sourceTree = "<group>"; };
+		E6AB671A24E88182003D5D2A /* TextNoteTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TextNoteTableViewCell.xib; sourceTree = "<group>"; };
+		E6AB671B24E88182003D5D2A /* PhotoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PhotoTableViewCell.xib; sourceTree = "<group>"; };
+		E6AB671C24E88182003D5D2A /* PhotoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PhotoTableViewCell.swift; sourceTree = "<group>"; };
+		E6AB671D24E88182003D5D2A /* VideoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoTableViewCell.swift; sourceTree = "<group>"; };
+		E6AB671E24E88182003D5D2A /* VideoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = VideoTableViewCell.xib; sourceTree = "<group>"; };
+		E6AB671F24E88182003D5D2A /* StoryTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryTableViewCell.swift; sourceTree = "<group>"; };
 		E6AC98B723CCD5DE00E95381 /* MainNavController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavController.swift; sourceTree = "<group>"; };
 		E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-ids-edit.json"; sourceTree = "<group>"; };
 		E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-edit.json"; sourceTree = "<group>"; };
@@ -793,6 +815,17 @@
 		E6138FFD22120433004E5B91 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				E6AB671524E88182003D5D2A /* AudioTableViewCell.swift */,
+				E6AB671924E88182003D5D2A /* AudioTableViewCell.xib */,
+				E6AB671C24E88182003D5D2A /* PhotoTableViewCell.swift */,
+				E6AB671B24E88182003D5D2A /* PhotoTableViewCell.xib */,
+				E6AB671F24E88182003D5D2A /* StoryTableViewCell.swift */,
+				E6AB671824E88182003D5D2A /* StoryTableViewCell.xib */,
+				E6AB671624E88182003D5D2A /* TextNoteTableViewCell.swift */,
+				E6AB671A24E88182003D5D2A /* TextNoteTableViewCell.xib */,
+				E6AB671D24E88182003D5D2A /* VideoTableViewCell.swift */,
+				E6AB671E24E88182003D5D2A /* VideoTableViewCell.xib */,
+				E6AB671724E88182003D5D2A /* CellBackgroundView.swift */,
 				E604EE4624C76FAD0015D284 /* CircularImageView.swift */,
 				E604EE4A24C774FB0015D284 /* SimpleTableViewCell.swift */,
 				E604EE4824C774A80015D284 /* UserView.swift */,
@@ -1193,13 +1226,18 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E6AB672624E88182003D5D2A /* PhotoTableViewCell.xib in Resources */,
 				E66B7D4822162754004355D3 /* replace_secrets.rb in Resources */,
+				E6AB672524E88182003D5D2A /* TextNoteTableViewCell.xib in Resources */,
 				E65469F724C78C420083FAA5 /* acknowledgements.htm in Resources */,
+				E6AB672924E88182003D5D2A /* VideoTableViewCell.xib in Resources */,
 				E6138FDF2211FE88004E5B91 /* LaunchScreen.storyboard in Resources */,
 				E66B7D4622162754004355D3 /* InfoPlist.tpl in Resources */,
+				E6AB672424E88182003D5D2A /* AudioTableViewCell.xib in Resources */,
 				E6138FDC2211FE88004E5B91 /* Assets.xcassets in Resources */,
 				E6138FD72211FE86004E5B91 /* Main.storyboard in Resources */,
 				E6190C4724BF834B0060D00A /* ColorStudio.xcassets in Resources */,
+				E6AB672324E88182003D5D2A /* StoryTableViewCell.xib in Resources */,
 				E66B7D4522162754004355D3 /* ApiCredentials.tpl in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1389,6 +1427,7 @@
 				E636C260234FBACC00564B63 /* MediaItemStore.swift in Sources */,
 				E61D8F6F2378C95B005FECED /* StagedMedia+CoreDataProperties.swift in Sources */,
 				E61D8F702378C95B005FECED /* StagedMedia+CoreDataClass.swift in Sources */,
+				E6AB672124E88182003D5D2A /* TextNoteTableViewCell.swift in Sources */,
 				E602E69822C1670800795CBA /* PostAction.swift in Sources */,
 				E6138FD42211FE86004E5B91 /* InitialViewController.swift in Sources */,
 				E66CCA072303527C00F1CA59 /* Account+CoreDataClass.swift in Sources */,
@@ -1396,6 +1435,7 @@
 				E6BA1322243F9D1E00635A8A /* AssetsViewController.swift in Sources */,
 				E6A4D742230A08A700929376 /* StagedEdits+CoreDataProperties.swift in Sources */,
 				E636C26B234FEAD800564B63 /* MediaQuery+CoreDataClass.swift in Sources */,
+				E6AB672224E88182003D5D2A /* CellBackgroundView.swift in Sources */,
 				E67339A6232EFEA3007C5E45 /* Logging.swift in Sources */,
 				E6034B1422529414007DB6DD /* UserAgent.swift in Sources */,
 				E6500F9D2368F36500CB8C6C /* MediaDetailViewController.swift in Sources */,
@@ -1407,6 +1447,7 @@
 				E6A4D743230A08A700929376 /* StagedEdits+CoreDataClass.swift in Sources */,
 				E602E69222C1666C00795CBA /* AccountAction.swift in Sources */,
 				E6D44DEC234BC56C00B51438 /* SiteMediaViewController.swift in Sources */,
+				E6AB672824E88182003D5D2A /* VideoTableViewCell.swift in Sources */,
 				E67B9D61236775FC00860A6C /* MediaCache+CoreDataProperties.swift in Sources */,
 				E6138FDA2211FE86004E5B91 /* Newspack.xcdatamodeld in Sources */,
 				E66CCA192303527D00F1CA59 /* Media+CoreDataProperties.swift in Sources */,
@@ -1440,6 +1481,7 @@
 				E632F9A123515116003737BF /* SiteMediaDataSource.swift in Sources */,
 				E62C7C662235E16E000FEB33 /* AccountStore.swift in Sources */,
 				E6C3988C24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift in Sources */,
+				E6AB672024E88182003D5D2A /* AudioTableViewCell.swift in Sources */,
 				E6E43EA4230F1D2B00A1974E /* EditAction.swift in Sources */,
 				E6190C4F24BF8DFA0060D00A /* UIColor+SemanticColors.swift in Sources */,
 				E695A7E6244FD686007B29BB /* StoryFolder+CoreDataProperties.swift in Sources */,
@@ -1462,6 +1504,7 @@
 				E679AD7324C0E831000FDF90 /* SidebarContainerViewController.swift in Sources */,
 				E66CCA102303527C00F1CA59 /* User+CoreDataProperties.swift in Sources */,
 				E6E2ACF722E10F3400A8E85D /* MainStoryboard.swift in Sources */,
+				E6AB672A24E88182003D5D2A /* StoryTableViewCell.swift in Sources */,
 				E6A800F524380A6600A14E6C /* FolderAction.swift in Sources */,
 				E67F56D52230914800BFD38B /* CoreDataManager.swift in Sources */,
 				E602E69F22C1747D00795CBA /* Dictionary+Unwrappers.swift in Sources */,
@@ -1502,6 +1545,7 @@
 				E636C262234FBE6800564B63 /* RemoteMedia.swift in Sources */,
 				E6DF5575242E7139007DDC47 /* FolderManager.swift in Sources */,
 				E6D44DF1234BDBA000B51438 /* MediaApiService.swift in Sources */,
+				E6AB672724E88182003D5D2A /* PhotoTableViewCell.swift in Sources */,
 				E694469E24DB3FA100D0BF56 /* MediaCaptureController.swift in Sources */,
 				E66CCA0C2303527C00F1CA59 /* Media+CoreDataClass.swift in Sources */,
 				E692CA9F24CA2E6D008FB96B /* EventMonitor.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		E60A250E2425418E003F3C81 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60A250D2425418E003F3C81 /* ShareViewController.swift */; };
 		E60A25112425418E003F3C81 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E60A250F2425418E003F3C81 /* MainInterface.storyboard */; };
 		E60A25152425418E003F3C81 /* NewspackShare.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = E60A250B2425418E003F3C81 /* NewspackShare.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		E610B64324EC59040011FBA8 /* UITableView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610B64224EC59040011FBA8 /* UITableView+Helpers.swift */; };
 		E6138FD22211FE86004E5B91 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6138FD12211FE86004E5B91 /* AppDelegate.swift */; };
 		E6138FD42211FE86004E5B91 /* InitialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6138FD32211FE86004E5B91 /* InitialViewController.swift */; };
 		E6138FD72211FE86004E5B91 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E6138FD52211FE86004E5B91 /* Main.storyboard */; };
@@ -319,6 +320,7 @@
 		E60A250D2425418E003F3C81 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		E60A25102425418E003F3C81 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
 		E60A25122425418E003F3C81 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E610B64224EC59040011FBA8 /* UITableView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Helpers.swift"; sourceTree = "<group>"; };
 		E6138FCE2211FE86004E5B91 /* Newspack.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Newspack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E6138FD12211FE86004E5B91 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E6138FD32211FE86004E5B91 /* InitialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitialViewController.swift; sourceTree = "<group>"; };
@@ -1100,6 +1102,7 @@
 				E6E2ACF822E2840C00A8E85D /* Date+FormatGMTString.swift */,
 				E68A965F2460990B00BE664B /* NSManagedObject+Helpers.swift */,
 				E68A965D246098C700BE664B /* NSObject+Helpers.swift */,
+				E610B64224EC59040011FBA8 /* UITableView+Helpers.swift */,
 				E696340F2440C1C400D906E0 /* UITableViewCell+Helpers.swift */,
 				E63FF0EB24AA864C0002A32F /* URL+FileReference.swift */,
 				E6C3988B24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift */,
@@ -1443,6 +1446,7 @@
 				E636C26B234FEAD800564B63 /* MediaQuery+CoreDataClass.swift in Sources */,
 				E6AB672224E88182003D5D2A /* CellBackgroundView.swift in Sources */,
 				E67339A6232EFEA3007C5E45 /* Logging.swift in Sources */,
+				E610B64324EC59040011FBA8 /* UITableView+Helpers.swift in Sources */,
 				E6034B1422529414007DB6DD /* UserAgent.swift in Sources */,
 				E6500F9D2368F36500CB8C6C /* MediaDetailViewController.swift in Sources */,
 				E68408A024D0D0ED00C36AB9 /* FolderViewController.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -122,6 +122,11 @@
 		E65875A823A811F100185C75 /* MediaItemStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65875A723A811F100185C75 /* MediaItemStoreTests.swift */; };
 		E65875AA23A8139500185C75 /* StagedMediaImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65875A923A8139500185C75 /* StagedMediaImporterTests.swift */; };
 		E65875AC23A813EA00185C75 /* StagedMediaStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65875AB23A813EA00185C75 /* StagedMediaStoreTests.swift */; };
+		E65F1A2C24E5DBED00C9D04E /* StoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A2B24E5DBED00C9D04E /* StoryTableViewCell.swift */; };
+		E65F1A2E24E5DC0000C9D04E /* PhotoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A2D24E5DC0000C9D04E /* PhotoTableViewCell.swift */; };
+		E65F1A3024E5DC0C00C9D04E /* VideoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A2F24E5DC0C00C9D04E /* VideoTableViewCell.swift */; };
+		E65F1A3224E5DC1A00C9D04E /* TextNoteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A3124E5DC1A00C9D04E /* TextNoteTableViewCell.swift */; };
+		E65F1A3424E5DC2800C9D04E /* AudioTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65F1A3324E5DC2800C9D04E /* AudioTableViewCell.swift */; };
 		E66B7D4522162754004355D3 /* ApiCredentials.tpl in Resources */ = {isa = PBXBuildFile; fileRef = E66B7D3F22162754004355D3 /* ApiCredentials.tpl */; };
 		E66B7D4622162754004355D3 /* InfoPlist.tpl in Resources */ = {isa = PBXBuildFile; fileRef = E66B7D4022162754004355D3 /* InfoPlist.tpl */; };
 		E66B7D4822162754004355D3 /* replace_secrets.rb in Resources */ = {isa = PBXBuildFile; fileRef = E66B7D4422162754004355D3 /* replace_secrets.rb */; };
@@ -378,6 +383,11 @@
 		E65875A723A811F100185C75 /* MediaItemStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaItemStoreTests.swift; sourceTree = "<group>"; };
 		E65875A923A8139500185C75 /* StagedMediaImporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedMediaImporterTests.swift; sourceTree = "<group>"; };
 		E65875AB23A813EA00185C75 /* StagedMediaStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedMediaStoreTests.swift; sourceTree = "<group>"; };
+		E65F1A2B24E5DBED00C9D04E /* StoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryTableViewCell.swift; sourceTree = "<group>"; };
+		E65F1A2D24E5DC0000C9D04E /* PhotoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoTableViewCell.swift; sourceTree = "<group>"; };
+		E65F1A2F24E5DC0C00C9D04E /* VideoTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTableViewCell.swift; sourceTree = "<group>"; };
+		E65F1A3124E5DC1A00C9D04E /* TextNoteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextNoteTableViewCell.swift; sourceTree = "<group>"; };
+		E65F1A3324E5DC2800C9D04E /* AudioTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioTableViewCell.swift; sourceTree = "<group>"; };
 		E66B7D3F22162754004355D3 /* ApiCredentials.tpl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ApiCredentials.tpl; sourceTree = "<group>"; };
 		E66B7D4022162754004355D3 /* InfoPlist.tpl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = InfoPlist.tpl; sourceTree = "<group>"; };
 		E66B7D4422162754004355D3 /* replace_secrets.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = replace_secrets.rb; sourceTree = "<group>"; };
@@ -790,6 +800,11 @@
 				E604EE4624C76FAD0015D284 /* CircularImageView.swift */,
 				E604EE4A24C774FB0015D284 /* SimpleTableViewCell.swift */,
 				E604EE4824C774A80015D284 /* UserView.swift */,
+				E65F1A2B24E5DBED00C9D04E /* StoryTableViewCell.swift */,
+				E65F1A2D24E5DC0000C9D04E /* PhotoTableViewCell.swift */,
+				E65F1A2F24E5DC0C00C9D04E /* VideoTableViewCell.swift */,
+				E65F1A3124E5DC1A00C9D04E /* TextNoteTableViewCell.swift */,
+				E65F1A3324E5DC2800C9D04E /* AudioTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1383,6 +1398,7 @@
 				E61D8F6F2378C95B005FECED /* StagedMedia+CoreDataProperties.swift in Sources */,
 				E61D8F702378C95B005FECED /* StagedMedia+CoreDataClass.swift in Sources */,
 				E602E69822C1670800795CBA /* PostAction.swift in Sources */,
+				E65F1A3224E5DC1A00C9D04E /* TextNoteTableViewCell.swift in Sources */,
 				E6138FD42211FE86004E5B91 /* InitialViewController.swift in Sources */,
 				E66CCA072303527C00F1CA59 /* Account+CoreDataClass.swift in Sources */,
 				E69E59F922540D0900899DE2 /* SiteServiceRemote.swift in Sources */,
@@ -1403,6 +1419,7 @@
 				E67B9D61236775FC00860A6C /* MediaCache+CoreDataProperties.swift in Sources */,
 				E6138FDA2211FE86004E5B91 /* Newspack.xcdatamodeld in Sources */,
 				E66CCA192303527D00F1CA59 /* Media+CoreDataProperties.swift in Sources */,
+				E65F1A2E24E5DC0000C9D04E /* PhotoTableViewCell.swift in Sources */,
 				E66CCA1E2303527D00F1CA59 /* Status+CoreDataClass.swift in Sources */,
 				E6051DEC23075A3A005AAF0B /* Dictionary+Merge.swift in Sources */,
 				E677AAEB24B3C954000FAA3D /* AssetStore.swift in Sources */,
@@ -1419,6 +1436,7 @@
 				E64594A122B448C2003BF6C0 /* PostServiceRemote.swift in Sources */,
 				E68BA80C2347BAA300AB60F9 /* Environment.swift in Sources */,
 				E636C269234FEAD800564B63 /* MediaItem+CoreDataClass.swift in Sources */,
+				E65F1A3024E5DC0C00C9D04E /* VideoTableViewCell.swift in Sources */,
 				E66CCA1C2303527D00F1CA59 /* Revision+CoreDataClass.swift in Sources */,
 				E66CCA062303527C00F1CA59 /* Site+CoreDataClass.swift in Sources */,
 				E69E59FD22541ABD00899DE2 /* WordPressCoreRestApi.swift in Sources */,
@@ -1460,6 +1478,7 @@
 				E602E69F22C1747D00795CBA /* Dictionary+Unwrappers.swift in Sources */,
 				E6A800F324380A5300A14E6C /* FolderStore.swift in Sources */,
 				E629822A2303667E00E8CEC7 /* EditorViewController.swift in Sources */,
+				E65F1A3424E5DC2800C9D04E /* AudioTableViewCell.swift in Sources */,
 				E66CCA1B2303527D00F1CA59 /* User+CoreDataClass.swift in Sources */,
 				E6051DE323071A3A005AAF0B /* RemoteRevision.swift in Sources */,
 				E695A7E9244FD686007B29BB /* StoryAsset+CoreDataClass.swift in Sources */,
@@ -1484,6 +1503,7 @@
 				E61D8F6C2375EC3E005FECED /* StagedMediaStore.swift in Sources */,
 				E66CCA0D2303527C00F1CA59 /* Site+CoreDataProperties.swift in Sources */,
 				E604EE4924C774A80015D284 /* UserView.swift in Sources */,
+				E65F1A2C24E5DBED00C9D04E /* StoryTableViewCell.swift in Sources */,
 				E66CCA0B2303527C00F1CA59 /* Account+CoreDataProperties.swift in Sources */,
 				E63F3F3C236350BE00DB760E /* MediaTypeDiscerner.swift in Sources */,
 				E602E68F22C1637800795CBA /* PostApiActions.swift in Sources */,

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -19,11 +19,16 @@ class AssetsViewController: ToolbarViewController, UITableViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        configureCells()
         configureDataSource()
         configureSortControl()
         configureNavbar()
         configureStyle()
         tableView.tableFooterView = UIView()
+    }
+
+    func configureCells() {
+        tableView.register(UINib(nibName: "TextNoteTableViewCell", bundle: nil), forCellReuseIdentifier: TextNoteTableViewCell.reuseIdentifier)
     }
 
     func configureDataSource() {
@@ -123,11 +128,21 @@ extension AssetsViewController {
 extension AssetsViewController {
 
     func cellFor(tableView: UITableView, indexPath: IndexPath, storyAsset: StoryAsset) -> UITableViewCell {
+        if storyAsset.assetType == .textNote {
+            return configureTextCell(tableView: tableView, indexPath: indexPath, storyAsset: storyAsset)
+        }
+
         let cell = tableView.dequeueReusableCell(withIdentifier: "AssetCell", for: indexPath)
         cell.textLabel?.text = storyAsset.name + " " + String(storyAsset.order)
         cell.detailTextLabel?.text = storyAsset.uuid.uuidString
         cell.accessoryType = .disclosureIndicator
 
+        return cell
+    }
+
+    func configureTextCell(tableView: UITableView, indexPath: IndexPath, storyAsset: StoryAsset) -> TextNoteTableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: TextNoteTableViewCell.reuseIdentifier, for: indexPath) as! TextNoteTableViewCell
+        cell.configure(note: storyAsset)
         return cell
     }
 

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -30,6 +30,7 @@ class AssetsViewController: ToolbarViewController, UITableViewDelegate {
     func configureCells() {
         tableView.register(UINib(nibName: "TextNoteTableViewCell", bundle: nil), forCellReuseIdentifier: TextNoteTableViewCell.reuseIdentifier)
         tableView.register(UINib(nibName: "PhotoTableViewCell", bundle: nil), forCellReuseIdentifier: PhotoTableViewCell.reuseIdentifier)
+        tableView.register(UINib(nibName: "VideoTableViewCell", bundle: nil), forCellReuseIdentifier: VideoTableViewCell.reuseIdentifier)
     }
 
     func configureDataSource() {
@@ -137,6 +138,10 @@ extension AssetsViewController {
             return configurePhotoCell(tableView: tableView, indexPath: indexPath, storyAsset: storyAsset)
         }
 
+        if storyAsset.assetType == .video {
+            return configureVideoCell(tableView: tableView, indexPath: indexPath, storyAsset: storyAsset)
+        }
+
         let cell = tableView.dequeueReusableCell(withIdentifier: "AssetCell", for: indexPath)
         cell.textLabel?.text = storyAsset.name + " " + String(storyAsset.order)
         cell.detailTextLabel?.text = storyAsset.uuid.uuidString
@@ -155,6 +160,14 @@ extension AssetsViewController {
         let cell = tableView.dequeueReusableCell(withIdentifier: PhotoTableViewCell.reuseIdentifier, for: indexPath) as! PhotoTableViewCell
 
         let image = thumbnail(from: storyAsset, size: PhotoTableViewCell.imageSize)
+        cell.configure(photo: storyAsset, image: image)
+        return cell
+    }
+
+    func configureVideoCell(tableView: UITableView, indexPath: IndexPath, storyAsset: StoryAsset) -> VideoTableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: VideoTableViewCell.reuseIdentifier, for: indexPath) as! VideoTableViewCell
+
+        let image = thumbnail(from: storyAsset, size: VideoTableViewCell.imageSize)
         cell.configure(photo: storyAsset, image: image)
         return cell
     }

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -143,13 +143,13 @@ extension AssetsViewController {
     }
 
     func configureTextCell(tableView: UITableView, indexPath: IndexPath, storyAsset: StoryAsset) -> TextNoteTableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: TextNoteTableViewCell.reuseIdentifier, for: indexPath) as! TextNoteTableViewCell
+        let cell = tableView.dequeueReusableCell(ofType: TextNoteTableViewCell.self, for: indexPath)
         cell.configure(note: storyAsset)
         return cell
     }
 
     func configurePhotoCell(tableView: UITableView, indexPath: IndexPath, storyAsset: StoryAsset) -> PhotoTableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: PhotoTableViewCell.reuseIdentifier, for: indexPath) as! PhotoTableViewCell
+        let cell = tableView.dequeueReusableCell(ofType: PhotoTableViewCell.self, for: indexPath)
 
         let image = thumbnail(from: storyAsset, size: PhotoTableViewCell.imageSize)
         cell.configure(photo: storyAsset, image: image)
@@ -157,7 +157,7 @@ extension AssetsViewController {
     }
 
     func configureVideoCell(tableView: UITableView, indexPath: IndexPath, storyAsset: StoryAsset) -> VideoTableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: VideoTableViewCell.reuseIdentifier, for: indexPath) as! VideoTableViewCell
+        let cell = tableView.dequeueReusableCell(ofType: VideoTableViewCell.self, for: indexPath)
 
         let image = thumbnail(from: storyAsset, size: VideoTableViewCell.imageSize)
         cell.configure(video: storyAsset, image: image)
@@ -165,7 +165,8 @@ extension AssetsViewController {
     }
 
     func configureAudioCell(tableView: UITableView, indexPath: IndexPath, storyAsset: StoryAsset) -> AudioTableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: AudioTableViewCell.reuseIdentifier, for: indexPath) as! AudioTableViewCell
+        let cell = tableView.dequeueReusableCell(ofType: AudioTableViewCell.self, for: indexPath)
+
         cell.configure(audio: storyAsset)
         return cell
     }

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -130,24 +130,16 @@ extension AssetsViewController {
 extension AssetsViewController {
 
     func cellFor(tableView: UITableView, indexPath: IndexPath, storyAsset: StoryAsset) -> UITableViewCell {
-        if storyAsset.assetType == .textNote {
+        switch storyAsset.assetType {
+        case .textNote:
             return configureTextCell(tableView: tableView, indexPath: indexPath, storyAsset: storyAsset)
-        }
-
-        if storyAsset.assetType == .image {
+        case .image:
             return configurePhotoCell(tableView: tableView, indexPath: indexPath, storyAsset: storyAsset)
-        }
-
-        if storyAsset.assetType == .video {
+        case .video:
             return configureVideoCell(tableView: tableView, indexPath: indexPath, storyAsset: storyAsset)
+        case .audioNote:
+            return configureAudioCell(tableView: tableView, indexPath: indexPath, storyAsset: storyAsset)
         }
-
-        let cell = tableView.dequeueReusableCell(withIdentifier: "AssetCell", for: indexPath)
-        cell.textLabel?.text = storyAsset.name + " " + String(storyAsset.order)
-        cell.detailTextLabel?.text = storyAsset.uuid.uuidString
-        cell.accessoryType = .disclosureIndicator
-
-        return cell
     }
 
     func configureTextCell(tableView: UITableView, indexPath: IndexPath, storyAsset: StoryAsset) -> TextNoteTableViewCell {
@@ -168,7 +160,13 @@ extension AssetsViewController {
         let cell = tableView.dequeueReusableCell(withIdentifier: VideoTableViewCell.reuseIdentifier, for: indexPath) as! VideoTableViewCell
 
         let image = thumbnail(from: storyAsset, size: VideoTableViewCell.imageSize)
-        cell.configure(photo: storyAsset, image: image)
+        cell.configure(video: storyAsset, image: image)
+        return cell
+    }
+
+    func configureAudioCell(tableView: UITableView, indexPath: IndexPath, storyAsset: StoryAsset) -> AudioTableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: AudioTableViewCell.reuseIdentifier, for: indexPath) as! AudioTableViewCell
+        cell.configure(audio: storyAsset)
         return cell
     }
 

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import CoreData
 import WordPressFlux
-import AVFoundation
+
 class AssetsViewController: ToolbarViewController, UITableViewDelegate {
 
     struct Constants {

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -29,6 +29,7 @@ class AssetsViewController: ToolbarViewController, UITableViewDelegate {
 
     func configureCells() {
         tableView.register(UINib(nibName: "TextNoteTableViewCell", bundle: nil), forCellReuseIdentifier: TextNoteTableViewCell.reuseIdentifier)
+        tableView.register(UINib(nibName: "PhotoTableViewCell", bundle: nil), forCellReuseIdentifier: PhotoTableViewCell.reuseIdentifier)
     }
 
     func configureDataSource() {
@@ -132,6 +133,10 @@ extension AssetsViewController {
             return configureTextCell(tableView: tableView, indexPath: indexPath, storyAsset: storyAsset)
         }
 
+        if storyAsset.assetType == .image {
+            return configurePhotoCell(tableView: tableView, indexPath: indexPath, storyAsset: storyAsset)
+        }
+
         let cell = tableView.dequeueReusableCell(withIdentifier: "AssetCell", for: indexPath)
         cell.textLabel?.text = storyAsset.name + " " + String(storyAsset.order)
         cell.detailTextLabel?.text = storyAsset.uuid.uuidString
@@ -146,6 +151,12 @@ extension AssetsViewController {
         return cell
     }
 
+    func configurePhotoCell(tableView: UITableView, indexPath: IndexPath, storyAsset: StoryAsset) -> PhotoTableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: PhotoTableViewCell.reuseIdentifier, for: indexPath) as! PhotoTableViewCell
+        let image = UIImage()
+        cell.configure(photo: storyAsset, image: image)
+        return cell
+    }
 }
 
 // MARK: - AssetDataSource

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -13,6 +13,7 @@ class FoldersViewController: ToolbarViewController, UITableViewDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         registerCells()
         configureDataSource()
         configureSortControls()

--- a/Newspack/Newspack/Controllers/FoldersViewController.swift
+++ b/Newspack/Newspack/Controllers/FoldersViewController.swift
@@ -13,12 +13,16 @@ class FoldersViewController: ToolbarViewController, UITableViewDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        registerCells()
         configureDataSource()
         configureSortControls()
         configureNavbar()
         configureStyle()
         tableView.tableFooterView = UIView()
+    }
+
+    func registerCells() {
+        tableView.register(UINib(nibName: "StoryTableViewCell", bundle: nil), forCellReuseIdentifier: StoryTableViewCell.reuseIdentifier)
     }
 
     func configureDataSource() {
@@ -159,34 +163,14 @@ extension FoldersViewController {
 extension FoldersViewController {
 
     func cellFor(tableView: UITableView, indexPath: IndexPath, storyFolder: StoryFolder) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: FolderCell.reuseIdentifier, for: indexPath) as? FolderCell else {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: StoryTableViewCell.reuseIdentifier, for: indexPath) as? StoryTableViewCell else {
             fatalError("Cannot create new cell")
         }
-        Appearance.style(cell: cell)
 
-        cell.textLabel?.text = storyFolder.name
-        cell.accessoryType = .disclosureIndicator
-        cell.selectedStory = storyFolder.uuid == StoreContainer.shared.folderStore.currentStoryFolderID
+        let current = storyFolder.uuid == StoreContainer.shared.folderStore.currentStoryFolderID
+        cell.configure(story: storyFolder, current: current)
 
         return cell
-    }
-
-}
-
-// MARK: - Folder Cell
-
-class FolderCell: UITableViewCell {
-
-    var selectedStory: Bool = false {
-        didSet {
-            textLabel?.textColor = selectedStory ? .textLink : .text
-        }
-    }
-
-    override func prepareForReuse() {
-        super.prepareForReuse()
-
-        selectedStory = false
     }
 
 }

--- a/Newspack/Newspack/Extensions/CGSize+Helpers.swift
+++ b/Newspack/Newspack/Extensions/CGSize+Helpers.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+// Helper extension to make CGSize hashable so it can be used as dictionary keys.
+//
+extension CGSize: Hashable {
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(width)
+        hasher.combine(height)
+    }
+
+    public var hashValue: Int {
+        var hasher = Hasher()
+        self.hash(into: &hasher)
+        return hasher.finalize()
+    }
+
+}

--- a/Newspack/Newspack/Extensions/UITableView+Helpers.swift
+++ b/Newspack/Newspack/Extensions/UITableView+Helpers.swift
@@ -1,0 +1,15 @@
+import UIKit
+
+extension UITableView {
+
+    /// Returns a cell of a given kind, to be displayed at the specified IndexPath
+    ///
+    func dequeueReusableCell<T: UITableViewCell>(ofType type: T.Type, for indexPath: IndexPath) -> T {
+        guard let cell = dequeueReusableCell(withIdentifier: T.reuseIdentifier, for: indexPath) as? T else {
+            fatalError()
+        }
+
+        return cell
+    }
+
+}

--- a/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
+++ b/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
@@ -2,14 +2,13 @@ import Foundation
 import CoreData
 
 @objc(StoryAsset)
-public class StoryAsset: NSManagedObject {
+public class StoryAsset: NSManagedObject, TextNoteCellProvider {
 
     public override func willSave() {
         super.willSave()
 
         updateSortedIfNeeded()
     }
-
 
     /// Called from willSave which will be called again if there are any changes
     /// so only update the property if necessary.

--- a/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
+++ b/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
@@ -2,7 +2,11 @@ import Foundation
 import CoreData
 
 @objc(StoryAsset)
-public class StoryAsset: NSManagedObject, TextNoteCellProvider {
+public class StoryAsset: NSManagedObject, TextNoteCellProvider, PhotoCellProvider {
+
+    var caption: String! {
+        return ""
+    }
 
     public override func willSave() {
         super.willSave()

--- a/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
+++ b/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
@@ -2,7 +2,7 @@ import Foundation
 import CoreData
 
 @objc(StoryAsset)
-public class StoryAsset: NSManagedObject, TextNoteCellProvider, PhotoCellProvider, VideoCellProvider {
+public class StoryAsset: NSManagedObject, TextNoteCellProvider, PhotoCellProvider, VideoCellProvider, AudioCellProvider {
 
     var caption: String! {
         return ""

--- a/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
+++ b/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
@@ -2,7 +2,7 @@ import Foundation
 import CoreData
 
 @objc(StoryAsset)
-public class StoryAsset: NSManagedObject, TextNoteCellProvider, PhotoCellProvider {
+public class StoryAsset: NSManagedObject, TextNoteCellProvider, PhotoCellProvider, VideoCellProvider {
 
     var caption: String! {
         return ""

--- a/Newspack/Newspack/Models/StoryFolder+CoreDataClass.swift
+++ b/Newspack/Newspack/Models/StoryFolder+CoreDataClass.swift
@@ -2,6 +2,54 @@ import Foundation
 import CoreData
 
 @objc(StoryFolder)
-public class StoryFolder: NSManagedObject {
+public class StoryFolder: NSManagedObject, StoryCellProvider {
+
+    var textNotes: [StoryAsset] {
+        let items = assets.filter { (asset) -> Bool in
+            asset.assetType == .textNote
+        }
+        return Array(items)
+    }
+
+    var videos: [StoryAsset] {
+        let items = assets.filter { (asset) -> Bool in
+            asset.assetType == .video
+        }
+        return Array(items)
+    }
+
+    var images: [StoryAsset] {
+        let items = assets.filter { (asset) -> Bool in
+            asset.assetType == .image
+        }
+        return Array(items)
+    }
+
+    var audioNotes: [StoryAsset] {
+        let items = assets.filter { (asset) -> Bool in
+            asset.assetType == .audioNote
+        }
+        return Array(items)
+    }
+
+    var needsSync: Bool {
+        return true
+    }
+
+    var textNoteCount: Int {
+        return textNotes.count
+    }
+
+    var imageCount: Int {
+        return images.count
+    }
+
+    var videoCount: Int {
+        return videos.count
+    }
+
+    var audioNoteCount: Int {
+        return audioNotes.count
+    }
 
 }

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hEm-rr-Shu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hEm-rr-Shu">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -229,16 +229,6 @@
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="DE7-1p-iKS">
                                 <rect key="frame" x="0.0" y="45" width="375" height="529"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="FolderCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FolderCell" id="8Pc-C0-8g3" customClass="FolderCell" customModule="Newspack" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8Pc-C0-8g3" id="L3s-pR-PR2">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </prototypes>
                                 <connections>
                                     <outlet property="dataSource" destination="HoW-Ma-W9C" id="8Ng-Wc-nDy"/>
                                     <outlet property="delegate" destination="HoW-Ma-W9C" id="6yv-IN-AI1"/>

--- a/Newspack/Newspack/Styles/Appearance.swift
+++ b/Newspack/Newspack/Styles/Appearance.swift
@@ -65,6 +65,11 @@ class Appearance {
         button.tintColor = .newspackBlue(.shade30)
     }
 
+    static func style(cellSyncButton button: UIButton, iconType: GridiconType) {
+        let size = CGSize(width: 24, height: 24)
+        button.setImage(.gridicon(iconType, size: size), for: .normal)
+        button.tintColor = .newspackBlue(.shade30)
+    }
 }
 
 // MARK: - Fonts

--- a/Newspack/Newspack/Styles/Appearance.swift
+++ b/Newspack/Newspack/Styles/Appearance.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import Gridicons
 
 class Appearance {
 
@@ -57,6 +58,13 @@ class Appearance {
         footer.textLabel?.textAlignment = .center
         footer.textLabel?.backgroundColor = .neutral(.shade0)
     }
+
+    static func style(cellIconButton button: UIButton, iconType: GridiconType) {
+        let size = CGSize(width: 16, height: 16)
+        button.setImage(.gridicon(iconType, size: size), for: .normal)
+        button.tintColor = .newspackBlue(.shade30)
+    }
+
 }
 
 // MARK: - Fonts
@@ -69,27 +77,6 @@ extension UIFont {
 
     static var tableViewSubtitle: UIFont {
         .preferredFont(forTextStyle: .callout)
-    }
-
-}
-
-// MARK: - Custom Views
-
-// Apparently views used for a cell's background do not have their traits updated
-// correctly. So we'll use this class to inspect the parent's traits to see if
-// we're in light or dark mode.
-class CellBackgroundView: UIView {
-
-    override func willMove(toSuperview newSuperview: UIView?) {
-        super.willMove(toSuperview: newSuperview)
-        guard let superView = newSuperview else {
-            return
-        }
-        if superView.traitCollection.userInterfaceStyle == .dark {
-            backgroundColor = .withColorStudio(.newspackBlue, shade: .shade80)
-        } else {
-            backgroundColor = .withColorStudio(.newspackBlue, shade: .shade20)
-        }
     }
 
 }

--- a/Newspack/Newspack/Utils/ImageResizer.swift
+++ b/Newspack/Newspack/Utils/ImageResizer.swift
@@ -1,0 +1,102 @@
+import UIKit
+import Foundation
+
+/// A singleton class for resizing UIImages. Resized images are kept in an NSCache
+/// for quick retrieval.  The resized images are resized so they will aspectFill
+/// their target size. (No letterboxing!)
+///
+class ImageResizer {
+
+    /// Singleton reference.
+    static let shared = ImageResizer()
+
+    private var cache = NSCache<NSString, UIImage>()
+
+    private var renderers = [CGSize: UIGraphicsImageRenderer]()
+
+    /// Private initializer.  Use the singleton.
+    private init() {}
+
+    /// Creates a resized version of the specified UIImage. Resized images are
+    /// cached for later retrivial via their identifier and size.
+    ///
+    /// - Parameters:
+    ///   - image: The UIImage instance to resize.
+    ///   - identifier: An identifier to use as part of a cache key for later retrieval.
+    ///   - size: The target size that the resized image should fill. Used as part of the cache key.
+    ///   - force: Whether to skip the cache and create a freshly resized image. Default is false.
+    /// - Returns: The resized image.
+    ///
+    func resizeImage(image: UIImage, identifier: String, fillingSize size: CGSize, force: Bool = false) -> UIImage {
+
+        // Return a cached iamge if one exists.
+        if !force, let thumb = resizedImage(identifier: identifier, size: size) {
+            return thumb
+        }
+
+        let originalSize = image.size
+        let scale = max((size.width / originalSize.width), (size.height / originalSize.height))
+        let targetSize = CGSize(width: originalSize.width * scale, height: originalSize.height * scale)
+
+        let r = renderer(for: targetSize)
+
+        let thumb = r.image { (context) in
+            image.draw(in: CGRect(origin: .zero, size: targetSize))
+        }
+
+        cacheImage(image: thumb, identifier: identifier, size: size)
+
+        return thumb
+    }
+
+    /// Fetches a resized image from the cache (if it exists).
+    ///
+    /// - Parameters:
+    ///   - identifier: The identifier for the image.
+    ///   - size: The size of the image.
+    /// - Returns: The cached image or nil if one was not found.
+    ///
+    func resizedImage(identifier: String, size: CGSize) -> UIImage? {
+        let key = cacheKey(for: identifier, size: size)
+        return cache.object(forKey: key)
+    }
+
+    /// Adds the specified image to the internal cache based on its identifier and size.
+    /// - Parameters:
+    ///   - image: The UIImage to cache.
+    ///   - identifier: The identifier to use as one part of the cache key.
+    ///   - size: The size of the image. This is used as the second part of the cache key.
+    private func cacheImage(image: UIImage, identifier: String, size: CGSize) {
+        let key = cacheKey(for: identifier, size: size)
+        cache.setObject(image, forKey: key)
+    }
+
+    /// Returns a UIGraphicsImageRenderer to render images of the specified size.
+    /// Rather than recreating renderers as needed we keep them in memory for
+    /// performance reasons.  UIGraphicsImageRenderer maintain an internal cache
+    /// that can speed up recreating images as needed.
+    ///
+    /// - Parameter size: The size of UIImage that the renderer should create.
+    /// - Returns: A renderer. If one is not cached a new renderer is created.
+    ///
+    private func renderer(for size: CGSize) -> UIGraphicsImageRenderer {
+        if let renderer = renderers[size] {
+            return renderer
+        }
+        let renderer = UIGraphicsImageRenderer(size: size)
+        renderers[size] = renderer
+        return renderer
+    }
+
+    /// Create a key to use for the image cache based on the identifier and size.
+    ///
+    /// - Parameters:
+    ///   - identifier: The identifier to use for the key.
+    ///   - size: The CGSize to use for the key.
+    /// - Returns: An NSString to use as a cache key.
+    ///
+    private func cacheKey(for identifier: String, size: CGSize) -> NSString {
+        let key = identifier + String(size.hashValue)
+        return NSString(string: key)
+    }
+}

--- a/Newspack/Newspack/View/AudioTableViewCell.swift
+++ b/Newspack/Newspack/View/AudioTableViewCell.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+class AudioTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/Newspack/Newspack/View/AudioTableViewCell.swift
+++ b/Newspack/Newspack/View/AudioTableViewCell.swift
@@ -1,16 +1,35 @@
 import UIKit
 
+protocol AudioCellProvider {
+    var name: String! { get }
+    var caption: String! { get }
+}
+
 class AudioTableViewCell: UITableViewCell {
+
+    @IBOutlet var titleLabel: UILabel!
+    @IBOutlet var captionLabel: UILabel!
+    @IBOutlet var syncButton: UIButton!
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+
+        applyStyles()
     }
 
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
+    func applyStyles() {
+        titleLabel.textColor = .text
+        captionLabel.textColor = .text
+        Appearance.style(cellSyncButton: syncButton, iconType: .cloudUpload)
+    }
 
-        // Configure the view for the selected state
+    @IBAction func handleSyncTapped() {
+        print("tapped")
+    }
+
+    func configure(audio: AudioCellProvider) {
+        titleLabel.text = audio.name
+        captionLabel.text = audio.caption
     }
 
 }

--- a/Newspack/Newspack/View/AudioTableViewCell.xib
+++ b/Newspack/Newspack/View/AudioTableViewCell.xib
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="AudioTableViewCell" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Newspack/Newspack/View/AudioTableViewCell.xib
+++ b/Newspack/Newspack/View/AudioTableViewCell.xib
@@ -1,21 +1,74 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="AudioTableViewCell" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="AudioTableViewCell" customModule="Newspack" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="1KI-rP-1i8">
+                        <rect key="frame" x="16" y="0.0" width="288" height="44"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="Vgk-xr-df3">
+                                <rect key="frame" x="0.0" y="0.0" width="256" height="44"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filename.png" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mPo-DG-VUv">
+                                        <rect key="frame" x="0.0" y="0.0" width="256" height="24.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A short caption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pfb-b7-M6j">
+                                        <rect key="frame" x="0.0" y="24.5" width="256" height="19.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="PBk-A4-gUp"/>
+                                </constraints>
+                            </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UiF-vl-BcH">
+                                <rect key="frame" x="264" y="10" width="24" height="24"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="24" id="Uvy-mQ-16J"/>
+                                </constraints>
+                                <state key="normal" image="cloud-upload"/>
+                                <connections>
+                                    <action selector="handleSyncTapped" destination="KGk-i7-Jjw" eventType="touchUpInside" id="QNc-Q9-UGo"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="1KI-rP-1i8" secondAttribute="bottom" id="0eD-KN-32i"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="1KI-rP-1i8" secondAttribute="trailing" id="39j-9N-gGW"/>
+                    <constraint firstItem="1KI-rP-1i8" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="HzX-kz-2Qz"/>
+                    <constraint firstItem="1KI-rP-1i8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="KSS-Pr-fFl"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="captionLabel" destination="pfb-b7-M6j" id="XmZ-kj-FDG"/>
+                <outlet property="syncButton" destination="UiF-vl-BcH" id="S87-NG-Bg1"/>
+                <outlet property="titleLabel" destination="mPo-DG-VUv" id="Zjk-sW-BxH"/>
+            </connections>
+            <point key="canvasLocation" x="139" y="131"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <image name="cloud-upload" width="24" height="24"/>
+    </resources>
 </document>

--- a/Newspack/Newspack/View/CellBackgroundView.swift
+++ b/Newspack/Newspack/View/CellBackgroundView.swift
@@ -1,0 +1,21 @@
+import Foundation
+import UIKit
+
+// Apparently views used for a cell's background do not have their traits updated
+// correctly. So we'll use this class to inspect the parent's traits to see if
+// we're in light or dark mode.
+class CellBackgroundView: UIView {
+
+    override func willMove(toSuperview newSuperview: UIView?) {
+        super.willMove(toSuperview: newSuperview)
+        guard let superView = newSuperview else {
+            return
+        }
+        if superView.traitCollection.userInterfaceStyle == .dark {
+            backgroundColor = .withColorStudio(.newspackBlue, shade: .shade80)
+        } else {
+            backgroundColor = .withColorStudio(.newspackBlue, shade: .shade20)
+        }
+    }
+
+}

--- a/Newspack/Newspack/View/PhotoTableViewCell.swift
+++ b/Newspack/Newspack/View/PhotoTableViewCell.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+class PhotoTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/Newspack/Newspack/View/PhotoTableViewCell.swift
+++ b/Newspack/Newspack/View/PhotoTableViewCell.swift
@@ -1,16 +1,38 @@
 import UIKit
 
+protocol PhotoCellProvider {
+    var name: String! { get }
+    var caption: String! { get }
+}
+
 class PhotoTableViewCell: UITableViewCell {
+
+    @IBOutlet var thumbnail: UIImageView!
+    @IBOutlet var titleLabel: UILabel!
+    @IBOutlet var captionLabel: UILabel!
+    @IBOutlet var syncButton: UIButton!
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+
+        applyStyles()
     }
 
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
+    func applyStyles() {
+        titleLabel.textColor = .text
+        captionLabel.textColor = .text
+        Appearance.style(cellSyncButton: syncButton, iconType: .cloudUpload)
+        thumbnail.layer.cornerRadius = 8
+    }
 
-        // Configure the view for the selected state
+    @IBAction func handleSyncTapped() {
+        print("tapped")
+    }
+
+    func configure(photo: PhotoCellProvider, image: UIImage) {
+        thumbnail.image = image
+        titleLabel.text = photo.name
+        captionLabel.text = photo.caption
     }
 
 }

--- a/Newspack/Newspack/View/PhotoTableViewCell.swift
+++ b/Newspack/Newspack/View/PhotoTableViewCell.swift
@@ -7,6 +7,8 @@ protocol PhotoCellProvider {
 
 class PhotoTableViewCell: UITableViewCell {
 
+    static let imageSize = CGSize(width: 32, height: 32)
+
     @IBOutlet var thumbnail: UIImageView!
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var captionLabel: UILabel!
@@ -29,7 +31,7 @@ class PhotoTableViewCell: UITableViewCell {
         print("tapped")
     }
 
-    func configure(photo: PhotoCellProvider, image: UIImage) {
+    func configure(photo: PhotoCellProvider, image: UIImage?) {
         thumbnail.image = image
         titleLabel.text = photo.name
         captionLabel.text = photo.caption

--- a/Newspack/Newspack/View/PhotoTableViewCell.xib
+++ b/Newspack/Newspack/View/PhotoTableViewCell.xib
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="PhotoTableViewCell" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Newspack/Newspack/View/PhotoTableViewCell.xib
+++ b/Newspack/Newspack/View/PhotoTableViewCell.xib
@@ -20,7 +20,7 @@
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="VGd-H8-JGt">
                         <rect key="frame" x="16" y="0.0" width="288" height="58"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="a7J-Pb-36d">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="a7J-Pb-36d">
                                 <rect key="frame" x="0.0" y="13" width="32" height="32"/>
                                 <color key="backgroundColor" name="Blue0"/>
                                 <constraints>

--- a/Newspack/Newspack/View/PhotoTableViewCell.xib
+++ b/Newspack/Newspack/View/PhotoTableViewCell.xib
@@ -1,21 +1,87 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="PhotoTableViewCell" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="58" id="KGk-i7-Jjw" customClass="PhotoTableViewCell" customModule="Newspack" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="58"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="58"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="VGd-H8-JGt">
+                        <rect key="frame" x="16" y="0.0" width="288" height="58"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="a7J-Pb-36d">
+                                <rect key="frame" x="0.0" y="13" width="32" height="32"/>
+                                <color key="backgroundColor" name="Blue0"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="32" id="9An-YK-PNE"/>
+                                    <constraint firstAttribute="height" constant="32" id="ySF-cN-mip"/>
+                                </constraints>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="v11-sv-yYq">
+                                <rect key="frame" x="40" y="7" width="216" height="44"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filename.png" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ipi-AX-Kta">
+                                        <rect key="frame" x="0.0" y="0.0" width="216" height="24.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A short caption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IEH-g8-IVe">
+                                        <rect key="frame" x="0.0" y="24.5" width="216" height="19.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="4sW-PR-bbI"/>
+                                </constraints>
+                            </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aSr-TH-1KN">
+                                <rect key="frame" x="264" y="17" width="24" height="24"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="24" id="Cge-Ah-Eqz"/>
+                                </constraints>
+                                <state key="normal" image="cloud-upload"/>
+                                <connections>
+                                    <action selector="handleSyncTapped" destination="KGk-i7-Jjw" eventType="touchUpInside" id="Wce-v9-tqP"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="VGd-H8-JGt" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="5mD-xP-dHt"/>
+                    <constraint firstItem="VGd-H8-JGt" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="Las-uT-gSG"/>
+                    <constraint firstAttribute="bottom" secondItem="VGd-H8-JGt" secondAttribute="bottom" id="Zul-q0-5AS"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="VGd-H8-JGt" secondAttribute="trailing" id="teK-dF-IF0"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="captionLabel" destination="IEH-g8-IVe" id="tJE-Fw-GhO"/>
+                <outlet property="syncButton" destination="aSr-TH-1KN" id="nBl-xP-XCc"/>
+                <outlet property="thumbnail" destination="a7J-Pb-36d" id="fxm-KA-RtJ"/>
+                <outlet property="titleLabel" destination="Ipi-AX-Kta" id="lJd-7N-ZQb"/>
+            </connections>
+            <point key="canvasLocation" x="118.84057971014494" y="123.21428571428571"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <image name="cloud-upload" width="24" height="24"/>
+        <namedColor name="Blue0">
+            <color red="0.9137254901960784" green="0.93725490196078431" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/Newspack/Newspack/View/StoryTableViewCell.swift
+++ b/Newspack/Newspack/View/StoryTableViewCell.swift
@@ -1,10 +1,27 @@
 import UIKit
+import Gridicons
+
+/// A convenience potocol to avoid tightly coupling the StoryFolder model to the
+/// cell. Any object implementing the protocol can be a provider.
+///
+protocol StoryCellProvider {
+    var postID: Int64 { get }
+    var name: String! { get }
+    var textNoteCount: Int { get }
+    var imageCount: Int { get }
+    var videoCount: Int { get }
+    var audioNoteCount: Int { get }
+    var needsSync: Bool { get }
+}
+
 
 class StoryTableViewCell: UITableViewCell {
 
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var syncImage: UIImageView!
     @IBOutlet var iconView: UIStackView!
+    // Note: Using buttons for convenience since they contain an image and a label.
+    // User interaction should be disabled in the xib.
     @IBOutlet var textIcon: UIButton!
     @IBOutlet var photosIcon: UIButton!
     @IBOutlet var videoIcon: UIButton!
@@ -16,22 +33,48 @@ class StoryTableViewCell: UITableViewCell {
         applyStyles()
     }
 
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
-
-    override func prepareForReuse() {
-        super.prepareForReuse()
-    }
-
     func applyStyles() {
-
+        Appearance.style(cellIconButton: textIcon, iconType: .posts)
+        Appearance.style(cellIconButton: photosIcon, iconType: .imageMultiple)
+        Appearance.style(cellIconButton: videoIcon, iconType: .video)
+        Appearance.style(cellIconButton: audioIcon, iconType: .microphone)
     }
 
-    func configure() {
+    /// Configure the cell for the story provider.
+    ///
+    /// - Parameters:
+    ///   - story: A StoryCellProvider instance.
+    ///   - current: Whether this cell represents the currently selected story.
+    ///
+    func configure(story: StoryCellProvider, current: Bool) {
+        // Configure title.
+        titleLabel.text = story.name
+        titleLabel.textColor = current ? .textLink : .text
 
+        // Configure which icons are visible (if any)
+        textIcon.isHidden = story.textNoteCount == 0
+        textIcon.setTitle(String(story.textNoteCount), for: .normal)
+
+        photosIcon.isHidden = story.imageCount == 0
+        photosIcon.setTitle(String(story.imageCount), for: .normal)
+
+        videoIcon.isHidden = story.videoCount == 0
+        videoIcon.setTitle(String(story.videoCount), for: .normal)
+
+        audioIcon.isHidden = story.audioNoteCount == 0
+        audioIcon.setTitle(String(story.audioNoteCount), for: .normal)
+
+        if story.postID > 0 {
+            syncImage.image = .gridicon(.cloudUpload)
+            syncImage.tintColor = story.needsSync ? .neutral(.shade30) : .accent
+        } else {
+            syncImage.image = .gridicon(.cloudOutline)
+            syncImage.tintColor = .neutral(.shade30)
+        }
+
+        // Hide or show the icon view and sync image.
+        iconView.isHidden = (textIcon.isHidden && photosIcon.isHidden && videoIcon.isHidden && audioIcon.isHidden)
+        syncImage.isHidden = iconView.isHidden
     }
 
 }

--- a/Newspack/Newspack/View/StoryTableViewCell.swift
+++ b/Newspack/Newspack/View/StoryTableViewCell.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+class StoryTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/Newspack/Newspack/View/StoryTableViewCell.swift
+++ b/Newspack/Newspack/View/StoryTableViewCell.swift
@@ -2,15 +2,36 @@ import UIKit
 
 class StoryTableViewCell: UITableViewCell {
 
+    @IBOutlet var titleLabel: UILabel!
+    @IBOutlet var syncImage: UIImageView!
+    @IBOutlet var iconView: UIStackView!
+    @IBOutlet var textIcon: UIButton!
+    @IBOutlet var photosIcon: UIButton!
+    @IBOutlet var videoIcon: UIButton!
+    @IBOutlet var audioIcon: UIButton!
+
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+
+        applyStyles()
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
 
         // Configure the view for the selected state
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+    }
+
+    func applyStyles() {
+
+    }
+
+    func configure() {
+
     }
 
 }

--- a/Newspack/Newspack/View/StoryTableViewCell.xib
+++ b/Newspack/Newspack/View/StoryTableViewCell.xib
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="StoryTableViewCell" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Newspack/Newspack/View/StoryTableViewCell.xib
+++ b/Newspack/Newspack/View/StoryTableViewCell.xib
@@ -1,21 +1,118 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="StoryTableViewCell" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="StoryTableViewCell" rowHeight="125" id="KGk-i7-Jjw" customClass="StoryTableViewCell" customModule="Newspack" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="125"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="125"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="z90-eF-0yh">
+                        <rect key="frame" x="8" y="8" width="304" height="109"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Cdy-Ny-O1q">
+                                <rect key="frame" x="0.0" y="0.0" width="304" height="81"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="10" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="699-nP-5oS">
+                                        <rect key="frame" x="0.0" y="0.0" width="275" height="81"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <color key="textColor" name="Gray90"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="cloud-upload" translatesAutoresizingMaskIntoConstraints="NO" id="LYz-Dt-Kfa">
+                                        <rect key="frame" x="283" y="0.0" width="21" height="24"/>
+                                    </imageView>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="LtG-6B-zWU">
+                                <rect key="frame" x="0.0" y="81" width="304" height="28"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="bottom" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="J7F-dn-qkY">
+                                        <rect key="frame" x="0.0" y="4" width="216" height="24"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OO1-sR-LYw">
+                                                <rect key="frame" x="0.0" y="0.0" width="30" height="24"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <state key="normal" title="1" image="posts">
+                                                    <color key="titleColor" red="0.20000000000000001" green="0.40000000000000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hku-cE-6a5">
+                                                <rect key="frame" x="62" y="0.0" width="30" height="24"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <state key="normal" title="1" image="image-multiple">
+                                                    <color key="titleColor" red="0.20000000000000001" green="0.40000000000000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aAY-ao-7ZA">
+                                                <rect key="frame" x="124" y="0.0" width="30" height="24"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <state key="normal" title="1" image="video">
+                                                    <color key="titleColor" red="0.20000000000000001" green="0.40000000000000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GaK-BY-GHs">
+                                                <rect key="frame" x="186" y="0.0" width="30" height="24"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <state key="normal" title="1" image="microphone">
+                                                    <color key="titleColor" red="0.20000000000000001" green="0.40000000000000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j2v-wK-6SO">
+                                        <rect key="frame" x="254" y="0.0" width="50" height="28"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="50" placeholder="YES" id="7Or-MQ-mPP"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="28" id="27A-e3-Tn3"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="z90-eF-0yh" secondAttribute="bottom" constant="8" id="JuX-er-2Rg"/>
+                    <constraint firstItem="z90-eF-0yh" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="QB6-0u-aSX"/>
+                    <constraint firstAttribute="trailing" secondItem="z90-eF-0yh" secondAttribute="trailing" constant="8" id="YzA-rP-Qxb"/>
+                    <constraint firstItem="z90-eF-0yh" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="wpk-Jg-bcc"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="audioIcon" destination="GaK-BY-GHs" id="Ynk-Rd-rNM"/>
+                <outlet property="iconView" destination="LtG-6B-zWU" id="ble-HS-wqT"/>
+                <outlet property="photosIcon" destination="Hku-cE-6a5" id="l7l-Iv-wWa"/>
+                <outlet property="syncImage" destination="LYz-Dt-Kfa" id="gO0-64-hfb"/>
+                <outlet property="textIcon" destination="OO1-sR-LYw" id="Y8W-Ob-QxP"/>
+                <outlet property="titleLabel" destination="699-nP-5oS" id="pF7-dC-4nz"/>
+                <outlet property="videoIcon" destination="aAY-ao-7ZA" id="3hY-bN-GlK"/>
+            </connections>
+            <point key="canvasLocation" x="137.68115942028987" y="179.79910714285714"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <image name="cloud-upload" width="24" height="24"/>
+        <image name="image-multiple" width="24" height="24"/>
+        <image name="microphone" width="24" height="24"/>
+        <image name="posts" width="24" height="24"/>
+        <image name="video" width="24" height="24"/>
+        <namedColor name="Gray90">
+            <color red="0.11372549019607843" green="0.13725490196078433" blue="0.15294117647058825" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/Newspack/Newspack/View/StoryTableViewCell.xib
+++ b/Newspack/Newspack/View/StoryTableViewCell.xib
@@ -40,28 +40,28 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="bottom" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="J7F-dn-qkY">
                                         <rect key="frame" x="0.0" y="4" width="216" height="24"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OO1-sR-LYw">
+                                            <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OO1-sR-LYw">
                                                 <rect key="frame" x="0.0" y="0.0" width="30" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <state key="normal" title="1" image="posts">
                                                     <color key="titleColor" red="0.20000000000000001" green="0.40000000000000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hku-cE-6a5">
+                                            <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hku-cE-6a5">
                                                 <rect key="frame" x="62" y="0.0" width="30" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <state key="normal" title="1" image="image-multiple">
                                                     <color key="titleColor" red="0.20000000000000001" green="0.40000000000000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aAY-ao-7ZA">
+                                            <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aAY-ao-7ZA">
                                                 <rect key="frame" x="124" y="0.0" width="30" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <state key="normal" title="1" image="video">
                                                     <color key="titleColor" red="0.20000000000000001" green="0.40000000000000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GaK-BY-GHs">
+                                            <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GaK-BY-GHs">
                                                 <rect key="frame" x="186" y="0.0" width="30" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <state key="normal" title="1" image="microphone">

--- a/Newspack/Newspack/View/StoryTableViewCell.xib
+++ b/Newspack/Newspack/View/StoryTableViewCell.xib
@@ -4,41 +4,40 @@
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="StoryTableViewCell" rowHeight="125" id="KGk-i7-Jjw" customClass="StoryTableViewCell" customModule="Newspack" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="StoryTableViewCell" rowHeight="125" id="KGk-i7-Jjw" customClass="StoryTableViewCell" customModule="Newspack" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="125"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="125"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="z90-eF-0yh">
-                        <rect key="frame" x="8" y="8" width="304" height="109"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="z90-eF-0yh">
+                        <rect key="frame" x="16" y="8" width="288" height="109"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Cdy-Ny-O1q">
-                                <rect key="frame" x="0.0" y="0.0" width="304" height="81"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" distribution="fillProportionally" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Cdy-Ny-O1q">
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="77"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="10" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="699-nP-5oS">
-                                        <rect key="frame" x="0.0" y="0.0" width="275" height="81"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="259" height="77"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <color key="textColor" name="Gray90"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="cloud-upload" translatesAutoresizingMaskIntoConstraints="NO" id="LYz-Dt-Kfa">
-                                        <rect key="frame" x="283" y="0.0" width="21" height="24"/>
+                                        <rect key="frame" x="267" y="0.0" width="21" height="24"/>
                                     </imageView>
                                 </subviews>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="LtG-6B-zWU">
-                                <rect key="frame" x="0.0" y="81" width="304" height="28"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" distribution="equalSpacing" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="LtG-6B-zWU">
+                                <rect key="frame" x="0.0" y="85" width="288" height="24"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="bottom" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="J7F-dn-qkY">
-                                        <rect key="frame" x="0.0" y="4" width="216" height="24"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="bottom" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="J7F-dn-qkY">
+                                        <rect key="frame" x="0.0" y="0.0" width="168" height="24"/>
                                         <subviews>
                                             <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OO1-sR-LYw">
                                                 <rect key="frame" x="0.0" y="0.0" width="30" height="24"/>
@@ -48,21 +47,21 @@
                                                 </state>
                                             </button>
                                             <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hku-cE-6a5">
-                                                <rect key="frame" x="62" y="0.0" width="30" height="24"/>
+                                                <rect key="frame" x="46" y="0.0" width="30" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <state key="normal" title="1" image="image-multiple">
                                                     <color key="titleColor" red="0.20000000000000001" green="0.40000000000000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
                                             </button>
                                             <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aAY-ao-7ZA">
-                                                <rect key="frame" x="124" y="0.0" width="30" height="24"/>
+                                                <rect key="frame" x="92" y="0.0" width="30" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <state key="normal" title="1" image="video">
                                                     <color key="titleColor" red="0.20000000000000001" green="0.40000000000000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
                                             </button>
                                             <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GaK-BY-GHs">
-                                                <rect key="frame" x="186" y="0.0" width="30" height="24"/>
+                                                <rect key="frame" x="138" y="0.0" width="30" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <state key="normal" title="1" image="microphone">
                                                     <color key="titleColor" red="0.20000000000000001" green="0.40000000000000002" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -71,28 +70,27 @@
                                         </subviews>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j2v-wK-6SO">
-                                        <rect key="frame" x="254" y="0.0" width="50" height="28"/>
+                                        <rect key="frame" x="238" y="0.0" width="50" height="24"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="50" placeholder="YES" id="7Or-MQ-mPP"/>
                                         </constraints>
                                     </view>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="28" id="27A-e3-Tn3"/>
-                                </constraints>
                             </stackView>
                         </subviews>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="42" id="pVM-pu-2q1"/>
+                        </constraints>
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="z90-eF-0yh" secondAttribute="bottom" constant="8" id="JuX-er-2Rg"/>
-                    <constraint firstItem="z90-eF-0yh" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="QB6-0u-aSX"/>
-                    <constraint firstAttribute="trailing" secondItem="z90-eF-0yh" secondAttribute="trailing" constant="8" id="YzA-rP-Qxb"/>
-                    <constraint firstItem="z90-eF-0yh" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="wpk-Jg-bcc"/>
+                    <constraint firstItem="z90-eF-0yh" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="9bm-aL-S19"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="z90-eF-0yh" secondAttribute="trailing" id="KCu-Nj-xTZ"/>
+                    <constraint firstItem="z90-eF-0yh" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Mna-uf-PT6"/>
+                    <constraint firstAttribute="bottom" secondItem="z90-eF-0yh" secondAttribute="bottom" constant="8" id="oLT-d1-f0I"/>
                 </constraints>
             </tableViewCellContentView>
-            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="audioIcon" destination="GaK-BY-GHs" id="Ynk-Rd-rNM"/>
                 <outlet property="iconView" destination="LtG-6B-zWU" id="ble-HS-wqT"/>

--- a/Newspack/Newspack/View/StoryTableViewCell.xib
+++ b/Newspack/Newspack/View/StoryTableViewCell.xib
@@ -80,7 +80,7 @@
                             </stackView>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="42" id="pVM-pu-2q1"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="pVM-pu-2q1"/>
                         </constraints>
                     </stackView>
                 </subviews>

--- a/Newspack/Newspack/View/TextNoteTableViewCell.swift
+++ b/Newspack/Newspack/View/TextNoteTableViewCell.swift
@@ -1,16 +1,31 @@
 import UIKit
 
+protocol TextNoteCellProvider {
+    var text: String? { get }
+}
+
 class TextNoteTableViewCell: UITableViewCell {
+
+    @IBOutlet var titleLabel: UILabel!
+    @IBOutlet var syncButton: UIButton!
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+
+        applyStyles()
     }
 
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
+    func applyStyles() {
+        titleLabel.textColor = .text
+        Appearance.style(cellSyncButton: syncButton, iconType: .cloudUpload)
+    }
 
-        // Configure the view for the selected state
+    @IBAction func handleSyncTapped() {
+        print("tapped")
+    }
+
+    func configure(note: TextNoteCellProvider) {
+        titleLabel?.text = note.text
     }
 
 }

--- a/Newspack/Newspack/View/TextNoteTableViewCell.swift
+++ b/Newspack/Newspack/View/TextNoteTableViewCell.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+class TextNoteTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/Newspack/Newspack/View/TextNoteTableViewCell.xib
+++ b/Newspack/Newspack/View/TextNoteTableViewCell.xib
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="TextNoteTableViewCell" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Newspack/Newspack/View/TextNoteTableViewCell.xib
+++ b/Newspack/Newspack/View/TextNoteTableViewCell.xib
@@ -1,21 +1,59 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="TextNoteTableViewCell" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="62" id="KGk-i7-Jjw" customClass="TextNoteTableViewCell" customModule="Newspack" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="62"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="62"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="aXG-fJ-j87">
+                        <rect key="frame" x="16" y="0.0" width="288" height="62"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem ipsum dolar sit amet consequetor" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ps8-11-CVs">
+                                <rect key="frame" x="0.0" y="0.0" width="259" height="62"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="tYY-7w-oq2"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GI7-Mi-Ono">
+                                <rect key="frame" x="267" y="0.0" width="21" height="62"/>
+                                <state key="normal" image="cloud-upload"/>
+                                <connections>
+                                    <action selector="handleSyncTapped" destination="KGk-i7-Jjw" eventType="touchUpInside" id="LX0-Tv-66S"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="aXG-fJ-j87" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="1Y7-a1-e2k"/>
+                    <constraint firstItem="aXG-fJ-j87" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="IK2-0w-JFJ"/>
+                    <constraint firstAttribute="bottom" secondItem="aXG-fJ-j87" secondAttribute="bottom" id="KNW-xy-aiz"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="aXG-fJ-j87" secondAttribute="trailing" id="Xbt-Op-7NT"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="syncButton" destination="GI7-Mi-Ono" id="ZjD-tR-9zW"/>
+                <outlet property="titleLabel" destination="ps8-11-CVs" id="PLG-38-isR"/>
+            </connections>
+            <point key="canvasLocation" x="137.68115942028987" y="107.8125"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <image name="cloud-upload" width="24" height="24"/>
+    </resources>
 </document>

--- a/Newspack/Newspack/View/VideoTableViewCell.swift
+++ b/Newspack/Newspack/View/VideoTableViewCell.swift
@@ -31,10 +31,10 @@ class VideoTableViewCell: UITableViewCell {
         print("tapped")
     }
 
-    func configure(photo: VideoCellProvider, image: UIImage?) {
+    func configure(video: VideoCellProvider, image: UIImage?) {
         thumbnail.image = image
-        titleLabel.text = photo.name
-        captionLabel.text = photo.caption
+        titleLabel.text = video.name
+        captionLabel.text = video.caption
     }
 
 }

--- a/Newspack/Newspack/View/VideoTableViewCell.swift
+++ b/Newspack/Newspack/View/VideoTableViewCell.swift
@@ -1,16 +1,40 @@
 import UIKit
 
+protocol VideoCellProvider {
+    var name: String! { get }
+    var caption: String! { get }
+}
+
 class VideoTableViewCell: UITableViewCell {
+
+    static let imageSize = CGSize(width: 32, height: 32)
+
+    @IBOutlet var thumbnail: UIImageView!
+    @IBOutlet var titleLabel: UILabel!
+    @IBOutlet var captionLabel: UILabel!
+    @IBOutlet var syncButton: UIButton!
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+
+        applyStyles()
     }
 
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
+    func applyStyles() {
+        titleLabel.textColor = .text
+        captionLabel.textColor = .text
+        Appearance.style(cellSyncButton: syncButton, iconType: .cloudUpload)
+        thumbnail.layer.cornerRadius = 8
+    }
 
-        // Configure the view for the selected state
+    @IBAction func handleSyncTapped() {
+        print("tapped")
+    }
+
+    func configure(photo: VideoCellProvider, image: UIImage?) {
+        thumbnail.image = image
+        titleLabel.text = photo.name
+        captionLabel.text = photo.caption
     }
 
 }

--- a/Newspack/Newspack/View/VideoTableViewCell.swift
+++ b/Newspack/Newspack/View/VideoTableViewCell.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+class VideoTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/Newspack/Newspack/View/VideoTableViewCell.xib
+++ b/Newspack/Newspack/View/VideoTableViewCell.xib
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="VideoTableViewCell" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Newspack/Newspack/View/VideoTableViewCell.xib
+++ b/Newspack/Newspack/View/VideoTableViewCell.xib
@@ -1,21 +1,98 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="VideoTableViewCell" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="56" id="KGk-i7-Jjw" customClass="VideoTableViewCell" customModule="Newspack" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8cY-I5-G1W">
+                        <rect key="frame" x="16" y="0.0" width="288" height="56"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="TEz-I3-UB8">
+                                <rect key="frame" x="0.0" y="12" width="32" height="32"/>
+                                <color key="backgroundColor" name="Blue0"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="32" id="30i-gb-fgh"/>
+                                    <constraint firstAttribute="width" constant="32" id="X2P-HC-e2v"/>
+                                </constraints>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="xlg-6K-jFq">
+                                <rect key="frame" x="40" y="6" width="216" height="44"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filename.png" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pg7-Ch-Igx">
+                                        <rect key="frame" x="0.0" y="0.0" width="216" height="24.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A short caption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L5h-C3-VYT">
+                                        <rect key="frame" x="0.0" y="24.5" width="216" height="19.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="epk-Dg-mRB"/>
+                                </constraints>
+                            </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pM3-hf-VKx">
+                                <rect key="frame" x="264" y="16" width="24" height="24"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="24" id="mYN-Py-CEg"/>
+                                </constraints>
+                                <state key="normal" image="cloud-upload"/>
+                                <connections>
+                                    <action selector="handleSyncTapped" destination="KGk-i7-Jjw" eventType="touchUpInside" id="LmC-fD-O0e"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                    </stackView>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="play.circle.fill" catalog="system" id="V7Y-4a-CSY">
+                        <rect key="frame" x="19" y="16" width="24" height="24"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="tintColor" name="White"/>
+                    </imageView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="V7Y-4a-CSY" firstAttribute="centerY" secondItem="TEz-I3-UB8" secondAttribute="centerY" id="8YS-9c-xCL"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="8cY-I5-G1W" secondAttribute="trailing" id="EJx-LF-0id"/>
+                    <constraint firstItem="8cY-I5-G1W" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="F4E-Lq-Ep3"/>
+                    <constraint firstAttribute="bottom" secondItem="8cY-I5-G1W" secondAttribute="bottom" id="TPE-vn-e3y"/>
+                    <constraint firstItem="V7Y-4a-CSY" firstAttribute="centerX" secondItem="TEz-I3-UB8" secondAttribute="centerX" id="V5W-JU-kJB"/>
+                    <constraint firstItem="8cY-I5-G1W" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="hsa-GX-ugX"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="captionLabel" destination="L5h-C3-VYT" id="XeR-xA-MH2"/>
+                <outlet property="syncButton" destination="pM3-hf-VKx" id="eci-WH-lJL"/>
+                <outlet property="thumbnail" destination="TEz-I3-UB8" id="IG1-gT-zM3"/>
+                <outlet property="titleLabel" destination="pg7-Ch-Igx" id="WvG-Xh-kOV"/>
+            </connections>
+            <point key="canvasLocation" x="137.68115942028987" y="134.59821428571428"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <image name="cloud-upload" width="24" height="24"/>
+        <image name="play.circle.fill" catalog="system" width="128" height="121"/>
+        <namedColor name="Blue0">
+            <color red="0.9137254901960784" green="0.93725490196078431" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="White">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>


### PR DESCRIPTION
Refs #91 

This PR is a first pass at cell UI for stories, text notes and photos, and stubbed cells for video and audio notes.

There is a lot of boiler plate in the changes (and project file and xib changes). Some highlights are:
- A CGSize extension for Hashable conformance.
- An ImageResizer utility used to downsize UIImages for display in cells.
- Thumbnail handling in the AssetsViewController
- The cells and cellprovider pattern (for decoupling the StoryAsset model from cells).
- StoryFolder helper methods and StoryAsset provider conformance.

Note: The behavior of the "cloud-upload" icons/buttons is not fully implemented. It will be revisited when syncing is addressed.  Also, video and audio cells are stubs and will see some modifications as video and audio features are implemented, so we'll skip the visual review for now.  Everything will get a final future design review closer to the v1 wrap up.

To test:
- Prep: Go to the Photos app. Select some photos and copy them.  Then use the files app to paste the photos in your current story folder.  This is to work around the known issue of imported images being all black, and will let you see the thumbnail images clearly. 
- Add some text notes and photos.
- Confirm the stories cell reflects the number of assets by asset type.
- Ensure cell layout looks good. (Nothing obviously broken.)
- Confirm cell colors look good in both light and dark mode.
- On the iPad, confirm that cells respect readable width margins.

@jleandroperez could I trouble you for a review of this one?  I apologize for the size, but about half of the changes are the xib and project file. 😬 

Examples:

<img width="386" alt="Screen Shot 2020-08-18 at 11 29 07 AM" src="https://user-images.githubusercontent.com/1435271/90540918-7cbe5f00-e147-11ea-8bbd-fa3136967d23.png">
<img width="407" alt="Screen Shot 2020-08-18 at 11 29 23 AM" src="https://user-images.githubusercontent.com/1435271/90540923-7f20b900-e147-11ea-9cf5-37a65db969a0.png">
<img width="392" alt="Screen Shot 2020-08-18 at 11 30 06 AM" src="https://user-images.githubusercontent.com/1435271/90540938-83e56d00-e147-11ea-8904-902ceed20533.png">
<img width="404" alt="Screen Shot 2020-08-18 at 11 29 40 AM" src="https://user-images.githubusercontent.com/1435271/90540944-8647c700-e147-11ea-9ddd-c1646341bae2.png">
<img width="386" alt="Screen Shot 2020-08-18 at 11 30 13 AM" src="https://user-images.githubusercontent.com/1435271/90540964-8ea00200-e147-11ea-950f-29cad37e25d6.png">
<img width="380" alt="Screen Shot 2020-08-18 at 11 29 54 AM" src="https://user-images.githubusercontent.com/1435271/90540976-92338900-e147-11ea-9975-c3524678b7ca.png">
