### PR TITLE
Tests: Fixes a flaky test. For realz this time.

### DIFF
--- a/Newspack/NewspackFrameworkTests/Tests/ShadowTests.swift
+++ b/Newspack/NewspackFrameworkTests/Tests/ShadowTests.swift
@@ -76,10 +76,16 @@ class ShadowTests: XCTestCase {
     }
 
     func testClearShadowAssets() {
+        let manager = ShadowManager()
+        manager.clearShadowAssets()
+
+        // Confirm there is nothing to start.
+        var retrieved = manager.retrieveShadowAssets()
+        XCTAssertTrue(retrieved.count == 0)
+
         let data = "data".data(using: .ascii)!
         let asset = ShadowAsset(storyUUID: "story", bookmarkData: data)
 
-        let manager = ShadowManager()
         manager.storeShadowAssets(assets: [asset])
 
         let folderURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: AppConstants.appGroupIdentifier)!
@@ -89,10 +95,7 @@ class ShadowTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: file.path))
         XCTAssertTrue(success)
 
-        let obj = UserDefaults.shared.object(forKey: AppConstants.shadowAssetsKey)
-        XCTAssertNotNil(obj)
-
-        var retrieved = manager.retrieveShadowAssets()
+        retrieved = manager.retrieveShadowAssets()
         XCTAssertTrue(retrieved.count == 1)
 
         manager.clearShadowAssets()


### PR DESCRIPTION
Take two at fixing this flaky test.

For me this one would sometimes work and sometimes not. A previous attempt at a fix seemed successful, but it appears I just happened to get a long run of successes when testing and it would still fail. :(  Props @jleandroperez for being able to trigger the breakage. 

When the test fails it seems to be because there is more than the one expected shadow asset.  It's not clear where the extra could be coming from, that's a mystery for another day.  Clearing the shadow assets at the start of the test seems to fix the issue.

@jleandroperez would you confirm this fixes the test on your system?  Thank you sir!