### PR TITLE
Issues/117 enable video part 2

### DIFF
--- a/Newspack/Newspack/Stores/MediaImporter.swift
+++ b/Newspack/Newspack/Stores/MediaImporter.swift
@@ -212,10 +212,11 @@ extension MediaImporter {
     }
 
     /// Copy the file backing a PHAsset to a local directory in preparation for uploading.
-    ///
-    /// - Parameter asset: A PHAsset instance.
-    /// - Parameter contentEditingInput: A PHContentEditingInput instance
-    /// - Returns: The file URL for the copied asset or nil.
+    /// - Parameters:
+    ///   - asset: A PHAsset instance.
+    ///   - contentEditingInput: A PHContentEditingInput instance
+    ///   - onComplete: A block to call on completion. The block accepts an optional URL.
+    /// - Throws: Can throw an exection if there is an error writing the file.
     ///
     func copyAssetToFile(asset: PHAsset, contentEditingInput: PHContentEditingInput, onComplete: @escaping (URL?) -> Void) throws {
         switch asset.mediaType {
@@ -232,9 +233,11 @@ extension MediaImporter {
 
     /// Copy the image backing a PHAsset to a local directory in preparation for uploading.
     ///
-    /// - Parameter asset: A PHAsset instance.  An image is expected.
-    /// - Parameter contentEditingInput: A PHContentEditingInput instance
-    /// - Returns: The file URL for the copied asset or nil.
+    /// - Parameters:
+    ///   - asset: A PHAsset instance.
+    ///   - contentEditingInput: A PHContentEditingInput instance
+    ///   - onComplete: A block to call on completion. The block accepts an optional URL.
+    /// - Throws: Can throw an exection if there is an error writing the file.
     ///
     func copyImageToFile(asset: PHAsset, contentEditingInput: PHContentEditingInput, onComplete: @escaping (URL?) -> Void) throws {
         guard
@@ -255,9 +258,11 @@ extension MediaImporter {
 
     /// Copy the image backing a PHAsset to a local directory in preparation for uploading.
     ///
-    /// - Parameter asset: A PHAsset instance.  A video is expected.
-    /// - Parameter contentEditingInput: A PHContentEditingInput instance
-    /// - Returns: The file URL for the copied asset or nil.
+    /// - Parameters:
+    ///   - asset: A PHAsset instance.
+    ///   - contentEditingInput: A PHContentEditingInput instance
+    ///   - onComplete: A block to call on completion. The block accepts an optional URL.
+    /// - Throws: Can throw an exection if there is an error writing the file.
     ///
     func copyVideoToFile(asset: PHAsset, contentEditingInput: PHContentEditingInput, onComplete: @escaping (URL?) -> Void) throws {
         onComplete(nil)

--- a/Newspack/Newspack/Stores/MediaImporter.swift
+++ b/Newspack/Newspack/Stores/MediaImporter.swift
@@ -215,11 +215,31 @@ extension MediaImporter {
 
     /// Copy the file backing a PHAsset to a local directory in preparation for uploading.
     ///
-    /// - Parameter asset: A PHAsset instance.  An image is expected.
+    /// - Parameter asset: A PHAsset instance.
     /// - Parameter contentEditingInput: A PHContentEditingInput instance
     /// - Returns: The file URL for the copied asset or nil.
     ///
     func copyAssetToFile(asset: PHAsset, contentEditingInput: PHContentEditingInput) throws -> URL? {
+        switch asset.mediaType {
+        case .image:
+            return try copyImageToFile(asset: asset, contentEditingInput: contentEditingInput)
+        case .video:
+            return try copyVideoToFile(asset: asset, contentEditingInput: contentEditingInput)
+        case .audio:
+            break
+        default:
+            return nil
+        }
+        return nil
+    }
+
+    /// Copy the image backing a PHAsset to a local directory in preparation for uploading.
+    ///
+    /// - Parameter asset: A PHAsset instance.  An image is expected.
+    /// - Parameter contentEditingInput: A PHContentEditingInput instance
+    /// - Returns: The file URL for the copied asset or nil.
+    ///
+    func copyImageToFile(asset: PHAsset, contentEditingInput: PHContentEditingInput) throws -> URL? {
         guard
             let originalFileURL = contentEditingInput.fullSizeImageURL,
             let originalImage = CIImage(contentsOf: originalFileURL),
@@ -234,6 +254,16 @@ extension MediaImporter {
         try writeImage(image: image, withUTI: uti, toFile: fileURL)
 
         return fileURL
+    }
+
+    /// Copy the image backing a PHAsset to a local directory in preparation for uploading.
+    ///
+    /// - Parameter asset: A PHAsset instance.  A video is expected.
+    /// - Parameter contentEditingInput: A PHContentEditingInput instance
+    /// - Returns: The file URL for the copied asset or nil.
+    ///
+    func copyVideoToFile(asset: PHAsset, contentEditingInput: PHContentEditingInput) throws -> URL? {
+        return nil
     }
 
     /// Find a usable import URL for the original URL. If a file already exists


### PR DESCRIPTION
Refs #117 

This is part two of [probably] three PRs enabling Video support in the app. The previous PR wired up the share extension, filesystem support, and uploads. This PR does the following:

- Enable videos to be selected and uploaded from the device photo library via the Photo button. 
- Enables videos to be captured via the camera (via the camera button) and the uploaded.  Captured videos will appear in the device's photo library. 

Notes:
- A detail/preview/edit screen is forthcoming
- There is an issue with uploads to self-hosted sites that still needs to be sorted. 

To test: 
Prep: 
- Use a device so you can test the camera. The camera is not supported in the simulator. 
- Use a wpcom site that supports video.

Scenario 1:
- Tap the Photo button and selected a video from you're device's photo album. 
- Be patient.. it will take a moment to process.
- Observe the assets list as the video is uploaded.
- Confirm the upload via your wp-admin. 

Scenario 2: 
- Capture new video via the camera button.
- Be patient.. it will take a moment to process.
- Observe the assets list as the video is uploaded.
- Confirm the upload via your wp-admin. 

@jleandroperez can I trouble you with one more (no rush!)
