### PR TITLE
Issues/two quick fixes

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -1962,7 +1962,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				SECRETS_PATH = "$HOME/.mobile-secrets/iOS/newspack/newspack_app_credentials.json";
+				SECRETS_PATH = "$(SRCROOT)/../.configure-files/newspack_app_credentials.json";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -2020,7 +2020,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
-				SECRETS_PATH = "$HOME/.mobile-secrets/iOS/newspack/newspack_app_credentials.json";
+				SECRETS_PATH = "$(SRCROOT)/../.configure-files/newspack_app_credentials.json";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
@@ -2344,7 +2344,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
-				SECRETS_PATH = "$HOME/.mobile-secrets/iOS/newspack/newspack_app_credentials.json";
+				SECRETS_PATH = "$(SRCROOT)/../.configure-files/newspack_app_credentials.json";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;

--- a/Newspack/Newspack/Controllers/MenuViewController.swift
+++ b/Newspack/Newspack/Controllers/MenuViewController.swift
@@ -53,8 +53,11 @@ extension MenuViewController {
         receipt = StoreContainer.shared.accountDetailsStore.onChange {
             self.configureHeader()
         }
-        menuDataSource.updateSections()
-        tableView.reloadData()
+        // To avoid a subtle UI behavior when logging out only reload when initalized.
+        if SessionManager.shared.state == .initialized {
+            menuDataSource.updateSections()
+            tableView.reloadData()
+        }
     }
 
 }


### PR DESCRIPTION
This is a quick PR to address two bugs.

First: The path assigned to `SECRETS_PATH` is updated to point to the contents of `.configure-files` in the project folder rather than the credentials file in the secrets repo.  This resolves an issue where the Alpha version would not be configured with an Oauth client ID and secret when built by CircleCI. 

Second: A check is added to only reload the Menu's tableView when there is a valid session.  This is to prevent a subtle, yet distracting, UI change to the menu when logging out. 

To test:
Install the Alpha build once it's ready.
Log in, then log out.  
Confirm both actions are successful and there are no errors.
Confirm there is no obviously distracting visual change to the menu's content when logging out.

@jleandroperez could I trouble you with this one when you have some free time?