### PR TITLE
Update WPAuthenticator to 1.31.0-beta

### DIFF
--- a/Newspack/Newspack/Authentication/AuthenticationManager.swift
+++ b/Newspack/Newspack/Authentication/AuthenticationManager.swift
@@ -145,6 +145,18 @@ class AuthenticationManager {
 
 
 extension AuthenticationManager: WordPressAuthenticatorDelegate {
+    var wpcomTermsOfServiceEnabled: Bool {
+        return true
+    }
+
+    func shouldHandleError(_ error: Error) -> Bool {
+        return false
+    }
+
+    func handleError(_ error: Error, onCompletion: @escaping (UIViewController) -> Void) {
+        // No op
+    }
+
 
     func promptAndNotifyUnableToLogIn() {
         NotificationCenter.default.post(name: .authNeedsRestart, object: nil)

--- a/Podfile
+++ b/Podfile
@@ -24,7 +24,7 @@ target 'Newspack' do
     pod 'Alamofire', '4.8.0'
     pod 'AlamofireImage', '3.5.2'
 
-    pod 'WordPressAuthenticator', '~> 1.30.0'
+    pod 'WordPressAuthenticator', '~> 1.31.0-beta.4'
     pod 'WordPressKit', '~> 4.19'
     pod 'WPMediaPicker', '~> 1.7.2'
     pod 'WordPressFlux', '1.0.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -48,7 +48,7 @@ PODS:
     - OHHTTPStubs/Default
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.5.0)
-  - WordPressAuthenticator (1.30.0):
+  - WordPressAuthenticator (1.31.0-beta.4):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -82,7 +82,7 @@ DEPENDENCIES:
   - CocoaLumberjack/Swift (= 3.5.3)
   - KeychainAccess (= 3.2.0)
   - OHHTTPStubs/Swift (= 8.0.0)
-  - WordPressAuthenticator (~> 1.30.0)
+  - WordPressAuthenticator (~> 1.31.0-beta.4)
   - WordPressFlux (= 1.0.0)
   - WordPressKit (~> 4.19)
   - WordPressUI (~> 1.7.2)
@@ -133,7 +133,7 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 9cbce6364bec557cc3439aa6bb7514670d780881
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
-  WordPressAuthenticator: 9dbc3b88a331f94ceb83a3e12a6f040aa7434398
+  WordPressAuthenticator: 3bc0d09d1617e540c6475cceac62ed6c3755cf22
   WordPressFlux: a381542b0a0414ef85fb0b2a0f9dbde78ffe0637
   WordPressKit: bbd17cd14a7f68080bdeb350c3780a40c29fd937
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
@@ -141,6 +141,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: d5ae9a83cd5cc0e4de46bfc1c59120aa86658bc3
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
 
-PODFILE CHECKSUM: 7a5ad5fd9a1f3f7e496f48c2c211452058335cb7
+PODFILE CHECKSUM: 12d866fd38882d0b4236a17be7dc07d54f6f1cb7
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Closes #126 

As part of the process to implement the Unified Login flow in WooCommerce, we have made a few breaking changes to the API exposed by WordPressAuthenticator.

This PR updates the dependency with WPAuthenticator and implements the new methods declared in WPAuthenticatorDelegate.

## Changes

* Point WPAuthenticator to 1.30.0
* Update AuthenticationManager to use the new API exposed by WordPressAuthenticatorDelegate
How to test

## Checkout the branch
* Run bundle exec pod install
* Build and run. Log out if necessary
* Attempt to log in again. Check that the login flow continues working as it should.