### PR TITLE
Issues/misc fixes

### DIFF
--- a/Newspack/Newspack/Api/Models/RemoteMedia.swift
+++ b/Newspack/Newspack/Api/Models/RemoteMedia.swift
@@ -53,7 +53,11 @@ struct RemoteMedia {
         guid = dict[stringAtKeyPath: "guid.raw"]
         guidRendered = dict[stringAtKeyPath: "guid.rendered"]
         link = dict[stringForKey: "link"]
-        mediaDetails = dict["media_details"] as! [String: AnyObject]
+        if let details = dict["media_details"] as? [String: AnyObject] {
+            mediaDetails = details
+        } else {
+            mediaDetails = [String: AnyObject]()
+        }
         mediaType = dict[stringForKey: "media_type"]
         mimeType = dict[stringForKey: "mime_type"]
         modified = dict[stringForKey: "modified"]

--- a/Newspack/Newspack/System/AppDelegate.swift
+++ b/Newspack/Newspack/System/AppDelegate.swift
@@ -22,18 +22,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         configureEventMonitor()
         configureLogger()
 
+        // Configure the session prior to state restoration running.
+        configureSession()
+
         // Configure the window which should call makeKeyAndVisible.
         // Necessary in order to present the authentication flow.
         configureWindow()
-        // Configure the session prior to state restoration running.
-        configureSession()
 
         return true
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         Appearance.configureGlobalAppearance()
-
 
         LogInfo(message: "Application did finish launching.")
 

--- a/Newspack/Newspack/System/SyncCoordinator.swift
+++ b/Newspack/Newspack/System/SyncCoordinator.swift
@@ -337,7 +337,7 @@ extension SyncCoordinator {
     ///
     func configureBackgroundTask() {
         guard backgroundTaskID == .invalid else {
-            // THere is already a long running task cnofigured. No need to configure another.
+            // There is already a long running task configured. No need to configure another.
             return
         }
 

--- a/Newspack/Newspack/View/AudioTableViewCell.swift
+++ b/Newspack/Newspack/View/AudioTableViewCell.swift
@@ -23,6 +23,7 @@ class AudioTableViewCell: ProgressCell {
     }
 
     func applyStyles() {
+        Appearance.style(cell: self)
         titleLabel.textColor = .text
         captionLabel.textColor = .text
         Appearance.style(cellSyncButton: syncButton, iconType: .cloudUpload)

--- a/Newspack/Newspack/View/PhotoTableViewCell.swift
+++ b/Newspack/Newspack/View/PhotoTableViewCell.swift
@@ -27,6 +27,7 @@ class PhotoTableViewCell: ProgressCell {
     }
 
     func applyStyles() {
+        Appearance.style(cell: self)
         titleLabel.textColor = .text
         captionLabel.textColor = .text
         Appearance.style(cellSyncButton: syncButton, iconType: .cloudUpload)

--- a/Newspack/Newspack/View/StoryTableViewCell.swift
+++ b/Newspack/Newspack/View/StoryTableViewCell.swift
@@ -33,6 +33,7 @@ class StoryTableViewCell: UITableViewCell {
     }
 
     func applyStyles() {
+        Appearance.style(cell: self)
         Appearance.style(cellIconButton: textIcon, iconType: .posts)
         Appearance.style(cellIconButton: photosIcon, iconType: .imageMultiple)
         Appearance.style(cellIconButton: videoIcon, iconType: .video)

--- a/Newspack/Newspack/View/TextNoteTableViewCell.swift
+++ b/Newspack/Newspack/View/TextNoteTableViewCell.swift
@@ -16,6 +16,7 @@ class TextNoteTableViewCell: UITableViewCell {
     }
 
     func applyStyles() {
+        Appearance.style(cell: self)
         titleLabel.textColor = .text
     }
 

--- a/Newspack/Newspack/View/VideoTableViewCell.swift
+++ b/Newspack/Newspack/View/VideoTableViewCell.swift
@@ -26,6 +26,7 @@ class VideoTableViewCell: ProgressCell {
     }
 
     func applyStyles() {
+        Appearance.style(cell: self)
         titleLabel.textColor = .text
         captionLabel.textColor = .text
         Appearance.style(cellSyncButton: syncButton, iconType: .cloudUpload)

--- a/Newspack/NewspackFramework/Folders/FolderManager.swift
+++ b/Newspack/NewspackFramework/Folders/FolderManager.swift
@@ -43,10 +43,12 @@ public class FolderManager {
         if
             let root = rootFolder,
             fileManager.fileExists(atPath: root.path, isDirectory: &isDirectory),
-            isDirectory.boolValue,
-            fileManager.isWritableFile(atPath: root.path)
+            isDirectory.boolValue
         {
             self.rootFolder = root
+            if !fileManager.isWritableFile(atPath: root.path) {
+                LogWarn(message: "The specified root folder may not be writable.")
+            }
         } else {
             self.rootFolder = documentDirectory
         }

--- a/Newspack/NewspackFramework/Folders/FolderManager.swift
+++ b/Newspack/NewspackFramework/Folders/FolderManager.swift
@@ -223,6 +223,7 @@ public class FolderManager {
     public func deleteItem(at source: URL) -> Bool {
         // Do not perform a delete operation on anything outside of our root folder.
         if !folder(rootFolder, contains: source) {
+            LogError(message: "Source item for deletion: \(source) is outside of the root folder: \(rootFolder)")
             return false
         }
 
@@ -230,7 +231,7 @@ public class FolderManager {
             try fileManager.removeItem(at: source)
             return true
         } catch {
-            LogError(message: "Error removing folder. \(error)")
+            LogError(message: "Error removing item. \(error)")
         }
 
         return false

--- a/Newspack/NewspackFramework/Shadows/ShadowManager.swift
+++ b/Newspack/NewspackFramework/Shadows/ShadowManager.swift
@@ -5,6 +5,22 @@ import Foundation
 ///
 public class ShadowManager {
 
+    public static var shadowFolder: URL? {
+        guard let groupFolder = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: AppConstants.appGroupIdentifier) else {
+            return nil
+        }
+        let url = groupFolder.appendingPathComponent(AppConstants.sharedAssetsFolderName, isDirectory: true)
+        if FileManager.default.fileExists(atPath: url.path) {
+            return url
+        }
+        do {
+            try FileManager.default.createDirectory(atPath: url.path, withIntermediateDirectories: false, attributes: nil)
+        } catch  {
+            return nil
+        }
+        return url
+    }
+
     public init() {}
 
     /// Stores the passed array of shadow sites in shared defaults.
@@ -82,8 +98,8 @@ public class ShadowManager {
         // Purge stored defaults.
         UserDefaults.shared.removeObject(forKey: AppConstants.shadowAssetsKey)
 
-        guard let folderURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: AppConstants.appGroupIdentifier) else {
-            LogWarn(message: "Unable to retrieve group directory URL.")
+        guard let folderURL = ShadowManager.shadowFolder else {
+            LogWarn(message: "Unable to retrieve group asset share directory URL.")
             return
         }
 

--- a/Newspack/NewspackFramework/Shadows/ShadowManager.swift
+++ b/Newspack/NewspackFramework/Shadows/ShadowManager.swift
@@ -15,7 +15,7 @@ public class ShadowManager {
         }
         do {
             try FileManager.default.createDirectory(atPath: url.path, withIntermediateDirectories: false, attributes: nil)
-        } catch  {
+        } catch {
             return nil
         }
         return url

--- a/Newspack/NewspackFramework/Utils/AppConstants.swift
+++ b/Newspack/NewspackFramework/Utils/AppConstants.swift
@@ -7,4 +7,5 @@ public class AppConstants {
     public static let lastSelectedStoryFolderKey = "LastSelectedStoryFolder_"
     public static let shadowSitesKey = "shadowSitesKey"
     public static let shadowAssetsKey = "shadowAssetsKey"
+    public static let sharedAssetsFolderName = "sharedAssets"
 }

--- a/Newspack/NewspackFrameworkTests/Tests/ShadowTests.swift
+++ b/Newspack/NewspackFrameworkTests/Tests/ShadowTests.swift
@@ -88,7 +88,7 @@ class ShadowTests: XCTestCase {
 
         manager.storeShadowAssets(assets: [asset])
 
-        let folderURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: AppConstants.appGroupIdentifier)!
+        let folderURL = ShadowManager.shadowFolder!
         let file = FileManager.default.availableFileURL(for: "file.txt", isDirectory: false, relativeTo: folderURL)
         var success = false
         success = FileManager.default.createFile(atPath: file.path, contents: data, attributes: nil)

--- a/Newspack/NewspackShare/Controllers/ShareMediaViewController.swift
+++ b/Newspack/NewspackShare/Controllers/ShareMediaViewController.swift
@@ -42,7 +42,8 @@ class ShareMediaViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+let dict = UserDefaults.shared.dictionaryRepresentation()
+print("SHARE VIEW LOADED. DEFAULTS: \(dict.debugDescription)")
         configureStyle()
         configureNav()
         configureShadows()
@@ -161,11 +162,11 @@ extension ShareMediaViewController {
     }
 
     func moveItems(at urls: [URL]) -> [URL] {
-        let groupFolder = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: AppConstants.appGroupIdentifier)
+        let shadowFolder = ShadowManager.shadowFolder
         var movedItems = [URL]()
 
         for url in urls {
-            let destination = FileManager.default.availableFileURL(for: url.lastPathComponent, isDirectory: false, relativeTo: groupFolder)
+            let destination = FileManager.default.availableFileURL(for: url.lastPathComponent, isDirectory: false, relativeTo: shadowFolder)
             do {
                 try FileManager.default.copyItem(at: url, to: destination)
                 movedItems.append(destination)

--- a/Newspack/NewspackShare/Controllers/ShareMediaViewController.swift
+++ b/Newspack/NewspackShare/Controllers/ShareMediaViewController.swift
@@ -42,8 +42,7 @@ class ShareMediaViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-let dict = UserDefaults.shared.dictionaryRepresentation()
-print("SHARE VIEW LOADED. DEFAULTS: \(dict.debugDescription)")
+
         configureStyle()
         configureNav()
         configureShadows()


### PR DESCRIPTION
This PR addresses a few recently spotted glitches.
- The background color of the cells in the FoldersViewController were sometimes incorrect.
- Occasionally the app would launch in a logged out state or appear to crash at launch.
- There was a warning when cleaning up shadow assets after using the share widget.

The cell background color is addressed by ensuring cells call `Appearance.style(cell:)`.

The issue with being logged out/crashing at launch appeared to be due to a race condition between restoring a session and making the UI visible.  This is addressed by restoring the session before making the key window visible.

The issue with the warning is addressed by removing an overly aggressive writability check which was causing the FolderManager to assign the app's document directory as its root rather than the specified folder URL (a shared group folder). Shadow asset deletion would fail because the specified shared item to delete was outside of the root directory. A check for writability is retained and logged for now.  I might just nuke this outright in the future but I want to observe the behavior more and see if there is a way to improve it.

To test:
- Smoke test the app.
- Confirm that rows in the FoldersViewController have the correct background color. 
- Confirm there is no longer a warning cleaning up shadow assets after returning to the app after sharing.
- Be logged in.  Repeatedly launch and force close the app.  Confirm that it never launches in a logged out state.

@jleandroperez Game for a small review? 