### PR TITLE
Issues/91 long tasks reachability

### DIFF
--- a/Newspack/Newspack/System/SyncCoordinator.swift
+++ b/Newspack/Newspack/System/SyncCoordinator.swift
@@ -359,6 +359,7 @@ extension SyncCoordinator {
 
     private func listenToReachability() {
         reachability?.listener = { status in
+            LogInfo(message: "Network Status: \(status)")
             if status == .reachable(.ethernetOrWiFi) || status == .reachable(.wwan) {
                 self.handleNetworkBecameReachable()
             }


### PR DESCRIPTION
Refs #91 

This PR addresses two things related to syncing.  
- First, it configures a long running task so when the app is sent to the background, any upload operations will (hopefully) complete successfully before the app is terminated.  
- Second, it adds a reachability listener to detect when a network connection becomes available and (if necessary) retry a failed sync.

Testing long running tasks will be easier once Video support is finished so let's plan on stress testing this feature then.  For now, please smoke test that the implementation looks correct.

Testing reachability doesn't work great in the simulator. Disabling wifi is detected but reenabling wifi is not detected. This makes it harder to have a perfect test but we can manage pretty close.

To Test:

- Set a breakpoint in SyncCoordinator line 373.
- Launch the app on a device.
- Check the console log and note that the logged network status.
- Swipe to view mission control. Disable wifi and enter airplane mode. 
- Note that an unavilable network status should be logged to the console. 
- Pull to refresh the stories list.
- Confirm that the spinner is dismissed and doesn't linger. 
- Back in mission control, exist airplane mode and renable wifi.
- Confirm reachability detected the network change and app execution reached the breakpoint on line 373.

@jleandroperez can I trouble you with this quick one? 