### PR TITLE
Issues/misc fixes

### DIFF
--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -243,7 +243,7 @@ class AssetDataSource: UITableViewDiffableDataSource<String, NSManagedObjectID> 
     // animate changes.
     weak var tableView: UITableView?
 
-    override init(tableView: UITableView, cellProvider: @escaping UITableViewDiffableDataSource<Int, NSManagedObjectID>.CellProvider) {
+    override init(tableView: UITableView, cellProvider: @escaping UITableViewDiffableDataSource<String, NSManagedObjectID>.CellProvider) {
         self.tableView = tableView
         super.init(tableView: tableView, cellProvider: cellProvider)
 
@@ -260,7 +260,7 @@ class AssetDataSource: UITableViewDiffableDataSource<String, NSManagedObjectID> 
     /// by the entities index path.
     ///
     /// - Parameter indexPath: The desired entity's index path.
-    /// - Returns: A story asset instance or nil.
+    /// - Returns: A story asset instance.
     ///
     func object(at indexPath: IndexPath) -> StoryAsset {
         return resultsController.object(at: indexPath)

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -356,32 +356,6 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="IC9-M0-AO4">
                                 <rect key="frame" x="0.0" y="45" width="375" height="529"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AssetCell" textLabel="fhP-Mh-0fy" detailTextLabel="3cd-FK-kOv" style="IBUITableViewCellStyleSubtitle" id="8GI-SA-Ocq">
-                                        <rect key="frame" x="0.0" y="55.5" width="375" height="55.5"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8GI-SA-Ocq" id="9kO-Br-4Fb">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="55.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="fhP-Mh-0fy">
-                                                    <rect key="frame" x="15" y="10" width="33.5" height="20.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3cd-FK-kOv">
-                                                    <rect key="frame" x="15" y="31.5" width="44" height="14.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </prototypes>
                                 <connections>
                                     <outlet property="dataSource" destination="NWk-Co-Z8t" id="3qC-Ir-9GJ"/>
                                     <outlet property="delegate" destination="NWk-Co-Z8t" id="tlA-mA-9ww"/>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -324,6 +324,13 @@
                                             <action selector="handleSortChangedWithSender:" destination="NWk-Co-Z8t" eventType="valueChanged" id="rav-mh-nq8"/>
                                         </connections>
                                     </segmentedControl>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PRZ-Np-Cex">
+                                        <rect key="frame" x="283.5" y="7" width="30" height="30"/>
+                                        <state key="normal" title="Edit"/>
+                                        <connections>
+                                            <action selector="handleToggleEditingWithSender:" destination="NWk-Co-Z8t" eventType="touchUpInside" id="mgg-qt-4DC"/>
+                                        </connections>
+                                    </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AMB-nt-ccw">
                                         <rect key="frame" x="0.0" y="43" width="375" height="1"/>
                                         <color key="backgroundColor" systemColor="separatorColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
@@ -334,11 +341,14 @@
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
+                                    <constraint firstItem="PRZ-Np-Cex" firstAttribute="centerY" secondItem="4KS-uW-XyS" secondAttribute="centerY" id="7vi-6J-zNj"/>
                                     <constraint firstItem="iLK-I6-MuO" firstAttribute="centerY" secondItem="4KS-uW-XyS" secondAttribute="centerY" id="LOl-qD-G6k"/>
                                     <constraint firstAttribute="bottom" secondItem="AMB-nt-ccw" secondAttribute="bottom" id="MX9-eX-bou"/>
                                     <constraint firstAttribute="trailing" secondItem="AMB-nt-ccw" secondAttribute="trailing" id="ZFs-b2-u4Z"/>
                                     <constraint firstItem="iLK-I6-MuO" firstAttribute="centerX" secondItem="4KS-uW-XyS" secondAttribute="centerX" id="bus-Nq-SZy"/>
+                                    <constraint firstItem="PRZ-Np-Cex" firstAttribute="leading" secondItem="iLK-I6-MuO" secondAttribute="trailing" constant="16" id="eGv-K1-Aup"/>
                                     <constraint firstAttribute="height" constant="44" id="pyr-ic-t2l"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="PRZ-Np-Cex" secondAttribute="trailing" priority="750" id="tcF-q9-JCe"/>
                                     <constraint firstItem="AMB-nt-ccw" firstAttribute="leading" secondItem="4KS-uW-XyS" secondAttribute="leading" id="ymL-Fz-Nj1"/>
                                 </constraints>
                             </view>
@@ -415,25 +425,18 @@
                         </barButtonItem>
                     </toolbarItems>
                     <navigationItem key="navigationItem" title="Assets" id="YtF-a8-687">
-                        <rightBarButtonItems>
-                            <barButtonItem image="cloud-upload" largeContentSizeImage="cloud-upload" id="YoR-aT-oGj">
-                                <connections>
-                                    <action selector="handleSyncTappedWithSender:" destination="NWk-Co-Z8t" id="gLL-2i-pfm"/>
-                                </connections>
-                            </barButtonItem>
-                            <barButtonItem title="Edit" id="7ng-Vi-nSB">
-                                <connections>
-                                    <action selector="handleToggleEditingWithSender:" destination="NWk-Co-Z8t" id="DLi-Up-EqJ"/>
-                                </connections>
-                            </barButtonItem>
-                        </rightBarButtonItems>
+                        <barButtonItem key="rightBarButtonItem" image="cloud-upload" largeContentSizeImage="cloud-upload" id="YoR-aT-oGj">
+                            <connections>
+                                <action selector="handleSyncTappedWithSender:" destination="NWk-Co-Z8t" id="gLL-2i-pfm"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="audioNoteButton" destination="GnL-gZ-eCi" id="RlS-n1-NlY"/>
                         <outlet property="cameraButton" destination="QOd-iL-h26" id="Vak-vA-3Ie"/>
-                        <outlet property="editButton" destination="7ng-Vi-nSB" id="Kcj-ya-LdH"/>
+                        <outlet property="editButton" destination="PRZ-Np-Cex" id="oDl-bs-43F"/>
                         <outlet property="photoButton" destination="fcy-JG-eKM" id="Ctf-YY-KUS"/>
                         <outlet property="sortControl" destination="iLK-I6-MuO" id="aAT-mL-p5F"/>
                         <outlet property="syncButton" destination="YoR-aT-oGj" id="IqL-DZ-n6V"/>

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -325,7 +325,8 @@
                                         </connections>
                                     </segmentedControl>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PRZ-Np-Cex">
-                                        <rect key="frame" x="283.5" y="7" width="30" height="30"/>
+                                        <rect key="frame" x="275.5" y="5.5" width="30" height="33"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <state key="normal" title="Edit"/>
                                         <connections>
                                             <action selector="handleToggleEditingWithSender:" destination="NWk-Co-Z8t" eventType="touchUpInside" id="mgg-qt-4DC"/>
@@ -346,7 +347,7 @@
                                     <constraint firstAttribute="bottom" secondItem="AMB-nt-ccw" secondAttribute="bottom" id="MX9-eX-bou"/>
                                     <constraint firstAttribute="trailing" secondItem="AMB-nt-ccw" secondAttribute="trailing" id="ZFs-b2-u4Z"/>
                                     <constraint firstItem="iLK-I6-MuO" firstAttribute="centerX" secondItem="4KS-uW-XyS" secondAttribute="centerX" id="bus-Nq-SZy"/>
-                                    <constraint firstItem="PRZ-Np-Cex" firstAttribute="leading" secondItem="iLK-I6-MuO" secondAttribute="trailing" constant="16" id="eGv-K1-Aup"/>
+                                    <constraint firstItem="PRZ-Np-Cex" firstAttribute="leading" secondItem="iLK-I6-MuO" secondAttribute="trailing" constant="8" id="eGv-K1-Aup"/>
                                     <constraint firstAttribute="height" constant="44" id="pyr-ic-t2l"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="PRZ-Np-Cex" secondAttribute="trailing" priority="750" id="tcF-q9-JCe"/>
                                     <constraint firstItem="AMB-nt-ccw" firstAttribute="leading" secondItem="4KS-uW-XyS" secondAttribute="leading" id="ymL-Fz-Nj1"/>


### PR DESCRIPTION
Refs #91 

This PR knocks out a few house keeping tasks.  Changes include: 
- Assets: Moves the edit button from the nav bar to beside the segment control. The button now hides when sorting is not available.
- Asset: Removes an obsolete cell reference.
- Folders and Assets: A small refactor to how diffable datasources are used to take advantage of snapshots generated via a NSFetchedResultsControllerDelegate method (thank you for finding this API Jorge!).

To test: 
- [x] Smoke test the folder and assets screens. Try adding new assets, and the sort controls.  Confirm nothing goes boom 💥. 
- [x] On the assets screen, confirm the edit button looks good, hides and shows as appropriate, and has the correct title depending on its state.

@jleandroperez would you please, kind sir?  More deletes than additions in this one. :) 