### PR TITLE
Issues/117 enable video part 1

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		E6AB672924E88182003D5D2A /* VideoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E6AB671E24E88182003D5D2A /* VideoTableViewCell.xib */; };
 		E6AB672A24E88182003D5D2A /* StoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AB671F24E88182003D5D2A /* StoryTableViewCell.swift */; };
 		E6AC98B823CCD5DE00E95381 /* MainNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AC98B723CCD5DE00E95381 /* MainNavController.swift */; };
+		E6AE5243254A103E002FADD7 /* Data+ImageContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AE5242254A103E002FADD7 /* Data+ImageContentType.swift */; };
 		E6B4034D22D8E12500A0DDCA /* remote-posts-ids-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */; };
 		E6B4034E22D8E12500A0DDCA /* remote-posts-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */; };
 		E6B7728824BCD8DA00CA8AB8 /* SortOrganizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B7728724BCD8DA00CA8AB8 /* SortOrganizer.swift */; };
@@ -484,6 +485,7 @@
 		E6AB671E24E88182003D5D2A /* VideoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = VideoTableViewCell.xib; sourceTree = "<group>"; };
 		E6AB671F24E88182003D5D2A /* StoryTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryTableViewCell.swift; sourceTree = "<group>"; };
 		E6AC98B723CCD5DE00E95381 /* MainNavController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavController.swift; sourceTree = "<group>"; };
+		E6AE5242254A103E002FADD7 /* Data+ImageContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+ImageContentType.swift"; sourceTree = "<group>"; };
 		E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-ids-edit.json"; sourceTree = "<group>"; };
 		E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-edit.json"; sourceTree = "<group>"; };
 		E6B7728724BCD8DA00CA8AB8 /* SortOrganizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortOrganizer.swift; sourceTree = "<group>"; };
@@ -1000,6 +1002,7 @@
 			children = (
 				E628CBA12527C23100770B44 /* Array+Helpers.swift */,
 				E6B779E924EB2FC5007EA033 /* CGSize+Helpers.swift */,
+				E6AE5242254A103E002FADD7 /* Data+ImageContentType.swift */,
 				E630E33E250029020028BBF2 /* FileManager+Helpers.swift */,
 				E63FF0EB24AA864C0002A32F /* URL+FileReference.swift */,
 				E6C3988B24ACDFC400E0EBE6 /* UserDefaults+Newspack.swift */,
@@ -1741,6 +1744,7 @@
 			files = (
 				E62018DB24F9B18500D96AFF /* UserDefaults+Newspack.swift in Sources */,
 				E61FA94324FD777C0060D301 /* ModelConstants.swift in Sources */,
+				E6AE5243254A103E002FADD7 /* Data+ImageContentType.swift in Sources */,
 				E62018DD24F9B1C700D96AFF /* Environment.swift in Sources */,
 				E63A3A3624FEF84700ACA871 /* ColorStudio.swift in Sources */,
 				E625B03525004F3300C55EDC /* ImageResizer.swift in Sources */,

--- a/Newspack/Newspack/Extensions/URL+TypeHelpers.swift
+++ b/Newspack/Newspack/Extensions/URL+TypeHelpers.swift
@@ -39,6 +39,13 @@ extension URL {
         return UTTypeConformsTo(uti, kUTTypeMovie)
     }
 
+    var isText: Bool {
+        guard let uti = utiFromPathExtension as NSString? else {
+            return false
+        }
+        return UTTypeConformsTo(uti, kUTTypeText)
+    }
+
     var isPDF: Bool {
         guard let uti = utiFromPathExtension as NSString? else {
             return false

--- a/Newspack/Newspack/Stores/AssetStore.swift
+++ b/Newspack/Newspack/Stores/AssetStore.swift
@@ -51,11 +51,6 @@ class AssetStore: Store {
         return SortOrganizer(defaultsKey: "AssetSortOrganizerIndex", modes: [typeSort, dateSort])
     }()
 
-    // TODO: This is a stub for now and will be improved as features are added.
-    var allowedExtensions: [String] {
-        return ["png", "jpg", "jpeg"]
-    }
-
     override init(dispatcher: ActionDispatcher = .global) {
 
         folderManager = SessionManager.shared.folderManager
@@ -87,6 +82,21 @@ class AssetStore: Store {
             }
         }
     }
+}
+
+// MARK: - Validation
+
+extension AssetStore {
+
+    /// Check if a URL points to a supported asset type.
+    ///
+    /// - Parameter url: A file URL to check.
+    /// - Returns: True if the URL points to a supported type. Otherwise false.
+    ///
+    func isSupportedType(url: URL) -> Bool {
+        return url.isImage || url.isVideo
+    }
+
 }
 
 // MARK: - Sorting

--- a/Newspack/Newspack/Stores/FolderStore.swift
+++ b/Newspack/Newspack/Stores/FolderStore.swift
@@ -764,6 +764,11 @@ extension FolderStore {
     ///
     func syncAndProcessRemoteDrafts(onComplete: @escaping (Error?) -> Void) {
         let postIDs = getStoryFolderPostIDs()
+        if postIDs.count == 0 {
+            onComplete(nil)
+            return
+        }
+
         let perPage = min(postIDs.count, 100)
 
         // Sync the posts for these POST IDs.

--- a/Newspack/Newspack/System/Reconciler.swift
+++ b/Newspack/Newspack/System/Reconciler.swift
@@ -273,7 +273,7 @@ class Reconciler {
 
         // Filter out any items that are not supported types.
         rawItems = rawItems.filter({ (url) -> Bool in
-            return store.allowedExtensions.contains(url.pathExtension.lowercased())
+            return store.isSupportedType(url: url)
         })
 
         for asset in assets {

--- a/Newspack/NewspackFramework/Extensions/Data+ImageContentType.swift
+++ b/Newspack/NewspackFramework/Extensions/Data+ImageContentType.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Props https://stackoverflow.com/a/57361865
+///
+extension Data {
+    public enum ImageContentType: String {
+        case jpg, png, gif, tiff, unknown
+
+        public var fileExtension: String {
+            return self.rawValue
+        }
+    }
+
+    public var imageContentType: ImageContentType {
+
+        var values = [UInt8](repeating: 0, count: 1)
+
+        self.copyBytes(to: &values, count: 1)
+
+        switch (values[0]) {
+        case 0xFF:
+            return .jpg
+        case 0x89:
+            return .png
+        case 0x47:
+           return .gif
+        case 0x49, 0x4D :
+           return .tiff
+        default:
+            return .unknown
+        }
+    }
+}

--- a/Newspack/NewspackFramework/Extensions/Data+ImageContentType.swift
+++ b/Newspack/NewspackFramework/Extensions/Data+ImageContentType.swift
@@ -17,7 +17,7 @@ extension Data {
 
         self.copyBytes(to: &values, count: 1)
 
-        switch (values[0]) {
+        switch values[0] {
         case 0xFF:
             return .jpg
         case 0x89:

--- a/Newspack/NewspackShare/Utils/ShareExtractor.swift
+++ b/Newspack/NewspackShare/Utils/ShareExtractor.swift
@@ -37,7 +37,7 @@ struct ShareExtractor {
     ///
     func loadShare(completion: @escaping (ExtractedShare) -> Void) {
         extractMovies { extractedMovies in
-            extractImages { extractedImages in
+            self.extractImages { extractedImages in
                 completion(ExtractedShare(images: extractedImages, movies: extractedMovies))
             }
         }

--- a/Newspack/NewspackShare/Utils/ShareExtractor.swift
+++ b/Newspack/NewspackShare/Utils/ShareExtractor.swift
@@ -1,14 +1,20 @@
 import Foundation
 import CoreServices
 import UIKit
+import NewspackFramework
 
 /// A type that represents the information we can extract from an extension context
 ///
 struct ExtractedShare {
     var images: [ExtractedImage]
+    var movies: [ExtractedMovie]
 }
 
 struct ExtractedImage {
+    let url: URL
+}
+
+struct ExtractedMovie {
     let url: URL
 }
 
@@ -30,8 +36,10 @@ struct ShareExtractor {
     ///   - completion: the block to be called when the extractor has obtained content.
     ///
     func loadShare(completion: @escaping (ExtractedShare) -> Void) {
-        extractImages { extractedImages in
-            completion(ExtractedShare(images: extractedImages))
+        extractMovies { extractedMovies in
+            extractImages { extractedImages in
+                completion(ExtractedShare(images: extractedImages, movies: extractedMovies))
+            }
         }
     }
 
@@ -56,12 +64,17 @@ private struct ExtractedItem {
     /// An image
     ///
     var images = [ExtractedImage]()
+    var movies = [ExtractedMovie]()
 }
 
 private extension ShareExtractor {
 
     var imageExtractor: ExtensionContentExtractor? {
         return ImageExtractor(tempDirectory: tempDirectory)
+    }
+
+    var movieExtractor: ExtensionContentExtractor? {
+        return MovieExtractor(tempDirectory: tempDirectory)
     }
 
     func extractImages(completion: @escaping ([ExtractedImage]) -> Void) {
@@ -75,21 +88,43 @@ private extension ShareExtractor {
                 return
             }
             var extractedImages = [ExtractedImage]()
-            extractedItems.forEach({ item in
-                item.images.forEach({ extractedImage in
+            extractedItems.forEach { item in
+                item.images.forEach { extractedImage in
                     extractedImages.append(extractedImage)
-                })
-            })
+                }
+            }
 
             completion(extractedImages)
         }
+    }
+
+    func extractMovies(completion: @escaping ([ExtractedMovie]) -> Void) {
+        guard let movieExtractor = movieExtractor else {
+            completion([])
+            return
+        }
+        movieExtractor.extract(context: extensionContext) { extractedItems in
+            guard extractedItems.count > 0 else {
+                completion([])
+                return
+            }
+            var extractedMovies = [ExtractedMovie]()
+            extractedItems.forEach { item in
+                item.movies.forEach { movie in
+                    extractedMovies.append(movie)
+                }
+            }
+
+            completion(extractedMovies)
+        }
+
     }
 }
 
 private protocol ExtensionContentExtractor {
     func canHandle(context: NSExtensionContext) -> Bool
     func extract(context: NSExtensionContext, completion: @escaping ([ExtractedItem]) -> Void)
-    func saveToSharedContainer(image: UIImage) -> URL?
+    func saveToSharedContainer(data: Data, fileExtension: String) -> URL?
     func saveToSharedContainer(wrapper: FileWrapper) -> URL?
     func copyToSharedContainer(url: URL) -> URL?
 }
@@ -136,18 +171,14 @@ private extension TypeBasedExtensionContentExtractor {
         syncGroup.notify(queue: DispatchQueue.main) {
             completion(results)
         }
-
     }
 
-    // TODO: We probably need PNG and HEIC options as well.  Not just JPGs. TBD.
-    func saveToSharedContainer(image: UIImage) -> URL? {
-        guard let encodedMedia = image.JPEGEncoded(),
-            let fullPath = tempPath(for: "jpg") else {
-                return nil
+    func saveToSharedContainer(data: Data, fileExtension: String) -> URL? {
+        guard let fullPath = tempPath(for: fileExtension) else {
+            return nil
         }
-
         do {
-            try encodedMedia.write(to: fullPath, options: [.atomic])
+            try data.write(to: fullPath, options: [.atomic])
         } catch {
             print("Error saving \(fullPath) to shared container: \(String(describing: error))")
             return nil
@@ -202,17 +233,55 @@ private struct ImageExtractor: TypeBasedExtensionContentExtractor {
 
         switch payload {
         case let url as URL:
-            if let imageURL = copyToSharedContainer(url: url) {
-                returnedItem.images = [ExtractedImage(url: imageURL)]
+            if let itemURL = copyToSharedContainer(url: url) {
+                returnedItem.images = [ExtractedImage(url: itemURL)]
             }
-        case let data as Data:
-            if let image = UIImage(data: data),
-                let imageURL = saveToSharedContainer(image: image) {
-                returnedItem.images = [ExtractedImage(url: imageURL)]
+        case var data as Data:
+            if data.imageContentType == .unknown, let encodedData = encodeImageDataAsJPEG(data: data) {
+                data = encodedData
+            }
+            let ext = data.imageContentType.fileExtension
+            if let itemURL = saveToSharedContainer(data: data, fileExtension: ext) {
+                returnedItem.images = [ExtractedImage(url: itemURL)]
             }
         case let image as UIImage:
-            if let imageURL = saveToSharedContainer(image: image) {
-                returnedItem.images = [ExtractedImage(url: imageURL)]
+            // If we have a UIImage, just save as a JPEG for now.
+            if let data = image.JPEGEncoded(),
+               let itemURL = saveToSharedContainer(data: data, fileExtension: Data.ImageContentType.jpg.fileExtension) {
+                returnedItem.images = [ExtractedImage(url: itemURL)]
+            }
+        default:
+            break
+        }
+        return returnedItem
+    }
+
+    func encodeImageDataAsJPEG(data: Data) -> Data? {
+        guard
+            let image = UIImage(data: data),
+            let data = image.JPEGEncoded()
+        else {
+            return nil
+        }
+        return data
+    }
+}
+
+private struct MovieExtractor: TypeBasedExtensionContentExtractor {
+    typealias Payload = AnyObject
+    let acceptedType = kUTTypeMovie as String // Note: The UTI for kUTTypeMovie encompases other types like kUTTypeVideo
+    let tempDirectory: URL
+    func convert(payload: AnyObject) -> ExtractedItem? {
+        var returnedItem = ExtractedItem()
+
+        switch payload {
+        case let url as URL:
+            if let itemURL = copyToSharedContainer(url: url) {
+                returnedItem.movies = [ExtractedMovie(url: itemURL)]
+            }
+        case let data as Data:
+            if let itemURL = saveToSharedContainer(data: data, fileExtension: "mp4") {
+                returnedItem.movies = [ExtractedMovie(url: itemURL)]
             }
         default:
             break


### PR DESCRIPTION
Refs #117 

This is the first of a handful of PRs that will enable the Video feature.  In this PR the following things are addressed:
- Copying and pasting a video via the Files app.
- Sharing a video via the Share Extension
- Updates to the Reconciler to support video types

With these changes _basic_ video feature functionality is supported and a video asset shared by the Files app or the Share Extension should be detected and uploaded.

Notes:
- The video UI is rudimentary.  A details/edit screen like there is for photos is forthcoming. 
- Error handling is pretty weak at this stage. If the video upload fails there is no good reason why communicated back.
- When testing, ensure the site supports video uploads. (Free/personal wpcom sites don't.)

To test:
Prep:
- Add a video to your device's media lib. If you are using the simulator you can drop a movie from your desktop onto Safari and have it add the movie to the Simulators photo app.

Scenario 1:
- Open the Photos app, select, and copy a video.
- Open the Files app and past the video into a Newspack story folder.
- Launch Newspack - quickly navigate to the story folder and observe that the video is being uploaded.
- Check your site's wp-admin media library and confirm the upload.

Scenario 2:
- Open the Photos app, select a video, tap share and share to Newspack.  This may take a moment. Be patient.
- In the share extension, confirm you see a thumbnail for the shared video.
- Complete the share action.
- Launch Newspack - quickly navigate to the story folder and observe that the video is being uploaded.
- Check your site's wp-admin media library and confirm the upload.

@jleandroperez Game to review the first PR for real Video support?
