### PR TITLE
Issues/128 text notes

### DIFF
--- a/Newspack/Newspack.xcodeproj/project.pbxproj
+++ b/Newspack/Newspack.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		E6AB672924E88182003D5D2A /* VideoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E6AB671E24E88182003D5D2A /* VideoTableViewCell.xib */; };
 		E6AB672A24E88182003D5D2A /* StoryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AB671F24E88182003D5D2A /* StoryTableViewCell.swift */; };
 		E6AC98B823CCD5DE00E95381 /* MainNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AC98B723CCD5DE00E95381 /* MainNavController.swift */; };
+		E6AC9A25258D15B900F1EB4E /* TextNoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AC9A24258D15B900F1EB4E /* TextNoteViewController.swift */; };
 		E6AE5243254A103E002FADD7 /* Data+ImageContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6AE5242254A103E002FADD7 /* Data+ImageContentType.swift */; };
 		E6B4034D22D8E12500A0DDCA /* remote-posts-ids-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */; };
 		E6B4034E22D8E12500A0DDCA /* remote-posts-edit.json in Resources */ = {isa = PBXBuildFile; fileRef = E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */; };
@@ -486,6 +487,7 @@
 		E6AB671E24E88182003D5D2A /* VideoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = VideoTableViewCell.xib; sourceTree = "<group>"; };
 		E6AB671F24E88182003D5D2A /* StoryTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryTableViewCell.swift; sourceTree = "<group>"; };
 		E6AC98B723CCD5DE00E95381 /* MainNavController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavController.swift; sourceTree = "<group>"; };
+		E6AC9A24258D15B900F1EB4E /* TextNoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextNoteViewController.swift; sourceTree = "<group>"; };
 		E6AE5242254A103E002FADD7 /* Data+ImageContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+ImageContentType.swift"; sourceTree = "<group>"; };
 		E6B4034B22D8E12400A0DDCA /* remote-posts-ids-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-ids-edit.json"; sourceTree = "<group>"; };
 		E6B4034C22D8E12400A0DDCA /* remote-posts-edit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "remote-posts-edit.json"; sourceTree = "<group>"; };
@@ -871,6 +873,7 @@
 				E65469F824C7A1950083FAA5 /* WebViewController.swift */,
 				E694469D24DB3FA100D0BF56 /* MediaCaptureController.swift */,
 				E694469F24DB3FB100D0BF56 /* MediaPickerViewController.swift */,
+				E6AC9A24258D15B900F1EB4E /* TextNoteViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -1686,6 +1689,7 @@
 				E66CCA0D2303527C00F1CA59 /* Site+CoreDataProperties.swift in Sources */,
 				E6A20371253A388600D85EE0 /* ProgressCell.swift in Sources */,
 				E604EE4924C774A80015D284 /* UserView.swift in Sources */,
+				E6AC9A25258D15B900F1EB4E /* TextNoteViewController.swift in Sources */,
 				E66CCA0B2303527C00F1CA59 /* Account+CoreDataProperties.swift in Sources */,
 				E63F3F3C236350BE00DB760E /* MediaTypeDiscerner.swift in Sources */,
 				E695A7E7244FD686007B29BB /* StoryAsset+CoreDataProperties.swift in Sources */,

--- a/Newspack/Newspack/Controllers/AssetsViewController.swift
+++ b/Newspack/Newspack/Controllers/AssetsViewController.swift
@@ -136,6 +136,12 @@ extension AssetsViewController {
         navigationController?.pushViewController(controller, animated: true)
     }
 
+    func showTextNoteDetail(asset: StoryAsset) {
+        let controller = MainStoryboard.instantiateViewController(withIdentifier: .textNote) as! TextNoteViewController
+        controller.asset = asset
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
 }
 
 // MARK: - TableViewDelegate methods
@@ -150,6 +156,8 @@ extension AssetsViewController {
         case .image, .video:
             showMediaDetail(asset: asset)
             return
+        case .textNote:
+            showTextNoteDetail(asset: asset)
         default:
             break
         }

--- a/Newspack/Newspack/Controllers/TextNoteViewController.swift
+++ b/Newspack/Newspack/Controllers/TextNoteViewController.swift
@@ -13,12 +13,19 @@ class TextNoteViewController: UIViewController {
         configureToolbar()
         configureTextView()
         configureStyle()
+        configureInsets()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
         saveOrDiscard()
+    }
+
+    override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+        coordinator.animate(alongsideTransition: { context in
+            self.configureInsets()
+        })
     }
 
     func configureNavbar() {
@@ -31,7 +38,20 @@ class TextNoteViewController: UIViewController {
 
     func configureStyle() {
         Appearance.style(textView: textView)
-        textView.textContainerInset = UIEdgeInsets.init(top: 16, left: 16, bottom: 16, right: 16)
+        configureInsets()
+    }
+
+    func configureInsets() {
+        guard UIDevice().userInterfaceIdiom == .pad else {
+            textView.textContainerInset = UIEdgeInsets.init(top: 16, left: 16, bottom: 16, right: 16)
+            return
+        }
+
+        if UIApplication.shared.windows.first?.windowScene?.interfaceOrientation.isLandscape == true {
+            textView.textContainerInset = UIEdgeInsets.init(top: 16, left: 120, bottom: 16, right: 120)
+        } else {
+            textView.textContainerInset = UIEdgeInsets.init(top: 16, left: 60, bottom: 16, right: 60)
+        }
     }
 
     func configureTextView() {

--- a/Newspack/Newspack/Controllers/TextNoteViewController.swift
+++ b/Newspack/Newspack/Controllers/TextNoteViewController.swift
@@ -21,6 +21,11 @@ class TextNoteViewController: UIViewController {
         configureInsets()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        textView.becomeFirstResponder()
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 

--- a/Newspack/Newspack/Controllers/TextNoteViewController.swift
+++ b/Newspack/Newspack/Controllers/TextNoteViewController.swift
@@ -11,8 +11,8 @@ class TextNoteViewController: UIViewController {
 
         configureNavbar()
         configureToolbar()
-        configureStyle()
         configureTextView()
+        configureStyle()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -30,7 +30,8 @@ class TextNoteViewController: UIViewController {
     }
 
     func configureStyle() {
-
+        Appearance.style(textView: textView)
+        textView.textContainerInset = UIEdgeInsets.init(top: 16, left: 16, bottom: 16, right: 16)
     }
 
     func configureTextView() {

--- a/Newspack/Newspack/Controllers/TextNoteViewController.swift
+++ b/Newspack/Newspack/Controllers/TextNoteViewController.swift
@@ -2,6 +2,11 @@ import UIKit
 
 class TextNoteViewController: UIViewController {
 
+    private struct Constants {
+        static let encodedTextKey = "encodedTextKey"
+        static let encodedAssetID = "encodedAssetID"
+    }
+
     @IBOutlet var textView: UITextView!
 
     var asset: StoryAsset?
@@ -26,6 +31,31 @@ class TextNoteViewController: UIViewController {
         coordinator.animate(alongsideTransition: { context in
             self.configureInsets()
         })
+    }
+
+    override func encodeRestorableState(with coder: NSCoder) {
+        super.encodeRestorableState(with: coder)
+
+        if let asset = asset {
+            coder.encode(asset.uuid.uuidString, forKey: Constants.encodedAssetID)
+        }
+
+        if !textView.text.isEmpty {
+            coder.encode(textView.text, forKey: Constants.encodedTextKey)
+        }
+    }
+
+    override func decodeRestorableState(with coder: NSCoder) {
+        super.decodeRestorableState(with: coder)
+
+        if let encodedID = coder.decodeObject(forKey: Constants.encodedAssetID) as? String,
+           let uuid = UUID(uuidString: encodedID) {
+            asset = StoreContainer.shared.assetStore.getStoryAssetByID(uuid: uuid)
+        }
+
+        if let text = coder.decodeObject(forKey: Constants.encodedTextKey) as? String {
+            textView.text = text
+        }
     }
 
     func configureNavbar() {
@@ -101,5 +131,5 @@ class TextNoteViewController: UIViewController {
 }
 
 extension TextNoteViewController: UITextViewDelegate {
-
+    // No op for now.
 }

--- a/Newspack/Newspack/Controllers/TextNoteViewController.swift
+++ b/Newspack/Newspack/Controllers/TextNoteViewController.swift
@@ -1,0 +1,84 @@
+import UIKit
+
+class TextNoteViewController: UIViewController {
+
+    @IBOutlet var textView: UITextView!
+
+    var asset: StoryAsset?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureNavbar()
+        configureToolbar()
+        configureStyle()
+        configureTextView()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        saveOrDiscard()
+    }
+
+    func configureNavbar() {
+        navigationItem.title = NSLocalizedString("Text Note", comment: "Noun. The title of a screen that shows the contents of a text note.")
+    }
+
+    func configureToolbar() {
+        navigationController?.setToolbarHidden(true, animated: true)
+    }
+
+    func configureStyle() {
+
+    }
+
+    func configureTextView() {
+        guard let note = asset else {
+            return
+        }
+        textView.text = note.text
+    }
+
+    func saveOrDiscard() {
+        if textView.text.isEmpty {
+            discardNote()
+        } else {
+            saveNote()
+        }
+    }
+
+    func discardNote() {
+        guard let asset = asset else {
+            return
+        }
+        let action = AssetAction.deleteAsset(assetID: asset.uuid)
+        SessionManager.shared.sessionDispatcher.dispatch(action)
+    }
+
+    func saveNote() {
+        if let _ = asset {
+            updateTextNote()
+        } else {
+            createTextNote()
+        }
+    }
+
+    func updateTextNote() {
+        guard let asset = asset else {
+            return
+        }
+        let action = AssetAction.updateText(assetID: asset.uuid, text: textView.text)
+        SessionManager.shared.sessionDispatcher.dispatch(action)
+    }
+
+    func createTextNote() {
+        let action = AssetAction.createAssetFor(text: textView.text)
+        SessionManager.shared.sessionDispatcher.dispatch(action)
+    }
+
+}
+
+extension TextNoteViewController: UITextViewDelegate {
+
+}

--- a/Newspack/Newspack/Controllers/ToolbarViewController.swift
+++ b/Newspack/Newspack/Controllers/ToolbarViewController.swift
@@ -45,9 +45,8 @@ class ToolbarViewController: UIViewController {
 extension ToolbarViewController {
 
     @IBAction func handleTextNoteButton(sender: UIBarButtonItem) {
-        // Temporary action just for testing.
-        let action = AssetAction.createAssetFor(text: "New Text Note")
-        SessionManager.shared.sessionDispatcher.dispatch(action)
+        let controller = MainStoryboard.instantiateViewController(withIdentifier: .textNote)
+        navigationController?.pushViewController(controller, animated: true)
     }
 
     @IBAction func handlePhotoButton(sender: UIBarButtonItem) {

--- a/Newspack/Newspack/Stores/Actions/AssetAction.swift
+++ b/Newspack/Newspack/Stores/Actions/AssetAction.swift
@@ -8,6 +8,7 @@ enum AssetAction: Action {
     case sortMode(index: Int)
     case sortDirection(ascending: Bool)
     case createAssetFor(text: String)
+    case updateText(assetID: UUID, text: String)
     case deleteAsset(assetID: UUID)
     case importMedia(assets: [PHAsset])
     case updateCaption(assetID: UUID, caption: String)

--- a/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
+++ b/Newspack/Newspack/Storyboards/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hEm-rr-Shu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hEm-rr-Shu">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -582,6 +582,44 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="org-bl-e0f" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="964" y="152"/>
+        </scene>
+        <!--Text Note-->
+        <scene sceneID="LE5-GT-6u0">
+            <objects>
+                <viewController storyboardIdentifier="TextNoteViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Szu-9R-r4d" customClass="TextNoteViewController" customModule="Newspack" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="bdw-oB-Rer">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" allowsEditingTextAttributes="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4WP-Nh-iZJ">
+                                <rect key="frame" x="0.0" y="44" width="375" height="623"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <connections>
+                                    <outlet property="delegate" destination="Szu-9R-r4d" id="tsA-Yg-jtc"/>
+                                </connections>
+                            </textView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="rgZ-iq-w36"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="4WP-Nh-iZJ" firstAttribute="top" secondItem="rgZ-iq-w36" secondAttribute="top" id="E0q-0T-c6m"/>
+                            <constraint firstItem="rgZ-iq-w36" firstAttribute="bottom" secondItem="4WP-Nh-iZJ" secondAttribute="bottom" id="LKJ-4X-Sya"/>
+                            <constraint firstItem="rgZ-iq-w36" firstAttribute="trailing" secondItem="4WP-Nh-iZJ" secondAttribute="trailing" id="hRJ-U3-1Kl"/>
+                            <constraint firstItem="4WP-Nh-iZJ" firstAttribute="leading" secondItem="rgZ-iq-w36" secondAttribute="leading" id="y4n-Kd-lWC"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="Text Note" id="GmV-cO-fF8"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <connections>
+                        <outlet property="textView" destination="4WP-Nh-iZJ" id="yum-Rn-wHz"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="kFQ-dB-feh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="964" y="822.63868065967017"/>
         </scene>
         <!--Image-->
         <scene sceneID="1Yb-Pc-f3E">

--- a/Newspack/Newspack/Storyboards/MainStoryboard.swift
+++ b/Newspack/Newspack/Storyboards/MainStoryboard.swift
@@ -17,6 +17,7 @@ class MainStoryboard {
         case imageView = "ImageViewController"
         case mediaDetails = "MediaDetailViewController"
         case textField = "TextFieldViewController"
+        case textNote = "TextNoteViewController"
     }
 
     static func instantiateViewController(withIdentifier identifier: Identifier) -> UIViewController {

--- a/Newspack/Newspack/Styles/Appearance.swift
+++ b/Newspack/Newspack/Styles/Appearance.swift
@@ -89,7 +89,7 @@ class Appearance {
     // MARK: - Text View Styles
 
     static func style(textView: UITextView) {
-        textView.textColor = .darkText
+        textView.textColor = .text
         textView.font = .preferredFont(forTextStyle: .body)
     }
 }

--- a/Newspack/Newspack/Styles/Appearance.swift
+++ b/Newspack/Newspack/Styles/Appearance.swift
@@ -85,6 +85,13 @@ class Appearance {
         button.setImage(.gridicon(iconType, size: size), for: .normal)
         button.tintColor = .newspackBlue(.shade30)
     }
+
+    // MARK: - Text View Styles
+
+    static func style(textView: UITextView) {
+        textView.textColor = .darkText
+        textView.font = .preferredFont(forTextStyle: .body)
+    }
 }
 
 // MARK: - Fonts

--- a/Newspack/Newspack/View/TextNoteTableViewCell.swift
+++ b/Newspack/Newspack/View/TextNoteTableViewCell.swift
@@ -8,7 +8,6 @@ protocol TextNoteCellProvider {
 class TextNoteTableViewCell: UITableViewCell {
 
     @IBOutlet var titleLabel: UILabel!
-    @IBOutlet var syncButton: UIButton!
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -18,11 +17,6 @@ class TextNoteTableViewCell: UITableViewCell {
 
     func applyStyles() {
         titleLabel.textColor = .text
-        Appearance.style(cellSyncButton: syncButton, iconType: .cloudUpload)
-    }
-
-    @IBAction func handleSyncTapped() {
-        print("tapped")
     }
 
     func configure(note: TextNoteCellProvider) {

--- a/Newspack/Newspack/View/TextNoteTableViewCell.xib
+++ b/Newspack/Newspack/View/TextNoteTableViewCell.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,10 +18,10 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="aXG-fJ-j87">
-                        <rect key="frame" x="16" y="0.0" width="288" height="62"/>
+                        <rect key="frame" x="16" y="8" width="288" height="46"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lorem ipsum dolar sit amet consequetor" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ps8-11-CVs">
-                                <rect key="frame" x="0.0" y="0.0" width="259" height="62"/>
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="46"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="tYY-7w-oq2"/>
                                 </constraints>
@@ -28,32 +29,21 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GI7-Mi-Ono">
-                                <rect key="frame" x="267" y="0.0" width="21" height="62"/>
-                                <state key="normal" image="cloud-upload"/>
-                                <connections>
-                                    <action selector="handleSyncTapped" destination="KGk-i7-Jjw" eventType="touchUpInside" id="LX0-Tv-66S"/>
-                                </connections>
-                            </button>
                         </subviews>
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="aXG-fJ-j87" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="1Y7-a1-e2k"/>
+                    <constraint firstItem="aXG-fJ-j87" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="1Y7-a1-e2k"/>
                     <constraint firstItem="aXG-fJ-j87" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="IK2-0w-JFJ"/>
-                    <constraint firstAttribute="bottom" secondItem="aXG-fJ-j87" secondAttribute="bottom" id="KNW-xy-aiz"/>
+                    <constraint firstAttribute="bottom" secondItem="aXG-fJ-j87" secondAttribute="bottom" constant="8" id="KNW-xy-aiz"/>
                     <constraint firstAttribute="trailingMargin" secondItem="aXG-fJ-j87" secondAttribute="trailing" id="Xbt-Op-7NT"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="syncButton" destination="GI7-Mi-Ono" id="ZjD-tR-9zW"/>
                 <outlet property="titleLabel" destination="ps8-11-CVs" id="PLG-38-isR"/>
             </connections>
             <point key="canvasLocation" x="137.68115942028987" y="107.8125"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <image name="cloud-upload" width="24" height="24"/>
-    </resources>
 </document>


### PR DESCRIPTION
Refs #128 
This PR is a first pass at implementing a basic text notes feature. Text notes are currently simple text snippets that can be added to the assets list. They do not sync to the server, but could in the future.
Currently, notes are created or updated when exiting the editor. If a note has no text it is discarded.

To test:
Scenario 1:
From the story list, tap the text notes tool bar button and create a new note.

Scenario 2:
From a story's asset list, tap the text notes tool bar button and create a new note.

Scenario 3:
In the asset list, tap a note that has been created to edit its text.  Add a dozen lines or so of text.
Confirm that a three line preview is shown in the text notes cell in the asset list. 

Scenario 4:
Edit an existing text note and remove all its text.
Return to the asset list and confirm the note has been deleted.

Scenario 5:
Test state restoration.  View a text note then background the app to preserve state. Terminate the debugger and then relaunch the app. Confirm you are returned to the text note when the app launches and that any text changes you had made are present. 

@jleandroperez I know it's been a while but would you be game for a review? 