### PR TITLE
Issues/91 syncing part 2

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		E625B03625004F5700C55EDC /* CGSize+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B779E924EB2FC5007EA033 /* CGSize+Helpers.swift */; };
 		E625B03825005AED00C55EDC /* PhotoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E625B03725005AED00C55EDC /* PhotoCell.swift */; };
 		E625B03A2500907000C55EDC /* CollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E625B0392500907000C55EDC /* CollectionHeaderView.swift */; };
+		E628CBA22527C23100770B44 /* Array+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E628CBA12527C23100770B44 /* Array+Helpers.swift */; };
 		E629822A2303667E00E8CEC7 /* EditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62982292303667E00E8CEC7 /* EditorViewController.swift */; };
 		E62A6BA424C6198300013092 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62A6BA324C6198300013092 /* MenuViewController.swift */; };
 		E62C7C662235E16E000FEB33 /* AccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62C7C652235E16E000FEB33 /* AccountStore.swift */; };
@@ -440,6 +441,7 @@
 		E625788A222F0B4B00DE6F26 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		E625B03725005AED00C55EDC /* PhotoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCell.swift; sourceTree = "<group>"; };
 		E625B0392500907000C55EDC /* CollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionHeaderView.swift; sourceTree = "<group>"; };
+		E628CBA12527C23100770B44 /* Array+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Helpers.swift"; sourceTree = "<group>"; };
 		E62982292303667E00E8CEC7 /* EditorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorViewController.swift; sourceTree = "<group>"; };
 		E62A6BA324C6198300013092 /* MenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuViewController.swift; sourceTree = "<group>"; };
 		E62C7C652235E16E000FEB33 /* AccountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountStore.swift; sourceTree = "<group>"; };
@@ -1125,6 +1127,7 @@
 				E63FF0EB24AA864C0002A32F /* URL+FileReference.swift */,
 				E6C3988B24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift */,
 				E630E33E250029020028BBF2 /* FileManager+Helpers.swift */,
+				E628CBA12527C23100770B44 /* Array+Helpers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1974,6 +1977,7 @@
 				E62018DA24F9AF4900D96AFF /* AppConstants.swift in Sources */,
 				E62018D824F9AE1500D96AFF /* Logging.swift in Sources */,
 				E61FA93E24FD76730060D301 /* ShadowAsset.swift in Sources */,
+				E628CBA22527C23100770B44 /* Array+Helpers.swift in Sources */,
 				E61FA93C24FD76600060D301 /* ShadowStory.swift in Sources */,
 				E61FA94024FD768C0060D301 /* ShadowManager.swift in Sources */,
 				E63A3A3824FEF85100ACA871 /* UIColor+SemanticColors.swift in Sources */,

--- a/Newspack/Newspack/Api/ServiceRemotes/MediaServiceRemote.swift
+++ b/Newspack/Newspack/Api/ServiceRemotes/MediaServiceRemote.swift
@@ -24,7 +24,8 @@ class MediaServiceRemote: ServiceRemoteCoreRest {
 
             let filter = ["id": ids] as [String: AnyObject]
             let params = [
-                "_fields": "id,date_gmt,media_details,mime_type,modified_gmt,source_url",
+                "context": "edit",
+                "_fields": "id,date_gmt,media_details,mime_type,modified_gmt,source_url,caption,title,alt_text",
                 "page": page,
                 "per_page": perPage
             ] as [String: AnyObject]
@@ -138,7 +139,7 @@ class MediaServiceRemote: ServiceRemoteCoreRest {
     ///   - onComplete: A completion call back.
     ///
     func updateMediaProperties(mediaID: Int64, mediaParameters: [String: AnyObject], onComplete: @escaping (_ media: RemoteMedia?, _ error: Error?) -> Void) {
-        let parameters = ["context": "edit"] as [String: AnyObject]
+        let parameters = sanitizeMediaParameters(parameters: mediaParameters)
         let path = "media/\(mediaID)"
         api.POST(path, parameters: parameters, success: { (response: AnyObject, httpResponse: HTTPURLResponse?) in
             let dict = response as! [String: AnyObject]

--- a/Newspack/Newspack/Api/ServiceRemotes/MediaServiceRemote.swift
+++ b/Newspack/Newspack/Api/ServiceRemotes/MediaServiceRemote.swift
@@ -5,6 +5,52 @@ import WordPressKit
 ///
 class MediaServiceRemote: ServiceRemoteCoreRest {
 
+    func fetchMedia(for mediaIDs: [Int64], onComplete: @escaping (_ mediaItems: [RemoteMedia]?, _ error: Error?) -> Void) {
+        let page = 1
+        let perPage = 100
+
+        var fetchError: Error?
+        var items = [RemoteMedia]()
+
+        let dispatchGroup = DispatchGroup()
+
+        // Sync all media. Max request size is 100 items so split the IDs into chunks and make multiple requests.
+        let chunks = mediaIDs.chunked(into: perPage)
+        for chunk in chunks {
+
+            let ids = chunk.map { (item) -> String in
+                String(item)
+            }.joined(separator: ",")
+
+            let filter = ["id": ids] as [String: AnyObject]
+            let params = [
+                "_fields": "id,date_gmt,media_details,mime_type,modified_gmt,source_url",
+                "page": page,
+                "per_page": perPage
+            ] as [String: AnyObject]
+            let parameters = params.mergedWith(filter)
+
+            dispatchGroup.enter()
+            api.GET("media", parameters: parameters, success: { (response: AnyObject, httpResponse: HTTPURLResponse?) in
+                let array = response as! [[String: AnyObject]]
+                items.append(contentsOf: self.remoteMediaArrayFromResponse(response: array))
+                dispatchGroup.leave()
+
+            }, failure: { (error: NSError, httpResponse: HTTPURLResponse?) in
+                fetchError = error
+                dispatchGroup.leave()
+            })
+        }
+
+        dispatchGroup.notify(queue: .main) {
+            if let error = fetchError {
+                onComplete(nil, error)
+            } else {
+                onComplete(items, nil)
+            }
+        }
+    }
+
     /// Fetch media items for the specified page.
     ///
     /// - Parameters:
@@ -68,12 +114,12 @@ class MediaServiceRemote: ServiceRemoteCoreRest {
                      localURL: URL,
                      filename: String,
                      mimeType: String,
-                     onComplete: @escaping (_ media: RemoteMedia?, _ error: Error?) -> Void) {
+                     onComplete: @escaping (_ media: RemoteMedia?, _ error: Error?) -> Void) -> Progress? {
         let fileParameterName = "file"
         let filePart = FilePart(parameterName: fileParameterName, url: localURL, filename: filename, mimeType: mimeType)
         let parameters = sanitizeMediaParameters(parameters: mediaParameters)
         let path = "media"
-        api.multipartPOST(path, parameters: parameters, fileParts: [filePart], success: { (response: AnyObject, httpResponse: HTTPURLResponse?) in
+        return api.multipartPOST(path, parameters: parameters, fileParts: [filePart], success: { (response: AnyObject, httpResponse: HTTPURLResponse?) in
             let dict = response as! [String: AnyObject]
             let media = self.remoteMediaFromResponse(response: dict)
             onComplete(media, nil)
@@ -84,6 +130,26 @@ class MediaServiceRemote: ServiceRemoteCoreRest {
 
     }
 
+    /// Updates media properties based on the parameters passed. Does not alter the remote file.
+    ///
+    /// - Parameters:
+    ///   - mediaID: The ID of the media item to update.
+    ///   - mediaParameters: A dictionary specifying the properties to update, and the values to use.
+    ///   - onComplete: A completion call back.
+    ///
+    func updateMediaProperties(mediaID: Int64, mediaParameters: [String: AnyObject], onComplete: @escaping (_ media: RemoteMedia?, _ error: Error?) -> Void) {
+        let parameters = ["context": "edit"] as [String: AnyObject]
+        let path = "media/\(mediaID)"
+        api.POST(path, parameters: parameters, success: { (response: AnyObject, httpResponse: HTTPURLResponse?) in
+            let dict = response as! [String: AnyObject]
+            let media = self.remoteMediaFromResponse(response: dict)
+
+            onComplete(media, nil)
+
+        }, failure: { (error: NSError, httpResponse: HTTPURLResponse?) in
+            onComplete(nil, error)
+        })
+    }
 
     /// Sanitize the passed array of parameters. Removes unsupported parameters.
     ///

--- a/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
+++ b/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
@@ -255,14 +255,14 @@
         <attribute name="bookmark" optional="YES" attributeType="Binary"/>
         <attribute name="caption" attributeType="String" defaultValueString=""/>
         <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="lastSync" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="modified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="link" attributeType="String" defaultValueString=""/>
+        <attribute name="modified" attributeType="Date" defaultDateTimeInterval="599554800" usesScalarValueType="NO"/>
         <attribute name="name" attributeType="String"/>
         <attribute name="order" attributeType="Integer 16" defaultValueString="-1" usesScalarValueType="YES"/>
-        <attribute name="pageURL" optional="YES" attributeType="URI"/>
         <attribute name="remoteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="sorted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="srcURL" optional="YES" attributeType="URI"/>
+        <attribute name="sourceURL" attributeType="String" defaultValueString=""/>
+        <attribute name="synced" attributeType="Date" defaultDateTimeInterval="599554800" usesScalarValueType="NO"/>
         <attribute name="text" attributeType="String" defaultValueString=""/>
         <attribute name="type" attributeType="String"/>
         <attribute name="uuid" attributeType="UUID" usesScalarValueType="NO"/>

--- a/Newspack/Newspack/Models/StoryAsset+CoreDataProperties.swift
+++ b/Newspack/Newspack/Models/StoryAsset+CoreDataProperties.swift
@@ -23,14 +23,16 @@ extension StoryAsset {
     @NSManaged public var uuid: UUID!
     @NSManaged public var order: Int16 // Default is -1
     @NSManaged public var date: Date!
-    @NSManaged public var lastSync: Date?
-    @NSManaged public var modified: Date?
+    // Synced indicates the date last synced.
+    @NSManaged public var synced: Date!
+    // Modified indicate the date last modified. If synced > modified data is current.
+    @NSManaged public var modified: Date!
     @NSManaged public var text: String!
     @NSManaged public var sorted: Bool
     @NSManaged public var altText: String!
     @NSManaged public var caption: String!
     @NSManaged public var remoteID: Int64
-    @NSManaged public var srcURL: URL?
-    @NSManaged public var pageURL: URL?
+    @NSManaged public var sourceURL: String!
+    @NSManaged public var link: String!
     @NSManaged public var folder: StoryFolder!
 }

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -397,34 +397,6 @@ extension AssetStore {
         }
     }
 
-    /// Update the StoryAssets belonging to the specified StoryFolder with the values
-    /// in the RemoteMedia.
-    ///
-    /// - Parameters:
-    ///   - folder: The StoryFolder that owns the StoryAssets.
-    ///   - remoteMedia: An array of RemoteMedia containing properties for the StoryAssets.
-    ///   - onComplete: A block to call when the update is complete.
-    ///
-    func updateAssets(for folder: StoryFolder, with remoteMedia: [RemoteMedia], onComplete: @escaping () -> Void) {
-        let objID = folder.objectID
-        CoreDataManager.shared.performOnWriteContext {[weak self] context in
-            let storyFolder = context.object(with: objID) as! StoryFolder
-            for item in remoteMedia {
-                guard let asset = self?.getStoryAsset(for: storyFolder, with: item.mediaID) else {
-                    continue
-                }
-
-                self?.updateAsset(asset: asset, with: item)
-            }
-
-            CoreDataManager.shared.saveContext(context: context)
-
-            DispatchQueue.main.async {
-                onComplete()
-            }
-        }
-    }
-
     /// Update an individual StoryAsset instance with the relevant values from
     /// the specified RemoteMedia. This method DOES NOT save core data.
     /// Ideally the ManagedObject being modified should belong to the write context.
@@ -618,30 +590,6 @@ extension AssetStore {
             LogError(message: error.localizedDescription)
         }
         return nil
-    }
-
-    /// Get the StoryAsset's for the specified folder that have the specified remoteIDs.
-    ///
-    /// - Parameters:
-    ///   - folder: The StoryFolder that owns the StoryAssets.
-    ///   - remoteIDs: The remoteIDs that the StoryAssets should have.
-    /// - Returns: An array of StoryAssets
-    ///
-    func getStoryAssets(for folder: StoryFolder, with remoteIDs: [Int64]) -> [StoryAsset] {
-        let assets = [StoryAsset]()
-        guard let context = folder.managedObjectContext else {
-            return assets
-        }
-
-        let fetchRequest = StoryAsset.defaultFetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "folder == %@ AND remoteID IN %@", folder, remoteIDs)
-        do {
-            return try context.fetch(fetchRequest)
-        } catch {
-            let error = error as NSError
-            LogError(message: error.localizedDescription)
-        }
-        return assets
     }
 
     /// Get the StoryAsset's for the specified StoryFolders that have the specified remoteIDs.
@@ -897,6 +845,5 @@ extension AssetStore {
             onComplete(remoteErrors)
         }
     }
-
 
 }

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -96,6 +96,12 @@ extension AssetStore {
         sortOrganizer.select(index: index)
     }
 
+}
+
+// MARK: - Asset Creation
+
+extension AssetStore {
+
     /// Create a new TextNote StoryAsset
     ///
     /// - Parameters:
@@ -118,6 +124,9 @@ extension AssetStore {
             let folder = context.object(with: objID) as! StoryFolder
             let asset = self.createAsset(type: .textNote, name: name, url: nil, storyFolder: folder, in: context)
             asset.text = text
+            let date = Date()
+            asset.modified = date
+            asset.synced = date
             CoreDataManager.shared.saveContext(context: context)
             DispatchQueue.main.async {
                 onComplete?()
@@ -174,14 +183,60 @@ extension AssetStore {
         }
         asset.assetType = type
         asset.name = assetName(from: name)
-        asset.date = Date()
+        let date = Date()
+        asset.date = date
+        asset.modified = date
+        asset.synced = date
         asset.uuid = UUID()
         asset.folder = storyFolder
 
         return asset
     }
 
-    /// Retursn the name to use for a story asset based on the supplied string.
+    /// Create assets for imported media.
+    ///
+    /// - Parameters:
+    ///   - imports: A dictionary of imported assets. PHAsset IDs are keys.
+    ///   - errors: A dictionary of errors. PHAsset IDs are keys.
+    ///
+    func createAssetsForImports(imports: [String: URL], errors: [String: Error]) {
+        guard let storyFolder = StoreContainer.shared.folderStore.currentStoryFolder else {
+            return
+        }
+        if imports.count > 0 {
+            createAssetsForURLs(urls: Array(imports.values), storyFolder: storyFolder)
+        }
+        if errors.count > 0 {
+            //TODO: Handle errors
+        }
+    }
+
+    /// Import the array of PHAssets from PhotoKit to the current StoryFolder
+    ///
+    /// - Parameter assets: An array of PHAsset instances.
+    ///
+    func importMedia(assets: [PHAsset]) {
+        guard
+            let storyFolder = StoreContainer.shared.folderStore.currentStoryFolder,
+            let url = SessionManager.shared.folderManager.urlFromBookmark(bookmark: storyFolder.bookmark)
+        else {
+            LogError(message: "Unable to determine current folder path.")
+            return
+        }
+
+        let importer = try? MediaImporter(destination: url)
+        importer?.importAssets(assets: assets, onComplete: { [weak self] (imported, errors) in
+            self?.createAssetsForImports(imports: imported, errors: errors)
+        })
+    }
+
+}
+
+// MARK: - Asset Modification
+
+extension AssetStore {
+
+    /// Returns the name to use for a story asset based on the supplied string.
     ///
     /// - Parameter string: A string from which to derived the StoryAsset's name.
     /// - Returns: The name for a StoryAsset.
@@ -251,6 +306,34 @@ extension AssetStore {
         }
     }
 
+    /// Handles StoryAsset's who have media that was deleted remotely.
+    /// Neither the StoryAsset nor its local file is deleted. Instead the remoteID
+    /// is set to zero. A user may still delete the StoryAsset locally.
+    ///
+    /// - Parameters:
+    ///   - folderIDs: The UUIDs of the folders that have StoryAssets with deleted remote media.
+    ///   - remoteIDs: The IDs of the deleted media.
+    ///   - onComplete: A block called after changes are saved.
+    ///
+    func handleDeletedRemoteMedia(for folderIDs: [UUID], remoteIDs: [Int64], onComplete: @escaping () -> Void) {
+        CoreDataManager.shared.performOnWriteContext { [weak self] context in
+            let store = StoreContainer.shared.folderStore
+            let folders = store.getStoryFoldersForIDs(uuids: folderIDs)
+
+            if let assets = self?.getStoryAssets(for: folders, with: remoteIDs) {
+                for asset in assets {
+                    asset.remoteID = 0
+                }
+
+                CoreDataManager.shared.saveContext(context: context)
+            }
+
+            DispatchQueue.main.async {
+                onComplete()
+            }
+        }
+    }
+
     /// Updates the sort order of the StoryAssets matching the specified UUIDs.
     ///
     /// - Parameter order: A dictionary representing the StoryAssets to update.
@@ -274,43 +357,12 @@ extension AssetStore {
         }
     }
 
-    /// Import the array of PHAssets from PHotoKit to the current StoryFolder
-    ///
-    /// - Parameter assets: An array of PHAsset instances.
-    ///
-    func importMedia(assets: [PHAsset]) {
-        guard
-            let storyFolder = StoreContainer.shared.folderStore.currentStoryFolder,
-            let url = SessionManager.shared.folderManager.urlFromBookmark(bookmark: storyFolder.bookmark)
-        else {
-            LogError(message: "Unable to determine current folder path.")
-            return
-        }
-
-        let importer = try? MediaImporter(destination: url)
-        importer?.importAssets(assets: assets, onComplete: { [weak self] (imported, errors) in
-            self?.createAssetsForImports(imports: imported, errors: errors)
-        })
-    }
-
-    /// Create assets for imported media.
+    /// Updates the caption of a StoryAsset matching the specified UUID.
     ///
     /// - Parameters:
-    ///   - imports: A dictionary of imported assets. PHAsset IDs are keys.
-    ///   - errors: A dictionary of errors. PHAsset IDs are keys.
+    ///   - assetID: The UUID of the StoryAsset
+    ///   - caption: The text for the caption.
     ///
-    func createAssetsForImports(imports: [String: URL], errors: [String: Error]) {
-        guard let storyFolder = StoreContainer.shared.folderStore.currentStoryFolder else {
-            return
-        }
-        if imports.count > 0 {
-            createAssetsForURLs(urls: Array(imports.values), storyFolder: storyFolder)
-        }
-        if errors.count > 0 {
-            //TODO: Handle errors
-        }
-    }
-
     func updateCaption(assetID: UUID, caption: String) {
         guard let asset = getStoryAssetByID(uuid: assetID) else {
             return
@@ -320,10 +372,17 @@ extension AssetStore {
         CoreDataManager.shared.performOnWriteContext { context in
             let asset = context.object(with: objID) as! StoryAsset
             asset.caption = caption
+            asset.modified = Date()
             CoreDataManager.shared.saveContext(context: context)
         }
     }
 
+    /// Updates the altText of a StoryAsset matching the specified UUID.
+    ///
+    /// - Parameters:
+    ///   - assetID: The UUID of the StoryAsset
+    ///   - altText: The text for the altText.
+    ///
     func updateAltText(assetID: UUID, altText: String) {
         guard let asset = getStoryAssetByID(uuid: assetID) else {
             return
@@ -333,11 +392,113 @@ extension AssetStore {
         CoreDataManager.shared.performOnWriteContext { context in
             let asset = context.object(with: objID) as! StoryAsset
             asset.altText = altText
+            asset.modified = Date()
+            CoreDataManager.shared.saveContext(context: context)
+        }
+    }
+
+    /// Update the StoryAssets belonging to the specified StoryFolder with the values
+    /// in the RemoteMedia.
+    ///
+    /// - Parameters:
+    ///   - folder: The StoryFolder that owns the StoryAssets.
+    ///   - remoteMedia: An array of RemoteMedia containing properties for the StoryAssets.
+    ///   - onComplete: A block to call when the update is complete.
+    ///
+    func updateAssets(for folder: StoryFolder, with remoteMedia: [RemoteMedia], onComplete: @escaping () -> Void) {
+        let objID = folder.objectID
+        CoreDataManager.shared.performOnWriteContext {[weak self] context in
+            let storyFolder = context.object(with: objID) as! StoryFolder
+            for item in remoteMedia {
+                guard let asset = self?.getStoryAsset(for: storyFolder, with: item.mediaID) else {
+                    continue
+                }
+
+                self?.updateAsset(asset: asset, with: item)
+            }
+
+            CoreDataManager.shared.saveContext(context: context)
+
+            DispatchQueue.main.async {
+                onComplete()
+            }
+        }
+    }
+
+    /// Update an individual StoryAsset instance with the relevant values from
+    /// the specified RemoteMedia. This method DOES NOT save core data.
+    /// Ideally the ManagedObject being modified should belong to the write context.
+    ///
+    /// - Parameters:
+    ///   - asset: The StoryAsset to update.
+    ///   - remoteMedia: The RemoteMedia to use for the update.
+    ///
+    func updateAsset(asset: StoryAsset, with remoteMedia: RemoteMedia) {
+        let date = Date()
+        asset.remoteID = remoteMedia.mediaID
+        asset.sourceURL = remoteMedia.sourceURL
+        asset.link = remoteMedia.link
+        asset.name = remoteMedia.titleRendered
+        asset.altText = remoteMedia.altText
+        asset.caption = remoteMedia.captionRendered
+        asset.date = remoteMedia.dateGMT
+        asset.synced = date
+    }
+
+    /// Updates properties for the StoryAssets owned by the specified StoryFolders
+    /// with the supplied RemoteMedia. StoryAssets must already have a remoteID set
+    /// in order to match with one of the passed RemoteMedia.
+    ///
+    /// - Parameters:
+    ///   - folderIDs: The UUIDs of the StoryFolders that own the StoryAssets.
+    ///   - remoteMedia: An array of RemoteMedia.
+    ///   - onComplete: A block called after changes are saved.
+    ///
+    func updateAssets(for folderIDs: [UUID], with remoteMedia: [RemoteMedia], onComplete: @escaping () -> Void) {
+        CoreDataManager.shared.performOnWriteContext { [weak self] context in
+            let store = StoreContainer.shared.folderStore
+            let folders = store.getStoryFoldersForIDs(uuids: folderIDs)
+
+            for media in remoteMedia {
+                guard let asset = self?.getStoryAsset(for: folders, with: media.mediaID) else {
+                    continue
+                }
+                self?.updateAsset(asset: asset, with: media)
+            }
+
+            CoreDataManager.shared.saveContext(context: context)
+
+            DispatchQueue.main.async {
+                onComplete()
+            }
+        }
+    }
+
+    /// Updates the remoteID of a StoryAsset matching the specified UUID. The remoteID
+    /// should belong to an existing remote media object.
+    ///
+    /// - Parameters:
+    ///   - assetID: The UUID of the StoryAsset to update.
+    ///   - remoteID: A RemoteMedia instance.
+    ///
+    func updateAsset(assetID: UUID, with remoteMedia: RemoteMedia) {
+        guard let asset = getStoryAssetByID(uuid: assetID) else {
+            return
+        }
+
+        let objID = asset.objectID
+        CoreDataManager.shared.performOnWriteContext { [weak self] context in
+            let asset = context.object(with: objID) as! StoryAsset
+
+            self?.updateAsset(asset: asset, with: remoteMedia)
+
             CoreDataManager.shared.saveContext(context: context)
         }
     }
 
 }
+
+// MARK: - Results Controller
 
 extension AssetStore {
 
@@ -363,8 +524,15 @@ extension AssetStore {
     }
 }
 
+// MARK: - Asset Retrieval
+
 extension AssetStore {
 
+    /// Get the StoryAsset that has the specified UUID.
+    ///
+    /// - Parameter uuid: The UUID of the StoryAsset
+    /// - Returns: A StoryAsset or nil.
+    ///
     func getStoryAssetByID(uuid: UUID) -> StoryAsset? {
         let fetchRequest = StoryAsset.defaultFetchRequest()
         fetchRequest.predicate = NSPredicate(format: "uuid == %@", uuid as CVarArg)
@@ -381,7 +549,7 @@ extension AssetStore {
 
     /// Get the assets for the currently selected story folder, sorted by date.
     ///
-    /// - Parameter storyFolder: storyFolder description
+    /// - Parameter storyFolder: A StoryFolder instance.
     /// - Returns: An array of StoryAssets for the currently selected story folder.
     ///
     func getStoryAssets(storyFolder: StoryFolder) -> [StoryAsset] {
@@ -395,4 +563,340 @@ extension AssetStore {
 
         return [StoryAsset]()
     }
+
+    /// Get an array of the remoteIDs for the StoryAssets belonging to the specified StoryFolders.
+    ///
+    /// - Parameter folder: An array of StoryFolder instances.
+    /// - Returns: An array of remote IDs.
+    ///
+    func getStoryAssetsRemoteIDsForFolders(folders: [StoryFolder]) -> [Int64] {
+        var remoteIDs = [Int64]()
+
+        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = StoryAsset.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "remoteID > 0 AND folder IN %@", folders)
+        fetchRequest.propertiesToFetch = ["remoteID"]
+        fetchRequest.resultType = .dictionaryResultType
+
+        let context = CoreDataManager.shared.mainContext
+
+        guard let results = try? context.fetch(fetchRequest) as? [[String: Int64]] else {
+            LogError(message: "Error fetching Asset remoteIDs.")
+            return remoteIDs
+        }
+
+        for item in results {
+            guard let remoteID = item["remoteID"] else {
+                continue
+            }
+            remoteIDs.append(remoteID)
+        }
+
+        return remoteIDs
+    }
+
+    /// Gets the StoryAsset belonging to the specifie StoryFolder that has the
+    /// specified remoteID. The StoryFolder's ManagedObjectContext will be used
+    /// for fetching.
+    ///
+    /// - Parameters:
+    ///   - folder: The StoryFolder that owns the StoryAsset.
+    ///   - remoteID: The value of the StoryAsset's remoteID.
+    /// - Returns: The StoryAsset instance or nil.
+    ///
+    func getStoryAsset(for folder: StoryFolder, with remoteID: Int64) -> StoryAsset? {
+        guard let context =  folder.managedObjectContext else {
+            return nil
+        }
+
+        let fetchRequest = StoryAsset.defaultFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "folder == %@ AND remoteID == %d", folder, remoteID)
+
+        do {
+            return try context.fetch(fetchRequest).first
+        } catch {
+            let error = error as NSError
+            LogError(message: error.localizedDescription)
+        }
+        return nil
+    }
+
+    /// Get the StoryAsset's for the specified folder that have the specified remoteIDs.
+    ///
+    /// - Parameters:
+    ///   - folder: The StoryFolder that owns the StoryAssets.
+    ///   - remoteIDs: The remoteIDs that the StoryAssets should have.
+    /// - Returns: An array of StoryAssets
+    ///
+    func getStoryAssets(for folder: StoryFolder, with remoteIDs: [Int64]) -> [StoryAsset] {
+        let assets = [StoryAsset]()
+        guard let context = folder.managedObjectContext else {
+            return assets
+        }
+
+        let fetchRequest = StoryAsset.defaultFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "folder == %@ AND remoteID IN %@", folder, remoteIDs)
+        do {
+            return try context.fetch(fetchRequest)
+        } catch {
+            let error = error as NSError
+            LogError(message: error.localizedDescription)
+        }
+        return assets
+    }
+
+    /// Get the StoryAsset's for the specified StoryFolders that have the specified remoteIDs.
+    ///
+    /// - Parameters:
+    ///   - folders: The StoryFolders that own the StoryAssets.
+    ///   - remoteIDs: The remoteIDs that the StoryAssets should have.
+    /// - Returns: An array of StoryAssets
+    ///
+    func getStoryAssets(for folders: [StoryFolder], with remoteIDs: [Int64]) -> [StoryAsset] {
+        let assets = [StoryAsset]()
+        guard let context = folders.first?.managedObjectContext else {
+            return assets
+        }
+
+        let fetchRequest = StoryAsset.defaultFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "folder IN %@ AND remoteID IN %@", folders, remoteIDs)
+        do {
+            return try context.fetch(fetchRequest)
+        } catch {
+            let error = error as NSError
+            LogError(message: error.localizedDescription)
+        }
+        return assets
+    }
+
+    /// Get the StoryAsset from the specified StoryFolders that has the specified remoteID.
+    ///
+    /// - Parameters:
+    ///   - folders: The StoryFolders, one of which owns the StoryAsset.
+    ///   - remoteIDs: The remoteID of the StoryAsset.
+    /// - Returns: A StoryAsset instance or nil.
+    ///
+    func getStoryAsset(for folders: [StoryFolder], with remoteID: Int64) -> StoryAsset? {
+        guard let context = folders.first?.managedObjectContext else {
+            return nil
+        }
+
+        let fetchRequest = StoryAsset.defaultFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "folder IN %@ AND remoteID == %d", folders, remoteID)
+        do {
+            return try context.fetch(fetchRequest).first
+        } catch {
+            let error = error as NSError
+            LogError(message: error.localizedDescription)
+        }
+        return nil
+    }
+
+    /// Get a list of StoryAssets for the specified StoryFolder that have changes
+    /// needing to be uploaded.
+    ///
+    /// - Parameter storyFolder: The StoryFolder that owns the StoryAssets
+    /// - Returns: An array of StoryAssets
+    ///
+    func getStoryAssetsWithChanges(storyFolders: [StoryFolder]) -> [StoryAsset] {
+        let context = CoreDataManager.shared.mainContext
+        let fetchRequest = StoryAsset.defaultFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "folder IN %@ AND modified > synced", storyFolders)
+        if let results = try? context.fetch(fetchRequest) {
+            return results
+        }
+
+        return [StoryAsset]()
+    }
+
+    /// Get a list of StoryAssets needing to have their respective media file uploaded.
+    ///
+    /// - Parameter storyFolder: The StoryFolder that owns the StoryAssets.
+    /// - Returns: An array of StoryAssets.
+    ///
+    func getStoryAssetsNeedingUpload(storyFolder: StoryFolder) -> [StoryAsset] {
+        let context = CoreDataManager.shared.mainContext
+        let fetchRequest = StoryAsset.defaultFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "folder = %@ AND remoteID == 0 AND type IS NOT text", storyFolder)
+        if let results = try? context.fetch(fetchRequest) {
+            return results
+        }
+
+        return [StoryAsset]()
+    }
+
+}
+
+// MARK: - Sync related
+
+extension AssetStore {
+
+    /// Syncs remote assets for the current site's stories.
+    ///
+    /// - Parameter onComplete: A block called after syncing is complete,
+    /// or if there was an error.
+    ///
+    func syncRemoteAssets(onComplete: @escaping (Error?) -> Void) {
+        let folderStore = StoreContainer.shared.folderStore
+        let folders = folderStore.getStoryFoldersWithPosts()
+        let folderUUIDs = folders.map { $0.uuid! }
+        let remoteIDs = getStoryAssetsRemoteIDsForFolders(folders: folders)
+        let dispatchGroup = DispatchGroup()
+        let remote = MediaServiceRemote(wordPressComRestApi: SessionManager.shared.api)
+        var remoteError: Error? = nil
+
+        dispatchGroup.enter()
+
+        remote.fetchMedia(for: remoteIDs) { [weak self] (mediaArray, error) in
+            guard let mediaArray = mediaArray else {
+                remoteError = error
+                LogError(message: "Error fetching remote media: \(error.debugDescription)")
+                dispatchGroup.leave()
+                return
+            }
+
+            // Handle any deleted remote media.
+            let fetchedIDs = mediaArray.map { item -> Int64 in
+                return item.mediaID
+            }
+            let missing = Set(remoteIDs).subtracting(fetchedIDs)
+            if missing.count > 0 {
+                dispatchGroup.enter()
+                self?.handleDeletedRemoteMedia(for: folderUUIDs, remoteIDs: Array(missing)) {
+                    dispatchGroup.leave()
+                }
+            }
+
+            self?.updateAssets(for: folderUUIDs, with: mediaArray, onComplete: {
+                dispatchGroup.leave()
+            })
+        }
+
+        dispatchGroup.notify(queue: .main) {
+            onComplete(remoteError)
+        }
+    }
+
+    /// Pushes any changes to the current site's StoryAssets to the site.
+    ///
+    /// - Parameter onComplete: A block to call when the update is complete.
+    ///
+    func pushUpdatesToRemote(onComplete: @escaping ([Error]) -> Void) {
+        let folderStore = StoreContainer.shared.folderStore
+        let folders = folderStore.getStoryFoldersWithPosts()
+        let assets = getStoryAssetsWithChanges(storyFolders: folders)
+        var remoteErrors = [Error]()
+
+        guard assets.count > 0 else {
+            onComplete(remoteErrors)
+            return
+        }
+
+        let folderUUIDs = folders.map { $0.uuid! }
+        let remote = MediaServiceRemote(wordPressComRestApi: SessionManager.shared.api)
+        let dispatchGroup = DispatchGroup()
+        var updatedMedia = [RemoteMedia]()
+
+        for asset in assets {
+            dispatchGroup.enter()
+
+            let mediaID = asset.remoteID
+            let params = [
+                "title": asset.name,
+                "captions": asset.caption,
+                "alt_text": asset.altText
+            ] as [String: AnyObject]
+
+            remote.updateMediaProperties(mediaID: mediaID, mediaParameters: params) { (remoteMedia, error) in
+                guard let remoteMedia = remoteMedia else {
+                    if let error = error {
+                        remoteErrors.append(error)
+                    }
+
+                    LogError(message: "Error fetching remote media: \(error.debugDescription)")
+                    dispatchGroup.leave()
+                    return
+                }
+
+                updatedMedia.append(remoteMedia)
+                dispatchGroup.leave()
+            }
+        }
+
+        dispatchGroup.notify(queue: .main) { [weak self] in
+            guard updatedMedia.count > 0 else {
+                onComplete(remoteErrors)
+                return
+            }
+
+            self?.updateAssets(for: folderUUIDs, with: updatedMedia, onComplete: {
+                onComplete(remoteErrors)
+            })
+        }
+    }
+
+    /// Upload files and create remote media for any StoryAsset that does not yet
+    /// have a remoteID.
+    ///
+    /// - Parameter onComplete: A block to call when the update is complete.
+    ///
+    func createRemoteMedia(onComplete: @escaping ([Error]) -> Void) {
+        let folderStore = StoreContainer.shared.folderStore
+        let folders = folderStore.getStoryFoldersWithPosts()
+        let folderManager = SessionManager.shared.folderManager
+        let remote = MediaServiceRemote(wordPressComRestApi: SessionManager.shared.api)
+        let dispatchGroup = DispatchGroup()
+        var remoteErrors = [Error]()
+
+        for folder in folders {
+            let assets = getStoryAssetsNeedingUpload(storyFolder: folder)
+            guard assets.count > 0 else {
+                continue
+            }
+
+            for asset in assets {
+                guard
+                    let bookmark = asset.bookmark,
+                    let fileURL = folderManager.urlFromBookmark(bookmark: bookmark),
+                    let assetID = asset.uuid
+                else {
+                    continue
+                }
+
+                dispatchGroup.enter()
+
+                let params = [
+                    "title": asset.name,
+                    "captions": asset.caption,
+                    "alt_text": asset.altText
+                ] as [String: AnyObject]
+
+                // TODO: Handle mime type in a better fashion
+                let progress = remote.createMedia(mediaParameters: params, localURL: fileURL, filename: asset.name, mimeType: "image.jpg") { [weak self] (remoteMedia, error) in
+                    dispatchGroup.leave()
+
+                    // TODO: Clean up Progress now that it's finished.
+
+                    guard let remoteMedia = remoteMedia else {
+                        if let error = error {
+                            remoteErrors.append(error)
+                        }
+                        return
+                    }
+
+                    self?.updateAsset(assetID: assetID, with: remoteMedia)
+                }
+
+                if let progress = progress {
+                    LogInfo(message: progress.description)
+                    // TODO: Implement mechanism to share progress with UI.
+                }
+            }
+        }
+
+        dispatchGroup.notify(queue: .main) {
+            onComplete(remoteErrors)
+        }
+    }
+
+
 }

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -406,15 +406,21 @@ extension AssetStore {
     ///   - remoteMedia: The RemoteMedia to use for the update.
     ///
     func updateAsset(asset: StoryAsset, with remoteMedia: RemoteMedia) {
-        let date = Date()
+        // Safety net.  Do not overwrite local changes that are more recent
+        // than the remote's last modified date.
+        if asset.modified > remoteMedia.modifiedGMT {
+            return
+        }
+
         asset.remoteID = remoteMedia.mediaID
         asset.sourceURL = remoteMedia.sourceURL
         asset.link = remoteMedia.link
-        asset.name = remoteMedia.titleRendered
+        asset.name = remoteMedia.title
         asset.altText = remoteMedia.altText
-        asset.caption = remoteMedia.captionRendered
+        asset.caption = remoteMedia.caption
         asset.date = remoteMedia.dateGMT
-        asset.synced = date
+        asset.modified = remoteMedia.modifiedGMT
+        asset.synced = Date()
     }
 
     /// Updates properties for the StoryAssets owned by the specified StoryFolders
@@ -750,7 +756,7 @@ extension AssetStore {
             let mediaID = asset.remoteID
             let params = [
                 "title": asset.name,
-                "captions": asset.caption,
+                "caption": asset.caption,
                 "alt_text": asset.altText
             ] as [String: AnyObject]
 
@@ -814,7 +820,7 @@ extension AssetStore {
 
                 let params = [
                     "title": asset.name,
-                    "captions": asset.caption,
+                    "caption": asset.caption,
                     "alt_text": asset.altText
                 ] as [String: AnyObject]
 

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -318,7 +318,7 @@ extension AssetStore {
     func handleDeletedRemoteMedia(for folderIDs: [UUID], remoteIDs: [Int64], onComplete: @escaping () -> Void) {
         CoreDataManager.shared.performOnWriteContext { [weak self] context in
             let store = StoreContainer.shared.folderStore
-            let folders = store.getStoryFoldersForIDs(uuids: folderIDs)
+            let folders = store.getStoryFoldersForIDs(uuids: folderIDs, context: context)
 
             if let assets = self?.getStoryAssets(for: folders, with: remoteIDs) {
                 for asset in assets {
@@ -457,7 +457,7 @@ extension AssetStore {
     func updateAssets(for folderIDs: [UUID], with remoteMedia: [RemoteMedia], onComplete: @escaping () -> Void) {
         CoreDataManager.shared.performOnWriteContext { [weak self] context in
             let store = StoreContainer.shared.folderStore
-            let folders = store.getStoryFoldersForIDs(uuids: folderIDs)
+            let folders = store.getStoryFoldersForIDs(uuids: folderIDs, context: context)
 
             for media in remoteMedia {
                 guard let asset = self?.getStoryAsset(for: folders, with: media.mediaID) else {
@@ -716,7 +716,7 @@ extension AssetStore {
     func getStoryAssetsNeedingUpload(storyFolder: StoryFolder) -> [StoryAsset] {
         let context = CoreDataManager.shared.mainContext
         let fetchRequest = StoryAsset.defaultFetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "folder = %@ AND remoteID == 0 AND type IS NOT text", storyFolder)
+        fetchRequest.predicate = NSPredicate(format: "folder == %@ AND remoteID == 0 AND type != 'text'", storyFolder)
         if let results = try? context.fetch(fetchRequest) {
             return results
         }

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -692,7 +692,7 @@ extension AssetStore {
     func syncRemoteAssets(onComplete: @escaping (Error?) -> Void) {
         let folderStore = StoreContainer.shared.folderStore
         let folders = folderStore.getStoryFoldersWithPosts()
-        let folderUUIDs = folders.map { $0.uuid! }
+        let folderUUIDs = folders.compactMap { $0.uuid }
         let remoteIDs = getStoryAssetsRemoteIDsForFolders(folders: folders)
         let dispatchGroup = DispatchGroup()
         let remote = MediaServiceRemote(wordPressComRestApi: SessionManager.shared.api)
@@ -745,7 +745,7 @@ extension AssetStore {
             return
         }
 
-        let folderUUIDs = folders.map { $0.uuid! }
+        let folderUUIDs = folders.compactMap { $0.uuid }
         let remote = MediaServiceRemote(wordPressComRestApi: SessionManager.shared.api)
         let dispatchGroup = DispatchGroup()
         var updatedMedia = [RemoteMedia]()

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -385,6 +385,11 @@ extension FolderStore {
         return 0
     }
 
+    /// Get the StoryFolder that has the specified UUID.
+    ///
+    /// - Parameter uuid: The UUID of the StoryFolder.
+    /// - Returns: The StoryFolder instance or nil.
+    ///
     func getStoryFolderByID(uuid: UUID) -> StoryFolder? {
         let fetchRequest = StoryFolder.defaultFetchRequest()
         fetchRequest.predicate = NSPredicate(format: "uuid == %@", uuid as CVarArg)
@@ -397,6 +402,24 @@ extension FolderStore {
             LogError(message: error.localizedDescription)
         }
         return nil
+    }
+
+    /// Get the StoryFolders that have the specified UUIDs.
+    ///
+    /// - Parameter uuids: The UUIDs of the StoryFolders.
+    /// - Returns: An array of StoryFolders.
+    ///
+    func getStoryFoldersForIDs(uuids: [UUID]) -> [StoryFolder] {
+        let fetchRequest = StoryFolder.defaultFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "uuid IN %@", uuids as [CVarArg])
+        let context = CoreDataManager.shared.mainContext
+        do {
+            return try context.fetch(fetchRequest)
+        } catch {
+            let error = error as NSError
+            LogError(message: error.localizedDescription)
+        }
+        return []
     }
 
     /// Get a list of the post IDs for stories that have backing drafts.
@@ -506,6 +529,32 @@ extension FolderStore {
 
         return folders
     }
+
+    /// Get an array of StoryFolders for the current site that have existing remote posts.
+    ///
+    /// - Returns: An array of StoryFolders.
+    ///
+    func getStoryFoldersWithPosts() -> [StoryFolder] {
+        let folders = [StoryFolder]()
+        guard let siteID = currentSiteID else {
+            LogError(message: "Attempted to fetch story folders without a current site.")
+            return folders
+        }
+
+        let fetchRequest = StoryFolder.defaultFetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "postID > 0 AND site.uuid = %@", siteID as CVarArg)
+
+        let context = CoreDataManager.shared.mainContext
+        do {
+            return try context.fetch(fetchRequest)
+        } catch {
+            let error = error as NSError
+            LogError(message: error.localizedDescription)
+        }
+
+        return folders
+    }
+
 }
 
 // MARK: - Story Folder Modification

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -406,13 +406,14 @@ extension FolderStore {
 
     /// Get the StoryFolders that have the specified UUIDs.
     ///
-    /// - Parameter uuids: The UUIDs of the StoryFolders.
+    /// - Parameters:
+    ///   - uuids: The UUIDs of the StoryFolders.
+    ///   - context: The NSManagedObjectContext to fetch from.
     /// - Returns: An array of StoryFolders.
     ///
-    func getStoryFoldersForIDs(uuids: [UUID]) -> [StoryFolder] {
+    func getStoryFoldersForIDs(uuids: [UUID], context: NSManagedObjectContext) -> [StoryFolder] {
         let fetchRequest = StoryFolder.defaultFetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "uuid IN %@", uuids as [CVarArg])
-        let context = CoreDataManager.shared.mainContext
+        fetchRequest.predicate = NSPredicate(format: "uuid IN %@", uuids)
         do {
             return try context.fetch(fetchRequest)
         } catch {

--- a/Newspack/NewspackFramework/Extensions/Array+Helpers.swift
+++ b/Newspack/NewspackFramework/Extensions/Array+Helpers.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+// Props https://www.hackingwithswift.com/example-code/language/how-to-split-an-array-into-chunks
+extension Array {
+    public func chunked(into size: Int) -> [[Element]] {
+        return stride(from: 0, to: count, by: size).map {
+            Array(self[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
+}


### PR DESCRIPTION
Refs #91 

This PR is part two of (at least) five that will introduce comprehensive syncing support to the app.

Changes in this PR: 
- Support for fetching remote changes to media.
- Support for pushing local changes to media.
- Support for uploading new media files (but hard coded to images for now). 

This PR does NOT:
- Fully implement sync for all asset types.  The code assumes images.  A future PR will make improvements to correctly reflect the mime type of the asset being uploaded.
- Add Unit tests. I'm trying to constrain the size of these changes so I owe a follow up PR with unit tests.
- Implement uploading when a new photo is taken or added from within the app.  This will follow in a future PR.
- Handle upload progress reporting. This will follow in a future PR.
- Intelligently retry failed uploads.  This will be introduced in a future  PR.

To Test:
Run unit tests. Ensure they all pass. (No regressions!)

### Scenario 1
- Ensure that the SyncCoordinator runs during launch.  You should see output logged to the console. 
- Add a new story folder.  It should be empty.
- Background the app.
- In a browser, go to your test site's wp-admin and view the Posts list and Media list. Note their contents.
- Go to the Photos app. Select multiple photos and choose the Copy option.
- Go to the Files app. Find the folder for the new Story and paste the copied photos into it.
- Resume the Newspack app.  Note the console output that the SyncCoordinator is running.  
- Confirm that the app now reflects the copied photos in the Story.
- In a browser, check the Post list and Media list again.  Confirm that the post list shows a new draft.  Confirm the media list shows the copied images have been uploaded.

### Scenario 2
- In the app, app captions to one or more of the photos.
- Background the app. 
- Resume the app. 
- Confirm the captions are still present on the photo details.
- Confirm the captions are present for the photos in the media library on the web.

### Scenaro 3
- In the app, delete one of the images you added.
- Background and resume the app. 
- Confirm nothing goes boom when the SyncCoordinator runs.
- Confirm the image remains deleted.

@jleandroperez could I trouble you with another sync PR?
