### PR TITLE
Issues/91 progress ui

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 		E69EB27E22BAE2E2004A92FA /* CoreRestApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69EB27D22BAE2E2004A92FA /* CoreRestApiTests.swift */; };
 		E6A10C6323579CE300435670 /* MediaAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A10C6223579CE300435670 /* MediaAction.swift */; };
 		E6A2036F2539E5DA00D85EE0 /* ProgressStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A2036E2539E5DA00D85EE0 /* ProgressStore.swift */; };
+		E6A20371253A388600D85EE0 /* ProgressCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A20370253A388600D85EE0 /* ProgressCell.swift */; };
 		E6A4D73D230766AC00929376 /* remote-posts-create.json in Resources */ = {isa = PBXBuildFile; fileRef = E6A4D73C230766AC00929376 /* remote-posts-create.json */; };
 		E6A4D73F23076A3200929376 /* remote-posts-update.json in Resources */ = {isa = PBXBuildFile; fileRef = E6A4D73E23076A3200929376 /* remote-posts-update.json */; };
 		E6A4D742230A08A700929376 /* StagedEdits+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A4D740230A08A600929376 /* StagedEdits+CoreDataProperties.swift */; };
@@ -570,6 +571,7 @@
 		E69EB27D22BAE2E2004A92FA /* CoreRestApiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreRestApiTests.swift; sourceTree = "<group>"; };
 		E6A10C6223579CE300435670 /* MediaAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaAction.swift; sourceTree = "<group>"; };
 		E6A2036E2539E5DA00D85EE0 /* ProgressStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressStore.swift; sourceTree = "<group>"; };
+		E6A20370253A388600D85EE0 /* ProgressCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressCell.swift; sourceTree = "<group>"; };
 		E6A4D73C230766AC00929376 /* remote-posts-create.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-create.json"; sourceTree = "<group>"; };
 		E6A4D73E23076A3200929376 /* remote-posts-update.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-update.json"; sourceTree = "<group>"; };
 		E6A4D740230A08A600929376 /* StagedEdits+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StagedEdits+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -976,6 +978,7 @@
 				E6D2193F24EF27F90011A2C1 /* ImageTableViewCell.xib */,
 				E605B32D24F4499F00E1768B /* TextFieldTableViewCell.swift */,
 				E605B32E24F4499F00E1768B /* TextFieldTableViewCell.xib */,
+				E6A20370253A388600D85EE0 /* ProgressCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1904,6 +1907,7 @@
 				E640D27823883ED800887FD9 /* StagedMediaImporter.swift in Sources */,
 				E61D8F6C2375EC3E005FECED /* StagedMediaStore.swift in Sources */,
 				E66CCA0D2303527C00F1CA59 /* Site+CoreDataProperties.swift in Sources */,
+				E6A20371253A388600D85EE0 /* ProgressCell.swift in Sources */,
 				E604EE4924C774A80015D284 /* UserView.swift in Sources */,
 				E66CCA0B2303527C00F1CA59 /* Account+CoreDataProperties.swift in Sources */,
 				E63F3F3C236350BE00DB760E /* MediaTypeDiscerner.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		E69E59FD22541ABD00899DE2 /* WordPressCoreRestApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69E59FC22541ABD00899DE2 /* WordPressCoreRestApi.swift */; };
 		E69EB27E22BAE2E2004A92FA /* CoreRestApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69EB27D22BAE2E2004A92FA /* CoreRestApiTests.swift */; };
 		E6A10C6323579CE300435670 /* MediaAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A10C6223579CE300435670 /* MediaAction.swift */; };
+		E6A2036F2539E5DA00D85EE0 /* ProgressStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A2036E2539E5DA00D85EE0 /* ProgressStore.swift */; };
 		E6A4D73D230766AC00929376 /* remote-posts-create.json in Resources */ = {isa = PBXBuildFile; fileRef = E6A4D73C230766AC00929376 /* remote-posts-create.json */; };
 		E6A4D73F23076A3200929376 /* remote-posts-update.json in Resources */ = {isa = PBXBuildFile; fileRef = E6A4D73E23076A3200929376 /* remote-posts-update.json */; };
 		E6A4D742230A08A700929376 /* StagedEdits+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A4D740230A08A600929376 /* StagedEdits+CoreDataProperties.swift */; };
@@ -564,6 +565,7 @@
 		E69E59FC22541ABD00899DE2 /* WordPressCoreRestApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressCoreRestApi.swift; sourceTree = "<group>"; };
 		E69EB27D22BAE2E2004A92FA /* CoreRestApiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreRestApiTests.swift; sourceTree = "<group>"; };
 		E6A10C6223579CE300435670 /* MediaAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaAction.swift; sourceTree = "<group>"; };
+		E6A2036E2539E5DA00D85EE0 /* ProgressStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressStore.swift; sourceTree = "<group>"; };
 		E6A4D73C230766AC00929376 /* remote-posts-create.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-create.json"; sourceTree = "<group>"; };
 		E6A4D73E23076A3200929376 /* remote-posts-update.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-update.json"; sourceTree = "<group>"; };
 		E6A4D740230A08A600929376 /* StagedEdits+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StagedEdits+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -1166,6 +1168,7 @@
 				E640D27723883ED800887FD9 /* StagedMediaImporter.swift */,
 				E640D27923883EE700887FD9 /* StagedMediaUploader.swift */,
 				E694469B24D9FB0100D0BF56 /* MediaImporter.swift */,
+				E6A2036E2539E5DA00D85EE0 /* ProgressStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -1823,6 +1826,7 @@
 				E61BBD6822FA0470008A6D4C /* StartupHelper.swift in Sources */,
 				E6D6346D251940E8001F20BF /* SyncCoordinator.swift in Sources */,
 				E636C26C234FEAD800564B63 /* MediaQuery+CoreDataProperties.swift in Sources */,
+				E6A2036F2539E5DA00D85EE0 /* ProgressStore.swift in Sources */,
 				E66CCA112303527C00F1CA59 /* AccountCapabilities+CoreDataClass.swift in Sources */,
 				E66CCA152303527D00F1CA59 /* AccountCapabilities+CoreDataProperties.swift in Sources */,
 				E638804E22DFC07900B3C16A /* PostItemStore.swift in Sources */,

--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		E6B8CFDD24ABC48C0068C6BE /* FolderStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDC24ABC48C0068C6BE /* FolderStoreTests.swift */; };
 		E6B8CFE024ABD6EB0068C6BE /* ReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */; };
 		E6BA1322243F9D1E00635A8A /* AssetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */; };
+		E6CD340A253E33FE00E9882F /* SyncAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CD3409253E33FE00E9882F /* SyncAction.swift */; };
 		E6CE56AF22B19001004895E5 /* ModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CE56AE22B19001004895E5 /* ModelFactory.swift */; };
 		E6D0F28124EDC6C000DBE52E /* PhotoDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D0F28024EDC6C000DBE52E /* PhotoDetailViewController.swift */; };
 		E6D0F28324EDC6F800DBE52E /* ImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D0F28224EDC6F800DBE52E /* ImageViewController.swift */; };
@@ -601,6 +602,7 @@
 		E6B8CFDF24ABD6EB0068C6BE /* ReconcilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconcilerTests.swift; sourceTree = "<group>"; };
 		E6BA1321243F9D1E00635A8A /* AssetsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsViewController.swift; sourceTree = "<group>"; };
 		E6C3988B24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Newspack.swift"; sourceTree = "<group>"; };
+		E6CD3409253E33FE00E9882F /* SyncAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAction.swift; sourceTree = "<group>"; };
 		E6CE56AE22B19001004895E5 /* ModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFactory.swift; sourceTree = "<group>"; };
 		E6D0F28024EDC6C000DBE52E /* PhotoDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoDetailViewController.swift; sourceTree = "<group>"; };
 		E6D0F28224EDC6F800DBE52E /* ImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewController.swift; sourceTree = "<group>"; };
@@ -752,6 +754,7 @@
 				E6A800F424380A6600A14E6C /* FolderAction.swift */,
 				E6A10C6223579CE300435670 /* MediaAction.swift */,
 				E602E69722C1670800795CBA /* PostAction.swift */,
+				E6CD3409253E33FE00E9882F /* SyncAction.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -1135,11 +1138,11 @@
 		E62018D924F9AF2100D96AFF /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				E628CBA12527C23100770B44 /* Array+Helpers.swift */,
 				E6B779E924EB2FC5007EA033 /* CGSize+Helpers.swift */,
+				E630E33E250029020028BBF2 /* FileManager+Helpers.swift */,
 				E63FF0EB24AA864C0002A32F /* URL+FileReference.swift */,
 				E6C3988B24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift */,
-				E630E33E250029020028BBF2 /* FileManager+Helpers.swift */,
-				E628CBA12527C23100770B44 /* Array+Helpers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1931,6 +1934,7 @@
 				E6FB520822B9D2A30010FDF8 /* AccountSetupHelper.swift in Sources */,
 				E6871F1922C3FD8A008D3D46 /* SiteMenuViewController.swift in Sources */,
 				E68A96602460990B00BE664B /* NSManagedObject+Helpers.swift in Sources */,
+				E6CD340A253E33FE00E9882F /* SyncAction.swift in Sources */,
 				E6AC98B823CCD5DE00E95381 /* MainNavController.swift in Sources */,
 				E68B2A0123048E050021283C /* EditorAttachmentImageProvider.swift in Sources */,
 				E6500F9A2368B63800CB8C6C /* ImageStore.swift in Sources */,

--- a/Newspack/Newspack/Api/ServiceRemotes/PostServiceRemote.swift
+++ b/Newspack/Newspack/Api/ServiceRemotes/PostServiceRemote.swift
@@ -52,6 +52,7 @@ class PostServiceRemote: ServiceRemoteCoreRest {
         let filter = ["id": ids] as [String: AnyObject]
         let params = [
             "_fields": "id,title,status,date_gmt,modified_gmt,_links",
+            "status": "draft,pending",
             "page": page,
             "per_page": perPage
         ] as [String: AnyObject]

--- a/Newspack/Newspack/Stores/Actions/SyncAction.swift
+++ b/Newspack/Newspack/Stores/Actions/SyncAction.swift
@@ -1,0 +1,10 @@
+import Foundation
+import WordPressFlux
+
+/// Supported Actions for Syncing
+///
+enum SyncAction: Action {
+    case syncAll
+    case syncStories
+    case syncAssets
+}

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -187,7 +187,7 @@ extension AssetStore {
 
             DispatchQueue.main.async {
                 onComplete?()
-                SyncCoordinator.shared.process(steps: [.createRemoteAssets])
+                SyncCoordinator.shared.process(steps: [.createRemoteStories, .createRemoteAssets])
             }
         }
     }

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -869,7 +869,7 @@ extension AssetStore {
 
             let progress = remote.createMedia(mediaParameters: params, localURL: fileURL, filename: asset.name, mimeType: asset.mimeType) { [weak self] (remoteMedia, error) in
 
-                // TODO: Clean up Progress now that it's finished.
+                StoreContainer.shared.progressStore.remove(for: assetID)
 
                 guard let remoteMedia = remoteMedia else {
                     if let error = error {
@@ -885,8 +885,7 @@ extension AssetStore {
             }
 
             if let progress = progress {
-                LogInfo(message: progress.description)
-                // TODO: Implement mechanism to share progress with UI.
+                StoreContainer.shared.progressStore.add(progress: progress, for: assetID)
             }
         }
 

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -187,6 +187,7 @@ extension AssetStore {
 
             DispatchQueue.main.async {
                 onComplete?()
+                SyncCoordinator.shared.process(steps: [.createRemoteAssets])
             }
         }
     }
@@ -404,6 +405,7 @@ extension AssetStore {
 
             DispatchQueue.main.async {
                 onComplete?()
+                SyncCoordinator.shared.process(steps: [.pushAssetUpdates])
             }
         }
     }
@@ -428,6 +430,7 @@ extension AssetStore {
 
             DispatchQueue.main.async {
                 onComplete?()
+                SyncCoordinator.shared.process(steps: [.pushAssetUpdates])
             }
         }
     }

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -213,6 +213,7 @@ extension FolderStore {
                 self?.selectDefaultStoryFolderIfNeeded()
                 onComplete?()
                 ShadowCaster.shared.castShadows()
+                SyncCoordinator.shared.process(steps: [.createRemoteStories])
             }
         }
     }
@@ -600,6 +601,7 @@ extension FolderStore {
 
             DispatchQueue.main.async {
                 onComplete?()
+                SyncCoordinator.shared.process(steps: [.pushStoryUpdates])
             }
         }
     }

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -730,10 +730,11 @@ extension FolderStore {
     ///
     func syncAndProcessRemoteDrafts(onComplete: @escaping (Error?) -> Void) {
         let postIDs = getStoryFolderPostIDs()
+        let perPage = min(postIDs.count, 100)
 
         // Sync the posts for these POST IDs.
         let remote = PostServiceRemote(wordPressComRestApi: SessionManager.shared.api)
-        remote.fetchPostStubs(for: postIDs, page: 1, perPage: 100) { [weak self] (postStubs, error) in
+        remote.fetchPostStubs(for: postIDs, page: 1, perPage: perPage) { [weak self] (postStubs, error) in
             guard let stubs = postStubs else {
                 LogError(message: "Error fetching post stubs.")
                 onComplete(error)

--- a/Newspack/Newspack/Stores/ProgressStore.swift
+++ b/Newspack/Newspack/Stores/ProgressStore.swift
@@ -1,6 +1,20 @@
 import Foundation
 import UIKit
 
+/// A simple class to wrap a UUID.  UUIDs are structs and we want value object
+/// to use with notifications. Hence this helper class.
+///
+class ProgressKey {
+    let uuid: UUID
+    init(uuid: UUID) {
+        self.uuid = uuid
+    }
+}
+
+/// Storage for UIProgress instances associated with a particular StoryAsset.
+/// Association is by UUID.  Interested observers should first get a ProgressKey
+/// for the UUID in question, then observe notifiations for that ProgressKey.
+///
 class ProgressStore {
 
     static let startedTrackingProgress = NSNotification.Name("startedTrackingProgress")
@@ -9,47 +23,73 @@ class ProgressStore {
     private var store = [UUID: Progress]()
     private var progressKeys = [UUID: ProgressKey]()
 
+    /// Get a progress object for the specified UUID if it exists.
+    ///
+    /// - Parameter uuid: A UUID.
+    /// - Returns: A Progress instance or nil.
+    ///
     func progress(for uuid: UUID) -> Progress? {
         return store[uuid]
     }
 
+    /// Add a Progress instance to the store for the specified UUID. This removes
+    /// an existing Progress instance from the store.
+    ///
+    /// - Parameters:
+    ///   - progress: A Progress instance.
+    ///   - uuid: The UUID.
+    ///
     func add(progress: Progress, for uuid: UUID) {
         remove(for: uuid) // remove stale progress if it exists.
         store[uuid] = progress
-        _ = keyForUUID(uuid: uuid)
-        notify(uuid: uuid, added: true)
+
+        let key = keyForUUID(uuid: uuid)
+        notify(key: key, added: true)
     }
 
+    /// Removes the Progress instance for the specified UUID.
+    ///
+    /// - Parameter uuid: The UUID.
+    ///
     func remove(for uuid: UUID) {
         guard let _ = store.removeValue(forKey: uuid) else {
             return
         }
+
+        // Get a reference to the key before removing it.
+        let key = keyForUUID(uuid: uuid)
         progressKeys.removeValue(forKey: uuid)
 
-        notify(uuid: uuid, added: false)
+        notify(key: key, added: false)
     }
 
-    private func notify(uuid: UUID, added: Bool) {
+    /// Posts notifications related to starting or stopping tracking progress for
+    /// the specified ProgressKey.
+    ///
+    /// - Parameters:
+    ///   - key: A ProgressKey instancce.
+    ///   - added: Whether progress is being tracked or not.
+    ///
+    private func notify(key: ProgressKey, added: Bool) {
         let name = added ? ProgressStore.startedTrackingProgress : ProgressStore.stoppedTrackingProgress
-        let obj = keyForUUID(uuid: uuid)
-        NotificationCenter.default.post(name: name , object: obj)
+        NotificationCenter.default.post(name: name , object: key)
     }
 
+    /// Get a ProgressKey for the specified UUID.
+    ///
+    /// - Parameter uuid: The UUID.
+    /// - Returns: A ProgressKey instance.
+    ///
     func keyForUUID(uuid: UUID) -> ProgressKey {
-        if let obj = progressKeys[uuid] {
-            return obj
+        // Just return an existing key.
+        if let key = progressKeys[uuid] {
+            return key
         }
 
-        let obj = ProgressKey(uuid: uuid)
-        progressKeys[uuid] = obj
-        return obj
+        // Create a key and return it.
+        let key = ProgressKey(uuid: uuid)
+        progressKeys[uuid] = key
+        return key
     }
 
-}
-
-class ProgressKey {
-    let uuid: UUID
-    init(uuid: UUID) {
-        self.uuid = uuid
-    }
 }

--- a/Newspack/Newspack/Stores/ProgressStore.swift
+++ b/Newspack/Newspack/Stores/ProgressStore.swift
@@ -1,0 +1,33 @@
+import Foundation
+import UIKit
+
+class ProgressStore {
+
+    static let startedTrackingProgress = NSNotification.Name("startedTrackingProgress")
+    static let stoppedTrackingProgress = NSNotification.Name("stoppedTrackingProgress")
+
+    private var store = [UUID: Progress]()
+
+    func progress(for uuid: UUID) -> Progress? {
+        return store[uuid]
+    }
+
+    func add(progress: Progress, for uuid: UUID) {
+        remove(for: uuid) // remove stale progress if it exists.
+        store[uuid] = progress
+        notify(uuid: uuid, added: true)
+    }
+
+    func remove(for uuid: UUID) {
+        guard let _ = store.removeValue(forKey: uuid) else {
+            return
+        }
+        notify(uuid: uuid, added: false)
+    }
+
+    func notify(uuid: UUID, added: Bool) {
+        let name = added ? ProgressStore.startedTrackingProgress : ProgressStore.stoppedTrackingProgress
+        NotificationCenter.default.post(name: name , object: uuid)
+    }
+
+}

--- a/Newspack/Newspack/Stores/ProgressStore.swift
+++ b/Newspack/Newspack/Stores/ProgressStore.swift
@@ -72,7 +72,7 @@ class ProgressStore {
     ///
     private func notify(key: ProgressKey, added: Bool) {
         let name = added ? ProgressStore.startedTrackingProgress : ProgressStore.stoppedTrackingProgress
-        NotificationCenter.default.post(name: name , object: key)
+        NotificationCenter.default.post(name: name, object: key)
     }
 
     /// Get a ProgressKey for the specified UUID.

--- a/Newspack/Newspack/Stores/StoreContainer.swift
+++ b/Newspack/Newspack/Stores/StoreContainer.swift
@@ -18,6 +18,7 @@ class StoreContainer {
     private(set) var stagedMediaStore = StagedMediaStore()
     private(set) var folderStore = FolderStore()
     private(set) var assetStore = AssetStore()
+    private(set) var progressStore = ProgressStore()
 
     private init() {}
 
@@ -34,7 +35,7 @@ class StoreContainer {
         // NOTE: The SiteStore must be reset BEFORE any other store that interacts
         // with folders, as the SiteStore is responsible for creating the site's
         // folder--the parent container for StoryFolders etc.
-        // It must also be set before any store that relies on retrieving the
+        // It must also be set before any store that relies on retrieving the site.
         siteStore = SiteStore(dispatcher: dispatcher, siteID: site?.uuid)
 
         postStore = PostStore(dispatcher: dispatcher, siteID: site?.uuid)
@@ -45,5 +46,6 @@ class StoreContainer {
         stagedMediaStore = StagedMediaStore(dispatcher: dispatcher, siteID: site?.uuid)
         folderStore = FolderStore(dispatcher: dispatcher, siteID: site?.uuid)
         assetStore = AssetStore(dispatcher: dispatcher)
+        progressStore = ProgressStore()
     }
 }

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hEm-rr-Shu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hEm-rr-Shu">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>

--- a/Newspack/Newspack/System/AppDelegate.swift
+++ b/Newspack/Newspack/System/AppDelegate.swift
@@ -12,7 +12,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // We want a single instance of the Reconciler for the lifecycle of the app.
     // We'll instantiate it here for convenience.
     let reconciler = Reconciler()
-    let syncCoordinator = SyncCoordinator()
 
     var sessionReceipt: Any?
     var window: UIWindow?

--- a/Newspack/Newspack/System/SyncCoordinator.swift
+++ b/Newspack/Newspack/System/SyncCoordinator.swift
@@ -312,6 +312,3 @@ extension SyncCoordinator {
     }
 
 }
-
-
-

--- a/Newspack/Newspack/System/SyncCoordinator.swift
+++ b/Newspack/Newspack/System/SyncCoordinator.swift
@@ -88,7 +88,7 @@ class SyncCoordinator: StatefulStore<SyncCoordinatorState> {
 
     private func listenToSession() {
         // Stop processing sync steps whenever the session changes.
-        // Regeister for the new session dispatcher.
+        // Register for the new session dispatcher.
         sessionReceipt = SessionManager.shared.onChange {
             self.stepQueue = []
             self.refreshSessionListener()

--- a/Newspack/Newspack/View/AudioTableViewCell.swift
+++ b/Newspack/Newspack/View/AudioTableViewCell.swift
@@ -1,11 +1,12 @@
 import UIKit
 
 protocol AudioCellProvider {
+    var uuid: UUID! { get }
     var name: String! { get }
     var caption: String! { get }
 }
 
-class AudioTableViewCell: UITableViewCell {
+class AudioTableViewCell: ProgressCell {
 
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var captionLabel: UILabel!
@@ -30,6 +31,7 @@ class AudioTableViewCell: UITableViewCell {
     func configure(audio: AudioCellProvider) {
         titleLabel.text = audio.name
         captionLabel.text = audio.caption
+        observeProgress(uuid: audio.uuid)
     }
 
 }

--- a/Newspack/Newspack/View/AudioTableViewCell.xib
+++ b/Newspack/Newspack/View/AudioTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -9,63 +9,72 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="AudioTableViewCell" customModule="Newspack" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="49" id="KGk-i7-Jjw" customClass="AudioTableViewCell" customModule="Newspack" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="49"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="49"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="1KI-rP-1i8">
-                        <rect key="frame" x="16" y="0.0" width="288" height="44"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="spl-AO-CAC">
+                        <rect key="frame" x="16" y="0.0" width="288" height="49"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="Vgk-xr-df3">
-                                <rect key="frame" x="0.0" y="0.0" width="256" height="44"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="1KI-rP-1i8">
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="47"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filename.png" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mPo-DG-VUv">
-                                        <rect key="frame" x="0.0" y="0.0" width="256" height="24.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A short caption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pfb-b7-M6j">
-                                        <rect key="frame" x="0.0" y="24.5" width="256" height="19.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="Vgk-xr-df3">
+                                        <rect key="frame" x="0.0" y="1.5" width="256" height="44"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filename.png" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mPo-DG-VUv">
+                                                <rect key="frame" x="0.0" y="0.0" width="256" height="24.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A short caption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pfb-b7-M6j">
+                                                <rect key="frame" x="0.0" y="24.5" width="256" height="19.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="PBk-A4-gUp"/>
+                                        </constraints>
+                                    </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UiF-vl-BcH">
+                                        <rect key="frame" x="264" y="11.5" width="24" height="24"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="24" id="Uvy-mQ-16J"/>
+                                        </constraints>
+                                        <state key="normal" image="cloud-upload"/>
+                                        <connections>
+                                            <action selector="handleSyncTapped" destination="KGk-i7-Jjw" eventType="touchUpInside" id="QNc-Q9-UGo"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="PBk-A4-gUp"/>
-                                </constraints>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UiF-vl-BcH">
-                                <rect key="frame" x="264" y="10" width="24" height="24"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="24" id="Uvy-mQ-16J"/>
-                                </constraints>
-                                <state key="normal" image="cloud-upload"/>
-                                <connections>
-                                    <action selector="handleSyncTapped" destination="KGk-i7-Jjw" eventType="touchUpInside" id="QNc-Q9-UGo"/>
-                                </connections>
-                            </button>
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ggy-jC-ncj">
+                                <rect key="frame" x="0.0" y="47" width="288" height="2"/>
+                            </progressView>
                         </subviews>
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="1KI-rP-1i8" secondAttribute="bottom" id="0eD-KN-32i"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="1KI-rP-1i8" secondAttribute="trailing" id="39j-9N-gGW"/>
-                    <constraint firstItem="1KI-rP-1i8" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="HzX-kz-2Qz"/>
-                    <constraint firstItem="1KI-rP-1i8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="KSS-Pr-fFl"/>
+                    <constraint firstAttribute="bottom" secondItem="spl-AO-CAC" secondAttribute="bottom" id="bwq-qm-l99"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="spl-AO-CAC" secondAttribute="trailing" id="eoF-iq-yOp"/>
+                    <constraint firstItem="spl-AO-CAC" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="h8X-5u-Rlq"/>
+                    <constraint firstItem="spl-AO-CAC" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="qsU-QS-fhF"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="captionLabel" destination="pfb-b7-M6j" id="XmZ-kj-FDG"/>
+                <outlet property="progressView" destination="ggy-jC-ncj" id="ksB-Dv-WKZ"/>
                 <outlet property="syncButton" destination="UiF-vl-BcH" id="S87-NG-Bg1"/>
                 <outlet property="titleLabel" destination="mPo-DG-VUv" id="Zjk-sW-BxH"/>
             </connections>
-            <point key="canvasLocation" x="139" y="131"/>
+            <point key="canvasLocation" x="137.68115942028987" y="132.25446428571428"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/Newspack/Newspack/View/PhotoTableViewCell.swift
+++ b/Newspack/Newspack/View/PhotoTableViewCell.swift
@@ -2,11 +2,12 @@ import UIKit
 import NewspackFramework
 
 protocol PhotoCellProvider {
+    var uuid: UUID! { get }
     var name: String! { get }
     var caption: String! { get }
 }
 
-class PhotoTableViewCell: UITableViewCell {
+class PhotoTableViewCell: ProgressCell {
 
     static let imageSize = CGSize(width: 32, height: 32)
 
@@ -36,6 +37,7 @@ class PhotoTableViewCell: UITableViewCell {
         thumbnail.image = image
         titleLabel.text = photo.name
         captionLabel.text = photo.caption
+        observeProgress(uuid: photo.uuid)
     }
 
 }

--- a/Newspack/Newspack/View/PhotoTableViewCell.xib
+++ b/Newspack/Newspack/View/PhotoTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -17,60 +17,69 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="58"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="VGd-H8-JGt">
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="7T4-nS-S4k">
                         <rect key="frame" x="16" y="0.0" width="288" height="58"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="a7J-Pb-36d">
-                                <rect key="frame" x="0.0" y="13" width="32" height="32"/>
-                                <color key="backgroundColor" name="Blue0"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="32" id="9An-YK-PNE"/>
-                                    <constraint firstAttribute="height" constant="32" id="ySF-cN-mip"/>
-                                </constraints>
-                            </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="v11-sv-yYq">
-                                <rect key="frame" x="40" y="7" width="216" height="44"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="VGd-H8-JGt">
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="56"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filename.png" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ipi-AX-Kta">
-                                        <rect key="frame" x="0.0" y="0.0" width="216" height="24.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A short caption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IEH-g8-IVe">
-                                        <rect key="frame" x="0.0" y="24.5" width="216" height="19.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="a7J-Pb-36d">
+                                        <rect key="frame" x="0.0" y="12" width="32" height="32"/>
+                                        <color key="backgroundColor" name="Blue0"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="32" id="9An-YK-PNE"/>
+                                            <constraint firstAttribute="height" constant="32" id="ySF-cN-mip"/>
+                                        </constraints>
+                                    </imageView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="v11-sv-yYq">
+                                        <rect key="frame" x="40" y="6" width="216" height="44"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filename.png" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ipi-AX-Kta">
+                                                <rect key="frame" x="0.0" y="0.0" width="216" height="24.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A short caption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IEH-g8-IVe">
+                                                <rect key="frame" x="0.0" y="24.5" width="216" height="19.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="4sW-PR-bbI"/>
+                                        </constraints>
+                                    </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aSr-TH-1KN">
+                                        <rect key="frame" x="264" y="16" width="24" height="24"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="24" id="Cge-Ah-Eqz"/>
+                                        </constraints>
+                                        <state key="normal" image="cloud-upload"/>
+                                        <connections>
+                                            <action selector="handleSyncTapped" destination="KGk-i7-Jjw" eventType="touchUpInside" id="Wce-v9-tqP"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="4sW-PR-bbI"/>
-                                </constraints>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aSr-TH-1KN">
-                                <rect key="frame" x="264" y="17" width="24" height="24"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="24" id="Cge-Ah-Eqz"/>
-                                </constraints>
-                                <state key="normal" image="cloud-upload"/>
-                                <connections>
-                                    <action selector="handleSyncTapped" destination="KGk-i7-Jjw" eventType="touchUpInside" id="Wce-v9-tqP"/>
-                                </connections>
-                            </button>
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="uhs-ot-xaX">
+                                <rect key="frame" x="0.0" y="56" width="288" height="2"/>
+                            </progressView>
                         </subviews>
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="VGd-H8-JGt" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="5mD-xP-dHt"/>
-                    <constraint firstItem="VGd-H8-JGt" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="Las-uT-gSG"/>
-                    <constraint firstAttribute="bottom" secondItem="VGd-H8-JGt" secondAttribute="bottom" id="Zul-q0-5AS"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="VGd-H8-JGt" secondAttribute="trailing" id="teK-dF-IF0"/>
+                    <constraint firstAttribute="bottom" secondItem="7T4-nS-S4k" secondAttribute="bottom" id="LTj-M3-Rmo"/>
+                    <constraint firstItem="7T4-nS-S4k" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="QvN-H1-5Yn"/>
+                    <constraint firstItem="7T4-nS-S4k" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="gax-kK-V4u"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="7T4-nS-S4k" secondAttribute="trailing" id="p4t-u1-iJz"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="captionLabel" destination="IEH-g8-IVe" id="tJE-Fw-GhO"/>
+                <outlet property="progressView" destination="uhs-ot-xaX" id="opn-4B-U6p"/>
                 <outlet property="syncButton" destination="aSr-TH-1KN" id="nBl-xP-XCc"/>
                 <outlet property="thumbnail" destination="a7J-Pb-36d" id="fxm-KA-RtJ"/>
                 <outlet property="titleLabel" destination="Ipi-AX-Kta" id="lJd-7N-ZQb"/>

--- a/Newspack/Newspack/View/ProgressCell.swift
+++ b/Newspack/Newspack/View/ProgressCell.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+class ProgressCell: UITableViewCell {
+
+    @IBOutlet var progressView: UIProgressView!
+
+    override func willMove(toWindow newWindow: UIWindow?) {
+        if newWindow == nil {
+            stopListeningForProgress()
+        }
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        stopListeningForProgress()
+    }
+
+    func startListeningForProgress(uuid: UUID) {
+        NotificationCenter.default.addObserver(self, selector: #selector(handleStartedTrackingProgress(notification:)), name: ProgressStore.startedTrackingProgress, object: uuid)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleStoppedTrackingProgress(notification:)), name: ProgressStore.stoppedTrackingProgress, object: uuid)
+    }
+
+    func stopListeningForProgress() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc func handleStartedTrackingProgress(notification: Notification) {
+        guard let uuid = notification.object as? UUID else {
+            return
+        }
+        progressView.observedProgress = StoreContainer.shared.progressStore.progress(for: uuid)
+    }
+
+    @objc func handleStoppedTrackingProgress(notification: Notification) {
+        progressView.observedProgress = nil
+    }
+
+    func observeProgress(uuid: UUID) {
+        progressView.observedProgress = StoreContainer.shared.progressStore.progress(for: uuid)
+        startListeningForProgress(uuid: uuid)
+    }
+}

--- a/Newspack/Newspack/View/ProgressCell.swift
+++ b/Newspack/Newspack/View/ProgressCell.swift
@@ -4,6 +4,12 @@ class ProgressCell: UITableViewCell {
 
     @IBOutlet var progressView: UIProgressView!
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        progressView.trackTintColor = .clear
+        progressView.trackImage = nil
+    }
+
     override func willMove(toWindow newWindow: UIWindow?) {
         if newWindow == nil {
             stopListeningForProgress()
@@ -37,7 +43,8 @@ class ProgressCell: UITableViewCell {
     }
 
     func observeProgress(uuid: UUID) {
-        progressView.observedProgress = StoreContainer.shared.progressStore.progress(for: uuid)
         startListeningForProgress(uuid: uuid)
+        progressView.progress = 0
+        progressView.observedProgress = StoreContainer.shared.progressStore.progress(for: uuid)
     }
 }

--- a/Newspack/Newspack/View/ProgressCell.swift
+++ b/Newspack/Newspack/View/ProgressCell.swift
@@ -23,8 +23,9 @@ class ProgressCell: UITableViewCell {
     }
 
     func startListeningForProgress(uuid: UUID) {
-        NotificationCenter.default.addObserver(self, selector: #selector(handleStartedTrackingProgress(notification:)), name: ProgressStore.startedTrackingProgress, object: uuid)
-        NotificationCenter.default.addObserver(self, selector: #selector(handleStoppedTrackingProgress(notification:)), name: ProgressStore.stoppedTrackingProgress, object: uuid)
+        let key = StoreContainer.shared.progressStore.keyForUUID(uuid: uuid)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleStartedTrackingProgress(notification:)), name: ProgressStore.startedTrackingProgress, object: key)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleStoppedTrackingProgress(notification:)), name: ProgressStore.stoppedTrackingProgress, object: key)
     }
 
     func stopListeningForProgress() {
@@ -32,10 +33,10 @@ class ProgressCell: UITableViewCell {
     }
 
     @objc func handleStartedTrackingProgress(notification: Notification) {
-        guard let uuid = notification.object as? UUID else {
+        guard let key = notification.object as? ProgressKey else {
             return
         }
-        progressView.observedProgress = StoreContainer.shared.progressStore.progress(for: uuid)
+        progressView.observedProgress = StoreContainer.shared.progressStore.progress(for: key.uuid)
     }
 
     @objc func handleStoppedTrackingProgress(notification: Notification) {
@@ -45,6 +46,7 @@ class ProgressCell: UITableViewCell {
     func observeProgress(uuid: UUID) {
         startListeningForProgress(uuid: uuid)
         progressView.progress = 0
-        progressView.observedProgress = StoreContainer.shared.progressStore.progress(for: uuid)
+        let key = StoreContainer.shared.progressStore.keyForUUID(uuid: uuid)
+        progressView.observedProgress = StoreContainer.shared.progressStore.progress(for: key.uuid)
     }
 }

--- a/Newspack/Newspack/View/VideoTableViewCell.swift
+++ b/Newspack/Newspack/View/VideoTableViewCell.swift
@@ -1,11 +1,12 @@
 import UIKit
 
 protocol VideoCellProvider {
+    var uuid: UUID! { get }
     var name: String! { get }
     var caption: String! { get }
 }
 
-class VideoTableViewCell: UITableViewCell {
+class VideoTableViewCell: ProgressCell {
 
     static let imageSize = CGSize(width: 32, height: 32)
 
@@ -35,6 +36,7 @@ class VideoTableViewCell: UITableViewCell {
         thumbnail.image = image
         titleLabel.text = video.name
         captionLabel.text = video.caption
+        observeProgress(uuid: video.uuid)
     }
 
 }

--- a/Newspack/Newspack/View/VideoTableViewCell.xib
+++ b/Newspack/Newspack/View/VideoTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -17,67 +17,74 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8cY-I5-G1W">
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="kad-Hh-iCN">
                         <rect key="frame" x="16" y="0.0" width="288" height="56"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="TEz-I3-UB8">
-                                <rect key="frame" x="0.0" y="12" width="32" height="32"/>
-                                <color key="backgroundColor" name="Blue0"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="32" id="30i-gb-fgh"/>
-                                    <constraint firstAttribute="width" constant="32" id="X2P-HC-e2v"/>
-                                </constraints>
-                            </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="xlg-6K-jFq">
-                                <rect key="frame" x="40" y="6" width="216" height="44"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8cY-I5-G1W">
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="54"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filename.png" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pg7-Ch-Igx">
-                                        <rect key="frame" x="0.0" y="0.0" width="216" height="24.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A short caption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L5h-C3-VYT">
-                                        <rect key="frame" x="0.0" y="24.5" width="216" height="19.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="TEz-I3-UB8">
+                                        <rect key="frame" x="0.0" y="11" width="32" height="32"/>
+                                        <color key="backgroundColor" name="Blue0"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="32" id="30i-gb-fgh"/>
+                                            <constraint firstAttribute="width" constant="32" id="X2P-HC-e2v"/>
+                                        </constraints>
+                                    </imageView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="xlg-6K-jFq">
+                                        <rect key="frame" x="40" y="5" width="216" height="44"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filename.png" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pg7-Ch-Igx">
+                                                <rect key="frame" x="0.0" y="0.0" width="216" height="24.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A short caption" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L5h-C3-VYT">
+                                                <rect key="frame" x="0.0" y="24.5" width="216" height="19.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="epk-Dg-mRB"/>
+                                        </constraints>
+                                    </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pM3-hf-VKx">
+                                        <rect key="frame" x="264" y="15" width="24" height="24"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="24" id="mYN-Py-CEg"/>
+                                        </constraints>
+                                        <state key="normal" image="cloud-upload"/>
+                                        <connections>
+                                            <action selector="handleSyncTapped" destination="KGk-i7-Jjw" eventType="touchUpInside" id="LmC-fD-O0e"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="epk-Dg-mRB"/>
-                                </constraints>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pM3-hf-VKx">
-                                <rect key="frame" x="264" y="16" width="24" height="24"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="24" id="mYN-Py-CEg"/>
-                                </constraints>
-                                <state key="normal" image="cloud-upload"/>
-                                <connections>
-                                    <action selector="handleSyncTapped" destination="KGk-i7-Jjw" eventType="touchUpInside" id="LmC-fD-O0e"/>
-                                </connections>
-                            </button>
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="8Id-7s-2UU">
+                                <rect key="frame" x="0.0" y="54" width="288" height="2"/>
+                            </progressView>
                         </subviews>
                     </stackView>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="play.circle.fill" catalog="system" id="V7Y-4a-CSY">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="play.circle.fill" catalog="system" id="V7Y-4a-CSY">
                         <rect key="frame" x="19" y="16" width="24" height="24"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="tintColor" name="White"/>
                     </imageView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="V7Y-4a-CSY" firstAttribute="centerY" secondItem="TEz-I3-UB8" secondAttribute="centerY" id="8YS-9c-xCL"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="8cY-I5-G1W" secondAttribute="trailing" id="EJx-LF-0id"/>
-                    <constraint firstItem="8cY-I5-G1W" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="F4E-Lq-Ep3"/>
-                    <constraint firstAttribute="bottom" secondItem="8cY-I5-G1W" secondAttribute="bottom" id="TPE-vn-e3y"/>
-                    <constraint firstItem="V7Y-4a-CSY" firstAttribute="centerX" secondItem="TEz-I3-UB8" secondAttribute="centerX" id="V5W-JU-kJB"/>
-                    <constraint firstItem="8cY-I5-G1W" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="hsa-GX-ugX"/>
+                    <constraint firstItem="kad-Hh-iCN" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="KqK-aW-Tks"/>
+                    <constraint firstItem="kad-Hh-iCN" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="WFM-Ko-rC2"/>
+                    <constraint firstAttribute="bottom" secondItem="kad-Hh-iCN" secondAttribute="bottom" id="eYL-J9-HL8"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="kad-Hh-iCN" secondAttribute="trailing" id="yoo-bu-PCG"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="captionLabel" destination="L5h-C3-VYT" id="XeR-xA-MH2"/>
+                <outlet property="progressView" destination="8Id-7s-2UU" id="UOk-Rc-D1f"/>
                 <outlet property="syncButton" destination="pM3-hf-VKx" id="eci-WH-lJL"/>
                 <outlet property="thumbnail" destination="TEz-I3-UB8" id="IG1-gT-zM3"/>
                 <outlet property="titleLabel" destination="pg7-Ch-Igx" id="WvG-Xh-kOV"/>

--- a/Newspack/NewspackFramework/Extensions/Array+Helpers.swift
+++ b/Newspack/NewspackFramework/Extensions/Array+Helpers.swift
@@ -8,3 +8,11 @@ extension Array {
         }
     }
 }
+
+// Props https://stackoverflow.com/a/46354989
+public extension Array where Element: Hashable {
+    func uniqued() -> [Element] {
+        var seen = Set<Element>()
+        return filter{ seen.insert($0).inserted }
+    }
+}

--- a/Newspack/NewspackFramework/Extensions/Array+Helpers.swift
+++ b/Newspack/NewspackFramework/Extensions/Array+Helpers.swift
@@ -13,6 +13,6 @@ extension Array {
 public extension Array where Element: Hashable {
     func uniqued() -> [Element] {
         var seen = Set<Element>()
-        return filter{ seen.insert($0).inserted }
+        return filter { seen.insert($0).inserted }
     }
 }


### PR DESCRIPTION
Refs #91 

This PR implements some UI improvements around syncing. 
- Asset cells now show a progress bar when their associated media file is uploading.
- Story and Asset lists now support pull to refresh.
- Creating/editing a story will attempt to sync to the server.
- Adding a new media asset will attempt to sync to the server.

Notes: 
- The sync buttons in the cells and story are probably going away in a future PR since pull to refresh will also handle any needed uploads.  I'm still thinking about this so I've left them for now.
- When adding/editing stories or assets there is a case where the sync coordinator might repeat a step. This is a quirk of the way I've implemented the queue and I'm content to leave it as the repeated step is basically a no op and handling the case would add complexity with out much gain.

@jleandroperez can I trouble you with another? 

Testing: 
Try this on a device with a test blog.  Due to a known issue with Metal the simulator probably won't work as well. 

Scenario 1: Creating Folders and Assets
- Create a few story folders. 
- Use the Photo feature and add a photo from your media library to the story.
- Confirm the Story and the Photo are uploaded.  Confirm you see a progress bar as the photo is uploaded.

Scenario 2: Pull to Refresh Folders
- Open the app to the stories list and keep the app open.
- In a browser, go to your test site's wp-admin and edit the title of the draft story. 
- In the app, pull to refresh the stories list. 
- Confirm that the story's title updates.

Scenario 3: Editing Folders
- In the app, rename a folder that has a remote draft.
- Once finished, check the draft story in a browser and confirm it's title has changed.

Scenario 4: Multiple media 
- In the app, view the folders list and add multiple photos to the current story from your device's media library.
- Quickly switch to the assets list for the current story and confirm you see the photos being uploaded and their progress indicators are displayed.
- Confirm multiple uploads complete successfully.

Scenario 5: Edit Story Asset
- Open the app to the assets list and keep the app open.
- In a browser, find the media object for an uploaded photo.
- Give the asset a caption.
- In the app, pull to refresh the assets list.
- Confirm the caption appears. 
- View the photo details and edit the caption again. 
- When finished, go back to the browser and confirm the edited caption appears.


