### PR TITLE
Issues/91 share extension part 1b

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -74,6 +74,11 @@
 		E61D8F6C2375EC3E005FECED /* StagedMediaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61D8F6B2375EC3E005FECED /* StagedMediaStore.swift */; };
 		E61D8F6F2378C95B005FECED /* StagedMedia+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61D8F6D2378C95A005FECED /* StagedMedia+CoreDataProperties.swift */; };
 		E61D8F702378C95B005FECED /* StagedMedia+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61D8F6E2378C95B005FECED /* StagedMedia+CoreDataClass.swift */; };
+		E61FA93924FD76330060D301 /* ShadowSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FA93824FD76330060D301 /* ShadowSite.swift */; };
+		E61FA93C24FD76600060D301 /* ShadowStory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FA93B24FD76600060D301 /* ShadowStory.swift */; };
+		E61FA93E24FD76730060D301 /* ShadowAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FA93D24FD76730060D301 /* ShadowAsset.swift */; };
+		E61FA94024FD768C0060D301 /* ShadowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FA93F24FD768C0060D301 /* ShadowManager.swift */; };
+		E61FA94324FD777C0060D301 /* ModelConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FA94224FD777C0060D301 /* ModelConstants.swift */; };
 		E61FC603229F2EEE009E1748 /* UserServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FC602229F2EEE009E1748 /* UserServiceRemoteTests.swift */; };
 		E61FC605229F2F10009E1748 /* SiteServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FC604229F2F10009E1748 /* SiteServiceRemoteTests.swift */; };
 		E61FC609229F329A009E1748 /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FC608229F329A009E1748 /* Loader.swift */; };
@@ -399,6 +404,11 @@
 		E61D8F6B2375EC3E005FECED /* StagedMediaStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagedMediaStore.swift; sourceTree = "<group>"; };
 		E61D8F6D2378C95A005FECED /* StagedMedia+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StagedMedia+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		E61D8F6E2378C95B005FECED /* StagedMedia+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StagedMedia+CoreDataClass.swift"; sourceTree = "<group>"; };
+		E61FA93824FD76330060D301 /* ShadowSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowSite.swift; sourceTree = "<group>"; };
+		E61FA93B24FD76600060D301 /* ShadowStory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStory.swift; sourceTree = "<group>"; };
+		E61FA93D24FD76730060D301 /* ShadowAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowAsset.swift; sourceTree = "<group>"; };
+		E61FA93F24FD768C0060D301 /* ShadowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowManager.swift; sourceTree = "<group>"; };
+		E61FA94224FD777C0060D301 /* ModelConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelConstants.swift; sourceTree = "<group>"; };
 		E61FC602229F2EEE009E1748 /* UserServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserServiceRemoteTests.swift; sourceTree = "<group>"; };
 		E61FC604229F2F10009E1748 /* SiteServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteServiceRemoteTests.swift; sourceTree = "<group>"; };
 		E61FC608229F329A009E1748 /* Loader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
@@ -968,6 +978,26 @@
 			path = Styles;
 			sourceTree = "<group>";
 		};
+		E61FA93A24FD764A0060D301 /* Shadows */ = {
+			isa = PBXGroup;
+			children = (
+				E61FA94124FD76A40060D301 /* ShadowModel */,
+				E61FA93F24FD768C0060D301 /* ShadowManager.swift */,
+			);
+			path = Shadows;
+			sourceTree = "<group>";
+		};
+		E61FA94124FD76A40060D301 /* ShadowModel */ = {
+			isa = PBXGroup;
+			children = (
+				E61FA94224FD777C0060D301 /* ModelConstants.swift */,
+				E61FA93824FD76330060D301 /* ShadowSite.swift */,
+				E61FA93B24FD76600060D301 /* ShadowStory.swift */,
+				E61FA93D24FD76730060D301 /* ShadowAsset.swift */,
+			);
+			path = ShadowModel;
+			sourceTree = "<group>";
+		};
 		E61FC601229F2E96009E1748 /* Api */ = {
 			isa = PBXGroup;
 			children = (
@@ -1015,8 +1045,9 @@
 			isa = PBXGroup;
 			children = (
 				E62018D924F9AF2100D96AFF /* Extensions */,
-				E62018D724F9ADEF00D96AFF /* Utils */,
 				E62018D324F9ACAE00D96AFF /* Folders */,
+				E61FA93A24FD764A0060D301 /* Shadows */,
+				E62018D724F9ADEF00D96AFF /* Utils */,
 				E62018B324F9AB6700D96AFF /* NewspackFramework.h */,
 				E62018B424F9AB6700D96AFF /* Info.plist */,
 			);
@@ -1853,11 +1884,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				E62018DB24F9B18500D96AFF /* UserDefaults+Newspack.swift in Sources */,
+				E61FA94324FD777C0060D301 /* ModelConstants.swift in Sources */,
 				E62018DD24F9B1C700D96AFF /* Environment.swift in Sources */,
+				E61FA93924FD76330060D301 /* ShadowSite.swift in Sources */,
 				E62018D424F9ACFD00D96AFF /* FolderManager.swift in Sources */,
 				E62018DC24F9B18F00D96AFF /* URL+FileReference.swift in Sources */,
 				E62018DA24F9AF4900D96AFF /* AppConstants.swift in Sources */,
 				E62018D824F9AE1500D96AFF /* Logging.swift in Sources */,
+				E61FA93E24FD76730060D301 /* ShadowAsset.swift in Sources */,
+				E61FA93C24FD76600060D301 /* ShadowStory.swift in Sources */,
+				E61FA94024FD768C0060D301 /* ShadowManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		E61FA93E24FD76730060D301 /* ShadowAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FA93D24FD76730060D301 /* ShadowAsset.swift */; };
 		E61FA94024FD768C0060D301 /* ShadowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FA93F24FD768C0060D301 /* ShadowManager.swift */; };
 		E61FA94324FD777C0060D301 /* ModelConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FA94224FD777C0060D301 /* ModelConstants.swift */; };
+		E61FA94524FD9BC40060D301 /* ShadowCaster.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FA94424FD9BC40060D301 /* ShadowCaster.swift */; };
 		E61FC603229F2EEE009E1748 /* UserServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FC602229F2EEE009E1748 /* UserServiceRemoteTests.swift */; };
 		E61FC605229F2F10009E1748 /* SiteServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FC604229F2F10009E1748 /* SiteServiceRemoteTests.swift */; };
 		E61FC609229F329A009E1748 /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61FC608229F329A009E1748 /* Loader.swift */; };
@@ -409,6 +410,7 @@
 		E61FA93D24FD76730060D301 /* ShadowAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowAsset.swift; sourceTree = "<group>"; };
 		E61FA93F24FD768C0060D301 /* ShadowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowManager.swift; sourceTree = "<group>"; };
 		E61FA94224FD777C0060D301 /* ModelConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelConstants.swift; sourceTree = "<group>"; };
+		E61FA94424FD9BC40060D301 /* ShadowCaster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowCaster.swift; sourceTree = "<group>"; };
 		E61FC602229F2EEE009E1748 /* UserServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserServiceRemoteTests.swift; sourceTree = "<group>"; };
 		E61FC604229F2F10009E1748 /* SiteServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteServiceRemoteTests.swift; sourceTree = "<group>"; };
 		E61FC608229F329A009E1748 /* Loader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
@@ -821,6 +823,7 @@
 				E6034B1322529414007DB6DD /* UserAgent.swift */,
 				E605418E2369E1920078D978 /* Diagnostics.swift */,
 				E63FF0E724AA4ECD0002A32F /* Reconciler.swift */,
+				E61FA94424FD9BC40060D301 /* ShadowCaster.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -1823,6 +1826,7 @@
 				E6D44DF1234BDBA000B51438 /* MediaApiService.swift in Sources */,
 				E6AB672724E88182003D5D2A /* PhotoTableViewCell.swift in Sources */,
 				E694469E24DB3FA100D0BF56 /* MediaCaptureController.swift in Sources */,
+				E61FA94524FD9BC40060D301 /* ShadowCaster.swift in Sources */,
 				E66CCA0C2303527C00F1CA59 /* Media+CoreDataClass.swift in Sources */,
 				E692CA9F24CA2E6D008FB96B /* EventMonitor.swift in Sources */,
 				E677AAED24B4EED9000FAA3D /* AssetAction.swift in Sources */,

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -241,6 +241,7 @@ extension FolderStore {
             DispatchQueue.main.async {
                 self?.selectDefaultStoryFolderIfNeeded()
                 onComplete?()
+                ShadowCaster.shared.castShadows()
             }
         }
     }
@@ -386,6 +387,7 @@ extension FolderStore {
             DispatchQueue.main.async {
                 self?.createDefaultStoryFolderIfNeeded()
                 onComplete?()
+                ShadowCaster.shared.castShadows()
             }
         }
     }

--- a/Newspack/Newspack/System/AppDelegate.swift
+++ b/Newspack/Newspack/System/AppDelegate.swift
@@ -37,6 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         LogInfo(message: "Application did finish launching.")
 
         Diagnostics.countEntitiesInCoreData()
+        Diagnostics.countShadows()
 
         return true
     }

--- a/Newspack/Newspack/System/Diagnostics.swift
+++ b/Newspack/Newspack/System/Diagnostics.swift
@@ -12,7 +12,7 @@ class Diagnostics {
             return
         }
 
-        LogDebug(message: "Diagnostics: Counting entities in core data.")
+        LogInfo(message: "Counting entities in core data.")
 
         let names:[String] = model.entities.compactMap { (entity) -> String in
             guard !entity.isAbstract, let name = entity.name else {
@@ -37,14 +37,28 @@ class Diagnostics {
         }
 
         if counts.count == 0 {
-            LogDebug(message: "Diagnostics: Nothing saved in core data.")
+            LogInfo(message: "Nothing saved in core data.")
             return
         }
 
         for (k, v) in counts {
-            LogDebug(message: "\(k): has \(v) records.")
+            LogInfo(message: "\(k): has \(v) records.")
         }
     }
 
+
+    static func countShadows() {
+        LogInfo(message: "Counting shadows.")
+        let manager = ShadowManager.init()
+        guard let sites = manager.retrieveShadowSites() else {
+            LogInfo(message: "No shadows found.")
+            return
+        }
+        LogInfo(message: "Found \(sites.count) shadow site(s).")
+
+        for site in sites {
+            LogInfo(message: "Found \(site.stories.count) stories for \(site.title)")
+        }
+    }
 
 }

--- a/Newspack/Newspack/System/ShadowCaster.swift
+++ b/Newspack/Newspack/System/ShadowCaster.swift
@@ -1,0 +1,30 @@
+import Foundation
+import NewspackFramework
+
+/// Responsible for persisting shadows of sites and stories for use by the
+/// share extension.
+///
+class ShadowCaster {
+    static let shared = ShadowCaster()
+    private let manager = ShadowManager()
+
+    private init() {}
+
+    /// Build and store shadows of sites and stories from core data to shared defaults.
+    ///
+    func castShadows() {
+        var shadows = [ShadowSite]()
+        let store = StoreContainer.shared.siteStore
+        let sites = store.getSites()
+        for site in sites {
+            var shadowStories = [ShadowStory]()
+            for story in site.storyFolders {
+                shadowStories.append(ShadowStory(uuid: story.uuid.uuidString, title: story.name, bookmarkData: story.bookmark))
+            }
+            shadows.append(ShadowSite(uuid: site.uuid.uuidString, title: site.title, stories: shadowStories))
+        }
+
+        manager.storeShadowSites(sites: shadows)
+    }
+
+}

--- a/Newspack/NewspackFramework/Folders/FolderManager.swift
+++ b/Newspack/NewspackFramework/Folders/FolderManager.swift
@@ -193,6 +193,7 @@ public class FolderManager {
 
     /// Delete the folder at the specified file URL. If the URL is not a folder
     /// it will not be deleted.
+    ///
     /// - Parameter source: A file URL.
     /// - Returns: true if the folder was deleted, otherwise false
     ///
@@ -205,7 +206,24 @@ public class FolderManager {
         return deleteItem(at: source)
     }
 
+    /// Delete the contents of the specified folder.
+    ///
+    /// - Parameter folder: The fileURL pointing to the folder whose contents should be deleted.
+    /// - Returns: True if successful. False if there were any errors.
+    ///
+    public func deleteContentsOfFolder(folder: URL) -> Bool {
+        var success = true
+        let arr = enumerateFolderContents(url: folder)
+        for item in arr {
+            if !deleteItem(at: item) {
+                success = false
+            }
+        }
+        return success
+    }
+
     /// Delete the item at the specified file URL
+    ///
     /// - Parameter source: A file URL.
     /// - Returns: true if the item was deleted, otherwise false
     ///

--- a/Newspack/NewspackFramework/Shadows/ShadowManager.swift
+++ b/Newspack/NewspackFramework/Shadows/ShadowManager.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+public class ShadowManager {
+
+    // Creates a cannonical copy
+    public func storeSiteShadows() {
+        // create empty shadow array
+        // Get sites
+        // for each site
+        // get folders
+        // for each folder
+        // generate shadow folder
+        // generate shadow site
+        // get shadow site dictionary
+        // add shadow site dictionary to shadow array
+        // save shadow array in user defaults
+    }
+
+    // Creates an non-cannonical copy based on the last saved info. Might be out of date.
+    public func retrieveSiteShadows() {
+        // Get shadow array from user defaults
+        // create Shadow Site array
+        // for each shadow site dictionary in the shadow array
+        // create a shadowsite from the dictionary
+        // add the shadow site to the shadow site array
+    }
+
+    // Store shadow assets in group user defaults
+    public func storeShadowAssets(assets: [ShadowAsset]) {
+        // retrieve array of existing shadow assets from user defaults, or create new array
+        // for each asset
+        // get asset dictionary
+        // add to shadow array
+        // save shadow array to user defaults
+    }
+
+    // Retrieve shadow assets from group user defaults
+    public func retrieveShadowAssets() {
+        // create shadow asset array
+        // retrieve array of existing shadow assets from user defaults, or create new array
+        // for item in array
+        // create shadow asset from dict
+        // add shadow asset to shadow asset array
+        // return
+    }
+
+    // TODO: Write file to group folder and return file URL.
+    public func saveInGroupStorage(rawAsset: Any) -> Data? {
+        // create group storage if needed.
+        return nil
+    }
+
+    // Remove all shadow assets. Do this after importing.
+
+    /// Removes the shadow asset dictionary fron shared defaults and
+    /// removes all files from shared storage.
+    ///
+    public func clearShadowAssets() {
+        UserDefaults.shared.removeObject(forKey: AppConstants.shadowAssetsKey)
+        //TODO: remove files from shared storage.
+    }
+
+}

--- a/Newspack/NewspackFramework/Shadows/ShadowManager.swift
+++ b/Newspack/NewspackFramework/Shadows/ShadowManager.swift
@@ -5,6 +5,8 @@ import Foundation
 ///
 public class ShadowManager {
 
+    public init() {}
+
     /// Stores the passed array of shadow sites in shared defaults.
     /// This will overwrite whatever information is currently stored.
     ///
@@ -37,7 +39,7 @@ public class ShadowManager {
     ///
     /// - Returns: An array of shadow sites or nil.
     ///
-    public func retrieveSiteShadows() -> [ShadowSite]? {
+    public func retrieveShadowSites() -> [ShadowSite]? {
         guard let arr = UserDefaults.shared.object(forKey: AppConstants.shadowSitesKey) as? [[String: Any]] else {
             return nil
         }

--- a/Newspack/NewspackFramework/Shadows/ShadowModel/ModelConstants.swift
+++ b/Newspack/NewspackFramework/Shadows/ShadowModel/ModelConstants.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct ModelConstants {
+    static let uuid = "uuid"
+    static let title = "title"
+    static let bookmarkData = "bookmarkData"
+    static let stories = "stories"
+}

--- a/Newspack/NewspackFramework/Shadows/ShadowModel/ModelConstants.swift
+++ b/Newspack/NewspackFramework/Shadows/ShadowModel/ModelConstants.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Common strings used by shadow models.
 struct ModelConstants {
     static let uuid = "uuid"
     static let title = "title"

--- a/Newspack/NewspackFramework/Shadows/ShadowModel/ShadowAsset.swift
+++ b/Newspack/NewspackFramework/Shadows/ShadowModel/ShadowAsset.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+/// Stores select information about an asset.
+/// Facilitates storage in shared defautls.
+///
 public struct ShadowAsset {
     public let storyUUID: String // The UUID of the destination story folder.
     public let bookmarkData: Data

--- a/Newspack/NewspackFramework/Shadows/ShadowModel/ShadowAsset.swift
+++ b/Newspack/NewspackFramework/Shadows/ShadowModel/ShadowAsset.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public struct ShadowAsset {
+    public let storyUUID: String // The UUID of the destination story folder.
+    public let bookmarkData: Data
+
+    public var dictionary: [String: Any] {
+        return [
+            ModelConstants.uuid: storyUUID,
+            ModelConstants.bookmarkData: bookmarkData
+        ]
+    }
+
+    public init(storyUUID: String, bookmarkData: Data) {
+        self.storyUUID = storyUUID
+        self.bookmarkData = bookmarkData
+    }
+
+    public init(dict: [String: Any]) {
+        guard
+            let uuid = dict[ModelConstants.uuid] as? String,
+            let bookmarkData = dict[ModelConstants.bookmarkData] as? Data
+        else {
+            // This should never happen.
+            fatalError()
+        }
+        self.storyUUID = uuid
+        self.bookmarkData = bookmarkData
+    }
+
+}

--- a/Newspack/NewspackFramework/Shadows/ShadowModel/ShadowSite.swift
+++ b/Newspack/NewspackFramework/Shadows/ShadowModel/ShadowSite.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public struct ShadowSite {
+    public let uuid: String
+    public let title: String
+    public let stories: [ShadowStory]
+
+    public var dictionary: [String: Any] {
+        var storyArray = [[String: Any]]()
+        for story in stories {
+            storyArray.append(story.dictionary)
+        }
+        return [
+            ModelConstants.uuid: uuid,
+            ModelConstants.title: title,
+            ModelConstants.stories: storyArray
+        ]
+    }
+
+    public init(uuid: String, title: String, stories: [ShadowStory]) {
+        self.uuid = uuid
+        self.title = title
+        self.stories = stories
+    }
+
+    public init(dict: [String: Any]) {
+        guard
+            let uuid = dict[ModelConstants.uuid] as? String,
+            let title = dict[ModelConstants.title] as? String,
+            let stories = dict[ModelConstants.stories] as? [[String: Any]]
+        else {
+            // This should never happen.
+            fatalError()
+        }
+        self.uuid = uuid
+        self.title = title
+
+        var shadowStories = [ShadowStory]()
+        for story in stories {
+            shadowStories.append(ShadowStory(dict: story))
+        }
+        self.stories = shadowStories
+    }
+
+}

--- a/Newspack/NewspackFramework/Shadows/ShadowModel/ShadowSite.swift
+++ b/Newspack/NewspackFramework/Shadows/ShadowModel/ShadowSite.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+/// Stores select information about a site.
+/// Facilitates storage in shared defautls.
+///
 public struct ShadowSite {
     public let uuid: String
     public let title: String

--- a/Newspack/NewspackFramework/Shadows/ShadowModel/ShadowStory.swift
+++ b/Newspack/NewspackFramework/Shadows/ShadowModel/ShadowStory.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+/// Stores select information about a story.
+/// Facilitates storage in shared defautls.
+///
 public struct ShadowStory {
     public let uuid: String
     public let title: String

--- a/Newspack/NewspackFramework/Shadows/ShadowModel/ShadowStory.swift
+++ b/Newspack/NewspackFramework/Shadows/ShadowModel/ShadowStory.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public struct ShadowStory {
+    public let uuid: String
+    public let title: String
+    public let bookmarkData: Data
+
+    public var dictionary: [String: Any] {
+        return [
+            ModelConstants.uuid: uuid,
+            ModelConstants.title: title,
+            ModelConstants.bookmarkData: bookmarkData
+        ]
+    }
+
+    public init(uuid: String, title: String, bookmarkData: Data) {
+        self.uuid = uuid
+        self.title = title
+        self.bookmarkData = bookmarkData
+    }
+
+    public init(dict: [String: Any]) {
+        guard
+            let uuid = dict[ModelConstants.uuid] as? String,
+            let title = dict[ModelConstants.title] as? String,
+            let bookmarkData = dict[ModelConstants.bookmarkData] as? Data
+        else {
+            // This should never happen.
+            fatalError()
+        }
+        self.uuid = uuid
+        self.title = title
+        self.bookmarkData = bookmarkData
+    }
+
+}

--- a/Newspack/NewspackFramework/Utils/AppConstants.swift
+++ b/Newspack/NewspackFramework/Utils/AppConstants.swift
@@ -3,4 +3,6 @@ import Foundation
 public class AppConstants {
     public static let appGroupIdentifier = "group.com.automattic.newspack"
     public static let currentSiteIDKey = "currentSiteIDKey"
+    public static let shadowSitesKey = "shadowSitesKey"
+    public static let shadowAssetsKey = "shadowAssetsKey"
 }

--- a/Newspack/NewspackShare/ShareViewController.swift
+++ b/Newspack/NewspackShare/ShareViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Social
+import NewspackFramework
 
 class ShareViewController: SLComposeServiceViewController {
 
@@ -12,9 +13,20 @@ class ShareViewController: SLComposeServiceViewController {
         // HACK: Temp debuging while wrangling the share extension.
         let defaults = UserDefaults(suiteName: "group.com.automattic.newspack")!
         let obj = defaults.string(forKey: "currentSiteIDKey")!
-        print(obj)
+        print("Current Key: \(obj)")
 
 
+        print("Counting shadows.")
+        let manager = ShadowManager.init()
+        guard let sites = manager.retrieveShadowSites() else {
+            print("No shadows found.")
+            return
+        }
+        print("Found \(sites.count) shadow site(s).")
+
+        for site in sites {
+            print("Found \(site.stories.count) stories for \(site.title)")
+        }
 
         // Inform the host that we're done, so it un-blocks its UI. Note: Alternatively you could call super's -didSelectPost, which will similarly complete the extension context.
         self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)

--- a/Podfile
+++ b/Podfile
@@ -76,8 +76,8 @@ target 'Newspack' do
     pod 'Alamofire', '4.8.0'
     pod 'AlamofireImage', '3.5.2'
 
-    pod 'WordPressAuthenticator', '~> 1.21.0'
-    pod 'WordPressKit', '~> 4.13.0'
+    pod 'WordPressAuthenticator', '~> 1.23.3'
+    pod 'WordPressKit', '~> 4.15.0'
     pod 'WPMediaPicker', '~> 1.7.0'
     pod 'WordPressFlux', '1.0.0'
     pod 'WordPressUI', '~> 1.7.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -165,7 +165,7 @@ PODS:
   - WordPress-Aztec-iOS (1.13.0)
   - WordPress-Editor-iOS (1.13.0):
     - WordPress-Aztec-iOS (= 1.13.0)
-  - WordPressAuthenticator (1.21.0):
+  - WordPressAuthenticator (1.23.3):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -174,22 +174,22 @@ PODS:
     - lottie-ios (= 3.1.6)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.0-beta.0)
-    - WordPressShared (~> 1.9-beta)
+    - WordPressKit (~> 4.14-beta)
+    - WordPressShared (~> 1.11-beta)
     - WordPressUI (~> 1.7.0)
   - WordPressFlux (1.0.0)
-  - WordPressKit (4.13.0):
+  - WordPressKit (4.15.0):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
     - UIDeviceIdentifier (~> 1)
-    - WordPressShared (~> 1.9)
+    - WordPressShared (~> 1.10-beta)
     - wpxmlrpc (= 0.8.5)
-  - WordPressShared (1.10.0-beta.1):
+  - WordPressShared (1.11.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.7.1)
-  - WPMediaPicker (1.7.0)
+  - WPMediaPicker (1.7.1)
   - wpxmlrpc (0.8.5)
   - yoga (0.60.0-patched.React)
 
@@ -227,9 +227,9 @@ DEPENDENCIES:
   - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.18.0/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
   - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v1.18.0`)
   - WordPress-Editor-iOS (~> 1.13.0)
-  - WordPressAuthenticator (~> 1.21.0)
+  - WordPressAuthenticator (~> 1.23.3)
   - WordPressFlux (= 1.0.0)
-  - WordPressKit (~> 4.13.0)
+  - WordPressKit (~> 4.15.0)
   - WordPressUI (~> 1.7.0)
   - WPMediaPicker (~> 1.7.0)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.18.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -379,15 +379,15 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: 450cb7095c6852c9c933d2062c318c4d7fa4d9a6
   WordPress-Editor-iOS: c3373b246efe59adf7b6ac476c8e562964724bf9
-  WordPressAuthenticator: 57538dea44fb0d05119c0dd3fc176cbe78fa8a78
+  WordPressAuthenticator: 19a4f2039a764fe380da4ff35f83be582d1e2815
   WordPressFlux: a381542b0a0414ef85fb0b2a0f9dbde78ffe0637
-  WordPressKit: b912e3436d7203e6a0d04b477aba05c7b78d495a
-  WordPressShared: b77083325416b075c99155ab2770f0dff8ba04eb
+  WordPressKit: c826b111887299024822fee12432ce62accf4d7c
+  WordPressShared: b56046080c99d41519d097c970df663fda48e218
   WordPressUI: 9da5d966b8beb091950cd96880db398d7f30e246
-  WPMediaPicker: 754bc043ea42abc2eae8a07e5680c777c112666a
+  WPMediaPicker: 46ae5807c8f64d30a39c28812ad150837a424ed2
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
   yoga: 4e71c9a33abf45ba55af55ae9cbc86f4234bb2a9
 
-PODFILE CHECKSUM: f5a1f99c548b3edf7b73fc0be86123c604d51d8a
+PODFILE CHECKSUM: f01695a1b81bac417d4389933baeb30d85a40b8c
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Refs: #91 

This PR is part two of a four part series of PRs implementing support for sharing photos via the share extension. 

In this PR a mechanism is introduced to share information about sites and stories between the main app and the share extension, and ground work is laid for the share extension to share and associate files (photos) back to the main app.

Notes:  
- I struggled with a naming scheme for this. I'm not entirely happy with the "shadow" motif but 🤷. Open to other suggestions.
- I owe this PR some unit tests but I'm holding off until part 4 so I can wrangle everything involved in this feature at once and not risk having to rewrite tests due to changes in part 3 and 4.

To test: 
- [x] Launch the app.  Check the info logged to the console.  Confirm zero shadow sites were found.
- [x] Create a new story or two. Then terminate the app.
- [x] Relaunch the app.  Check the info logged to the console.  Confirm that shadow sites and stories were found and their number correctly corresponds to the number of site (1) and stories currently in the app.
- [x] Switch to the share extension target and launch the share extension selecting the Photos app.
- [x] Select some photos and share to the share extension.
- [x] Click the post button.  Look at the info logged to the console. Confirm that shadow sites and stories were found and their number correctly corresponds to the number of site (1) and stories currently in the main app.

@jleandroperez could I trouble you for a review sir? 