### PR TITLE
Issues/91 syncing part 2a

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		E607386122A9A5EF00504EA4 /* AccountDetailsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E607386022A9A5EF00504EA4 /* AccountDetailsStoreTests.swift */; };
 		E60A25112425418E003F3C81 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E60A250F2425418E003F3C81 /* MainInterface.storyboard */; };
 		E60A25152425418E003F3C81 /* NewspackShare.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = E60A250B2425418E003F3C81 /* NewspackShare.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		E60E976E25376E8300144BB9 /* URL+TypeHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60E976D25376E8300144BB9 /* URL+TypeHelpers.swift */; };
 		E610B64324EC59040011FBA8 /* UITableView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E610B64224EC59040011FBA8 /* UITableView+Helpers.swift */; };
 		E6138FD22211FE86004E5B91 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6138FD12211FE86004E5B91 /* AppDelegate.swift */; };
 		E6138FD42211FE86004E5B91 /* InitialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6138FD32211FE86004E5B91 /* InitialViewController.swift */; };
@@ -392,6 +393,7 @@
 		E60A250B2425418E003F3C81 /* NewspackShare.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NewspackShare.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		E60A25102425418E003F3C81 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
 		E60A25122425418E003F3C81 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E60E976D25376E8300144BB9 /* URL+TypeHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+TypeHelpers.swift"; sourceTree = "<group>"; };
 		E610B64224EC59040011FBA8 /* UITableView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Helpers.swift"; sourceTree = "<group>"; };
 		E6138FCE2211FE86004E5B91 /* Newspack.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Newspack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E6138FD12211FE86004E5B91 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -1350,6 +1352,7 @@
 				E68A965D246098C700BE664B /* NSObject+Helpers.swift */,
 				E610B64224EC59040011FBA8 /* UITableView+Helpers.swift */,
 				E696340F2440C1C400D906E0 /* UITableViewCell+Helpers.swift */,
+				E60E976D25376E8300144BB9 /* URL+TypeHelpers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1918,6 +1921,7 @@
 				E68B2A0123048E050021283C /* EditorAttachmentImageProvider.swift in Sources */,
 				E6500F9A2368B63800CB8C6C /* ImageStore.swift in Sources */,
 				E6241B96224EC8CD00B578F5 /* SessionManager.swift in Sources */,
+				E60E976E25376E8300144BB9 /* URL+TypeHelpers.swift in Sources */,
 				E68689C0243C080400B7E363 /* FoldersViewController.swift in Sources */,
 				E641A66122A71A83008BBD85 /* SiteStore.swift in Sources */,
 				E6A10C6323579CE300435670 /* MediaAction.swift in Sources */,

--- a/Newspack/Newspack/Extensions/URL+TypeHelpers.swift
+++ b/Newspack/Newspack/Extensions/URL+TypeHelpers.swift
@@ -1,0 +1,49 @@
+import Foundation
+import CoreServices
+
+extension URL {
+
+    var utiFromPathExtension: String? {
+        let ext = pathExtension as NSString
+        guard ext.length > 0 else {
+            return nil
+        }
+        return UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, ext, nil)?.takeRetainedValue() as String?
+    }
+
+    var mimeType: String? {
+        guard let uti = utiFromPathExtension else {
+            return nil
+        }
+        return UTTypeCopyPreferredTagWithClass(uti as NSString, kUTTagClassMIMEType)?.takeRetainedValue() as String?
+    }
+
+    var isImage: Bool {
+        guard let uti = utiFromPathExtension as NSString? else {
+            return false
+        }
+        return UTTypeConformsTo(uti, kUTTypeImage)
+    }
+
+    var isAudio: Bool {
+        guard let uti = utiFromPathExtension as NSString? else {
+            return false
+        }
+        return UTTypeConformsTo(uti, kUTTypeAudio)
+    }
+
+    var isVideo: Bool {
+        guard let uti = utiFromPathExtension as NSString? else {
+            return false
+        }
+        return UTTypeConformsTo(uti, kUTTypeMovie)
+    }
+
+    var isPDF: Bool {
+        guard let uti = utiFromPathExtension as NSString? else {
+            return false
+        }
+        return UTTypeConformsTo(uti, kUTTypePDF)
+    }
+
+}

--- a/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
+++ b/Newspack/Newspack/Models/Newspack.xcdatamodeld/Newspack.xcdatamodel/contents
@@ -256,6 +256,7 @@
         <attribute name="caption" attributeType="String" defaultValueString=""/>
         <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="link" attributeType="String" defaultValueString=""/>
+        <attribute name="mimeType" attributeType="String" defaultValueString="application/octet-stream"/>
         <attribute name="modified" attributeType="Date" defaultDateTimeInterval="599554800" usesScalarValueType="NO"/>
         <attribute name="name" attributeType="String"/>
         <attribute name="order" attributeType="Integer 16" defaultValueString="-1" usesScalarValueType="YES"/>
@@ -306,7 +307,7 @@
         <element name="StagedEdits" positionX="-868.6484375" positionY="-275.66015625" width="128" height="118"/>
         <element name="StagedMedia" positionX="-2097.73828125" positionY="129.59765625" width="128" height="208"/>
         <element name="Status" positionX="-1600.76953125" positionY="-2.2265625" width="128" height="165"/>
-        <element name="StoryAsset" positionX="-1702.796875" positionY="382.8671875" width="128" height="283"/>
+        <element name="StoryAsset" positionX="-1702.796875" positionY="382.8671875" width="128" height="298"/>
         <element name="StoryFolder" positionX="-1515.86328125" positionY="210.171875" width="128" height="178"/>
         <element name="User" positionX="-976.9921875" positionY="-127.2734375" width="128" height="163"/>
     </elements>

--- a/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
+++ b/Newspack/Newspack/Models/StoryAsset+CoreDataClass.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreData
+import CoreServices
 
 @objc(StoryAsset)
 public class StoryAsset: NSManagedObject, TextNoteCellProvider, PhotoCellProvider, VideoCellProvider, AudioCellProvider {
@@ -41,4 +42,31 @@ enum StoryAssetType: String {
 
         }
     }
+
+    /// Return the type of asset for the specified mimeType. TextNotes do not have
+    /// backing files so .textNote is not a valid result.
+    ///
+    /// - Parameter mimeType: A string representing a mime type.
+    /// - Returns: The type of asset for the mime type or nil if there was no match.
+    ///
+    static func typeFromMimeType(mimeType: String) -> StoryAssetType? {
+        guard let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mimeType as NSString, nil)?.takeRetainedValue() as NSString? else {
+            return nil
+        }
+
+        if UTTypeConformsTo(uti, kUTTypeImage) {
+            return .image
+        }
+
+        if UTTypeConformsTo(uti, kUTTypeVideo) {
+            return .video
+        }
+
+        if UTTypeConformsTo(uti, kUTTypeAudio) {
+            return .audioNote
+        }
+
+        return nil
+    }
+
 }

--- a/Newspack/Newspack/Models/StoryAsset+CoreDataProperties.swift
+++ b/Newspack/Newspack/Models/StoryAsset+CoreDataProperties.swift
@@ -34,5 +34,6 @@ extension StoryAsset {
     @NSManaged public var remoteID: Int64
     @NSManaged public var sourceURL: String!
     @NSManaged public var link: String!
+    @NSManaged public var mimeType: String! // Default is application/octet-stream
     @NSManaged public var folder: StoryFolder!
 }

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -850,8 +850,7 @@ extension AssetStore {
                     "alt_text": asset.altText
                 ] as [String: AnyObject]
 
-                // TODO: Handle mime type in a better fashion
-                let progress = remote.createMedia(mediaParameters: params, localURL: fileURL, filename: asset.name, mimeType: "image.jpg") { [weak self] (remoteMedia, error) in
+                let progress = remote.createMedia(mediaParameters: params, localURL: fileURL, filename: asset.name, mimeType: asset.mimeType) { [weak self] (remoteMedia, error) in
                     dispatchGroup.leave()
 
                     // TODO: Clean up Progress now that it's finished.

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -147,10 +147,15 @@ extension AssetStore {
             let folder = context.object(with: objID) as! StoryFolder
 
             for url in urls {
-                // TODO: There is more to do depending on the type of item.
-                // But we'll deal with this as we build out the individual features.
-                // For testing purposes we'll default to image for now.
-                let _ = self?.createAsset(type: .image, name: url.lastPathComponent, url: url, storyFolder: folder, in: context)
+                // Get the type based off the fileURLs extension.
+                // By convention treat unknown types as images (for now) as this will work for heic files.
+                var type: StoryAssetType = .image
+                if url.isVideo {
+                    type = .video
+                } else if url.isAudio {
+                    type = .audioNote
+                }
+                let _ = self?.createAsset(type: type, name: url.lastPathComponent, url: url, storyFolder: folder, in: context)
             }
 
             CoreDataManager.shared.saveContext(context: context)
@@ -226,7 +231,7 @@ extension AssetStore {
             return
         }
         if imports.count > 0 {
-            createAssetsForURLs(urls: Array(imports.values), storyFolder: storyFolder)
+            createAssetsForImportedMedia(importedMedia: Array(imports.values), storyFolder: storyFolder)
         }
         if errors.count > 0 {
             LogError(message: "Errors Importing Media: \(errors)")

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -122,11 +122,8 @@ extension AssetStore {
                 return
             }
             let folder = context.object(with: objID) as! StoryFolder
-            let asset = self.createAsset(type: .textNote, name: name, url: nil, storyFolder: folder, in: context)
+            let asset = self.createAsset(type: .textNote, name: name, mimeType: "text/plain", url: nil, storyFolder: folder, in: context)
             asset.text = text
-            let date = Date()
-            asset.modified = date
-            asset.synced = date
             CoreDataManager.shared.saveContext(context: context)
             DispatchQueue.main.async {
                 onComplete?()
@@ -155,7 +152,8 @@ extension AssetStore {
                 } else if url.isAudio {
                     type = .audioNote
                 }
-                let _ = self?.createAsset(type: type, name: url.lastPathComponent, url: url, storyFolder: folder, in: context)
+                let mime = url.mimeType ?? "application/octet-stream"
+                let _ = self?.createAsset(type: type, name: url.lastPathComponent, mimeType: mime, url: url, storyFolder: folder, in: context)
             }
 
             CoreDataManager.shared.saveContext(context: context)
@@ -182,7 +180,7 @@ extension AssetStore {
                 // Get the type based off the mime type of the imported asset.
                 // By convention treat unknown types as images (for now) as this will work for heic files.
                 let type = StoryAssetType.typeFromMimeType(mimeType: media.mimeType) ?? .image
-                let _ = self?.createAsset(type: type, name: media.fileURL.lastPathComponent, url: media.fileURL, storyFolder: folder, in: context)
+                let _ = self?.createAsset(type: type, name: media.fileURL.lastPathComponent, mimeType: media.mimeType, url: media.fileURL, storyFolder: folder, in: context)
             }
 
             CoreDataManager.shared.saveContext(context: context)
@@ -198,12 +196,13 @@ extension AssetStore {
     /// - Parameters:
     ///   - type: The type of asset.
     ///   - name: The asset's name.
+    ///   - mimeType: The mimeType for the asset.
     ///   - url: The file URL of the asset if there is a corresponding file system object.
     ///   - storyFolder: The asset's StoryFolder.
     ///   - context: A NSManagedObjectContext to use.
     /// - Returns: A new StoryAsset
     ///
-    func createAsset(type: StoryAssetType, name: String, url: URL?, storyFolder: StoryFolder, in context: NSManagedObjectContext) -> StoryAsset {
+    func createAsset(type: StoryAssetType, name: String, mimeType: String, url: URL?, storyFolder: StoryFolder, in context: NSManagedObjectContext) -> StoryAsset {
         let asset = StoryAsset(context: context)
         if let url = url {
             asset.bookmark = folderManager.bookmarkForURL(url: url)

--- a/Newspack/Newspack/Stores/MediaImporter.swift
+++ b/Newspack/Newspack/Stores/MediaImporter.swift
@@ -112,7 +112,6 @@ extension MediaImporter {
 
         importAsset(asset: asset) { [weak self] (asset, fileURL, filename, mimeType, error) in
             if let fileURL = fileURL, let mimeType = mimeType {
-
                 self?.imported[asset.identifier()] = ImportedMedia(fileURL: fileURL, mimeType: mimeType)
             }
 

--- a/Newspack/Newspack/Stores/MediaImporter.swift
+++ b/Newspack/Newspack/Stores/MediaImporter.swift
@@ -13,6 +13,13 @@ enum MediaImporterError: Error {
     case missingUniformTypeIdentifier
 }
 
+/// A lightweight data model for imported media.
+///
+struct ImportedMedia {
+    let fileURL: URL
+    let mimeType: String
+}
+
 /// A utility for copying PHAssets to a specified directory in the file system.
 ///
 class MediaImporter {
@@ -40,13 +47,13 @@ class MediaImporter {
     private var assets = [PHAsset]()
 
     /// Container dictionary. Imported asset identifiers are keys and their fileURLs are values.
-    private var imported = [String: URL]()
+    private var imported = [String: ImportedMedia]()
 
     /// Container dictionary. Errored asset identifiers are keys and their errors are values.
     private var errors = [String: Error]()
 
     /// Callback executed when importing is complete.
-    private var completionHandler: (( [String: URL], [String: Error] ) -> Void)?
+    private var completionHandler: (( [String: ImportedMedia], [String: Error] ) -> Void)?
 
     /// Designated initializer.
     ///
@@ -67,7 +74,7 @@ class MediaImporter {
     ///   - assets: An array of PHAssets to copy to the destination directory.
     ///   - onComplete: An optional completion handler.
     ///
-    func importAssets(assets: [PHAsset], onComplete: (([String: URL], [String: Error]) -> Void)?) {
+    func importAssets(assets: [PHAsset], onComplete: (([String: ImportedMedia], [String: Error]) -> Void)?) {
         self.assets.append(contentsOf: assets)
         completionHandler = onComplete
         importNext()
@@ -104,8 +111,9 @@ extension MediaImporter {
         currentImportID = asset.identifier()
 
         importAsset(asset: asset) { [weak self] (asset, fileURL, filename, mimeType, error) in
-            if let fileURL = fileURL {
-                self?.imported[asset.identifier()] = fileURL
+            if let fileURL = fileURL, let mimeType = mimeType {
+
+                self?.imported[asset.identifier()] = ImportedMedia(fileURL: fileURL, mimeType: mimeType)
             }
 
             if let error = error {

--- a/Newspack/Newspack/System/SyncCoordinator.swift
+++ b/Newspack/Newspack/System/SyncCoordinator.swift
@@ -188,12 +188,21 @@ extension SyncCoordinator {
     ///
     func createNewAssetsIfNeeded() {
         let store = StoreContainer.shared.assetStore
-        store.createRemoteMedia { [weak self] (errors) in
+        let batchSize = 3
+        store.batchCreateRemoteMedia(batchSize: batchSize) { [weak self] (count, errors) in
+            // Bail on any errors.
             guard self?.handleErrors(errors: errors) == false else {
                 self?.processing = false
                 return
             }
-            self?.performNextStep()
+
+            if count < batchSize {
+                self?.performNextStep()
+                return
+            }
+
+            // Keep going until there are none left.
+            self?.createNewAssetsIfNeeded()
         }
     }
 

--- a/Newspack/NewspackTests/Stores/FolderStoreTests.swift
+++ b/Newspack/NewspackTests/Stores/FolderStoreTests.swift
@@ -203,11 +203,11 @@ class FolderStoreTests: BaseTest {
         for folder in folders {
             let context = folder.managedObjectContext!
             if folder.name == "alpha" {
-                let _ = assetStore.createAsset(type: .image, name: "alphaImage", url: nil, storyFolder: folder, in: context)
+                let _ = assetStore.createAsset(type: .image, name: "alphaImage", mimeType: "image/png", url: nil, storyFolder: folder, in: context)
                 try? context.save()
 
             } else if folder.name == "gamma" {
-                let _ = assetStore.createAsset(type: .image, name: "gammaImage", url: nil, storyFolder: folder, in: context)
+                let _ = assetStore.createAsset(type: .image, name: "gammaImage", mimeType: "image/png", url: nil, storyFolder: folder, in: context)
                 try? context.save()
                 let expect = expectation(description: "expect")
                 folderStore.assignPostIDAfterCreatingDraft(postID: 4, to: folder.uuid!, onComplete: {


### PR DESCRIPTION
Refs #91 

This is a follow up to the Asset Sync part 2 PR that does the following: 
- Adds a mimeType field to AssetStore and assigns a default value.
- Wrangles a file's mimeType, either via the MediaImporter or via URL inspection.
- Implements a mechanism to throttle the number of concurrent uploads by the SyncCoordinator. 

Keeping this PR small(ish), so Unit tests will follow next.

@jleandroperez can I trouble you for a peek at this one? The testing steps are basically the same as the previous PR, just needing to confirm there are no regressions.

To test: 
For convenience, change the value of `batchSize` to 1 so you can see individual file uploads.
Repeat the testing scenarios from #109 and confirm there are no regressions.